### PR TITLE
Show source indexer on Status page and redesign queue as cards

### DIFF
--- a/server/api/lidarr/types.ts
+++ b/server/api/lidarr/types.ts
@@ -54,6 +54,8 @@ export type LidarrHistoryRecord = {
   id: number;
   albumId: number;
   date: string;
+  downloadId: string;
+  data: Record<string, string>;
   artist: { id: number; artistName: string };
   album: { id: number; title: string };
 };

--- a/server/routes/lidarr/history.test.ts
+++ b/server/routes/lidarr/history.test.ts
@@ -17,65 +17,139 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const mockData = {
-  page: 1,
-  pageSize: 20,
-  totalRecords: 1,
-  records: [{ id: 1, date: "2025-01-01" }],
-};
+function makeRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    albumId: 100,
+    date: "2025-01-01",
+    downloadId: "dl-abc",
+    data: {},
+    artist: { id: 1, artistName: "Test Artist" },
+    album: { id: 100, title: "Test Album" },
+    ...overrides,
+  };
+}
+
+function paginatedResponse(records: unknown[]) {
+  return {
+    page: 1,
+    pageSize: 20,
+    totalRecords: records.length,
+    records,
+  };
+}
 
 describe("GET /history", () => {
-  it("passes default query params to Lidarr", async () => {
-    mockLidarrGet.mockResolvedValue({ status: 200, data: mockData });
+  it("makes two Lidarr calls for imported and grabbed events", async () => {
+    mockLidarrGet.mockResolvedValue({
+      status: 200,
+      data: paginatedResponse([]),
+    });
 
     await request(app).get("/history");
 
-    expect(mockLidarrGet).toHaveBeenCalledWith("/history", {
-      page: 1,
-      pageSize: 20,
-      includeArtist: true,
-      includeAlbum: true,
-      sortKey: "date",
-      sortDirection: "descending",
-    });
+    expect(mockLidarrGet).toHaveBeenCalledTimes(2);
+    expect(mockLidarrGet).toHaveBeenCalledWith(
+      "/history",
+      expect.objectContaining({ eventType: 3 })
+    );
+    expect(mockLidarrGet).toHaveBeenCalledWith(
+      "/history",
+      expect.objectContaining({ eventType: 1 })
+    );
   });
 
-  it("forwards page and pageSize from request query", async () => {
-    mockLidarrGet.mockResolvedValue({ status: 200, data: mockData });
+  it("correlates indexer from grabbed events via downloadId", async () => {
+    const imported = makeRecord({ downloadId: "dl-abc" });
+    const grabbed = makeRecord({
+      id: 2,
+      downloadId: "dl-abc",
+      data: { indexer: "Prowlarr" },
+    });
+
+    mockLidarrGet.mockImplementation((_path: string, query: Record<string, unknown>) => {
+      if (query.eventType === 3) {
+        return Promise.resolve({ status: 200, data: paginatedResponse([imported]) });
+      }
+      return Promise.resolve({ status: 200, data: paginatedResponse([grabbed]) });
+    });
+
+    const res = await request(app).get("/history");
+
+    expect(res.status).toBe(200);
+    expect(res.body.records[0].sourceIndexer).toBe("Prowlarr");
+  });
+
+  it("returns sourceIndexer null when no matching grabbed event exists", async () => {
+    const imported = makeRecord({ downloadId: "dl-no-match" });
+
+    mockLidarrGet.mockImplementation((_path: string, query: Record<string, unknown>) => {
+      if (query.eventType === 3) {
+        return Promise.resolve({ status: 200, data: paginatedResponse([imported]) });
+      }
+      return Promise.resolve({ status: 200, data: paginatedResponse([]) });
+    });
+
+    const res = await request(app).get("/history");
+
+    expect(res.body.records[0].sourceIndexer).toBeNull();
+  });
+
+  it("returns sourceIndexer null when grabbed fetch fails", async () => {
+    const imported = makeRecord();
+
+    mockLidarrGet.mockImplementation((_path: string, query: Record<string, unknown>) => {
+      if (query.eventType === 3) {
+        return Promise.resolve({ status: 200, data: paginatedResponse([imported]) });
+      }
+      return Promise.reject(new Error("Lidarr down"));
+    });
+
+    const res = await request(app).get("/history");
+
+    expect(res.status).toBe(200);
+    expect(res.body.records[0].sourceIndexer).toBeNull();
+  });
+
+  it("forwards page and pageSize to both Lidarr calls", async () => {
+    mockLidarrGet.mockResolvedValue({
+      status: 200,
+      data: paginatedResponse([]),
+    });
 
     await request(app).get("/history?page=3&pageSize=50");
 
-    expect(mockLidarrGet).toHaveBeenCalledWith(
-      "/history",
-      expect.objectContaining({ page: "3", pageSize: "50" })
-    );
+    for (const call of mockLidarrGet.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ page: "3", pageSize: "50" }));
+    }
   });
 
-  it("includes eventType when present in query", async () => {
-    mockLidarrGet.mockResolvedValue({ status: 200, data: mockData });
-
-    await request(app).get("/history?eventType=grabbed");
-
-    expect(mockLidarrGet).toHaveBeenCalledWith(
-      "/history",
-      expect.objectContaining({ eventType: "grabbed" })
-    );
-  });
-
-  it("does not include eventType when absent", async () => {
-    mockLidarrGet.mockResolvedValue({ status: 200, data: mockData });
-
-    await request(app).get("/history");
-
-    const callArgs = mockLidarrGet.mock.calls[0][1] as Record<string, unknown>;
-    expect(callArgs).not.toHaveProperty("eventType");
-  });
-
-  it("proxies status and data from Lidarr", async () => {
-    mockLidarrGet.mockResolvedValue({ status: 200, data: mockData });
+  it("proxies status code from imported result", async () => {
+    mockLidarrGet.mockImplementation((_path: string, query: Record<string, unknown>) => {
+      if (query.eventType === 3) {
+        return Promise.resolve({ status: 404, data: paginatedResponse([]) });
+      }
+      return Promise.resolve({ status: 200, data: paginatedResponse([]) });
+    });
 
     const res = await request(app).get("/history");
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual(mockData);
+    expect(res.status).toBe(404);
+  });
+
+  it("strips downloadId and data from response records", async () => {
+    const imported = makeRecord({
+      downloadId: "dl-abc",
+      data: { downloadClient: "sabnzbd" },
+    });
+
+    mockLidarrGet.mockResolvedValue({
+      status: 200,
+      data: paginatedResponse([imported]),
+    });
+
+    const res = await request(app).get("/history");
+
+    expect(res.body.records[0]).not.toHaveProperty("downloadId");
+    expect(res.body.records[0]).not.toHaveProperty("data");
   });
 });

--- a/server/routes/lidarr/history.ts
+++ b/server/routes/lidarr/history.ts
@@ -6,10 +6,12 @@ import type {
   LidarrHistoryRecord,
 } from "../../api/lidarr/types";
 
-const router = express.Router();
+type EnrichedHistoryRecord = Omit<LidarrHistoryRecord, "downloadId" | "data"> & {
+  sourceIndexer: string | null;
+};
 
-router.get("/history", async (req: Request, res: Response) => {
-  const query: Record<string, unknown> = {
+function buildBaseQuery(req: Request): Record<string, unknown> {
+  return {
     page: req.query.page || 1,
     pageSize: req.query.pageSize || 20,
     includeArtist: true,
@@ -17,12 +19,56 @@ router.get("/history", async (req: Request, res: Response) => {
     sortKey: "date",
     sortDirection: "descending",
   };
-  if (req.query.eventType) query.eventType = req.query.eventType;
-  const result = await lidarrGet<LidarrPaginatedResponse<LidarrHistoryRecord>>(
-    "/history",
-    query
+}
+
+function buildIndexerMap(
+  grabbedRecords: LidarrHistoryRecord[]
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const record of grabbedRecords) {
+    if (record.downloadId && record.data?.indexer) {
+      map.set(record.downloadId, record.data.indexer);
+    }
+  }
+  return map;
+}
+
+function enrichRecords(
+  importedRecords: LidarrHistoryRecord[],
+  indexerMap: Map<string, string>
+): EnrichedHistoryRecord[] {
+  return importedRecords.map(({ downloadId, data: _, ...rest }) => ({
+    ...rest,
+    sourceIndexer: indexerMap.get(downloadId) ?? null,
+  }));
+}
+
+const router = express.Router();
+
+router.get("/history", async (req: Request, res: Response) => {
+  const baseQuery = buildBaseQuery(req);
+
+  const [importedResult, grabbedResult] = await Promise.all([
+    lidarrGet<LidarrPaginatedResponse<LidarrHistoryRecord>>("/history", {
+      ...baseQuery,
+      eventType: 3,
+    }),
+    lidarrGet<LidarrPaginatedResponse<LidarrHistoryRecord>>("/history", {
+      ...baseQuery,
+      eventType: 1,
+    }).catch(() => null),
+  ]);
+
+  const indexerMap = buildIndexerMap(grabbedResult?.data?.records ?? []);
+  const enrichedRecords = enrichRecords(
+    importedResult.data.records,
+    indexerMap
   );
-  res.status(result.status).json(result.data);
+
+  res.status(importedResult.status).json({
+    ...importedResult.data,
+    records: enrichedRecords,
+  });
 });
 
 export default router;

--- a/src/pages/StatusPage/StatusPage.tsx
+++ b/src/pages/StatusPage/StatusPage.tsx
@@ -3,6 +3,7 @@ import QueueTable from "./components/QueueTable";
 import WantedList from "./components/WantedList";
 import RecentImports from "./components/RecentImports";
 import Skeleton from "@/components/Skeleton";
+import { RefreshIcon } from "@/components/icons";
 import { QueueItem, WantedItem, RecentImport } from "@/types";
 
 export default function StatusPage() {
@@ -10,6 +11,7 @@ export default function StatusPage() {
   const [wanted, setWanted] = useState<WantedItem[]>([]);
   const [history, setHistory] = useState<RecentImport[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchAll = useCallback(async () => {
@@ -17,7 +19,7 @@ export default function StatusPage() {
       const [queueRes, wantedRes, historyRes] = await Promise.all([
         fetch("/api/lidarr/queue"),
         fetch("/api/lidarr/wanted/missing"),
-        fetch("/api/lidarr/history?eventType=3"),
+        fetch("/api/lidarr/history"),
       ]);
 
       if (queueRes.ok) {
@@ -46,6 +48,12 @@ export default function StatusPage() {
     const interval = setInterval(fetchAll, 30000);
     return () => clearInterval(interval);
   }, [fetchAll]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchAll();
+    setRefreshing(false);
+  };
 
   const handleAlbumSearch = async (albumId: number) => {
     try {
@@ -117,9 +125,22 @@ export default function StatusPage() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          Download Queue
-        </h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            Download Queue
+          </h2>
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 text-xs font-bold bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Refresh queue"
+          >
+            <RefreshIcon
+              className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
+            />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+        </div>
         <QueueTable items={queue} />
       </section>
 

--- a/src/pages/StatusPage/__tests__/StatusPage.test.tsx
+++ b/src/pages/StatusPage/__tests__/StatusPage.test.tsx
@@ -153,6 +153,26 @@ describe("StatusPage", () => {
     });
   });
 
+  it("refreshes data when Refresh button is clicked", async () => {
+    mockAllEndpoints();
+
+    render(<StatusPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Download Queue")).toBeInTheDocument();
+    });
+
+    const initialCallCount = vi.mocked(fetch).mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh queue" }));
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(
+        initialCallCount
+      );
+    });
+  });
+
   it("removes wanted item from list when Unmonitor succeeds", async () => {
     const wantedItem = {
       id: 1,

--- a/src/pages/StatusPage/components/QueueTable.tsx
+++ b/src/pages/StatusPage/components/QueueTable.tsx
@@ -5,58 +5,42 @@ interface QueueTableProps {
   items: QueueItem[];
 }
 
+function formatProgress(item: QueueItem): string {
+  if (!item.sizeleft || !item.size) return "—";
+  return `${Math.round(((item.size - item.sizeleft) / item.size) * 100)}%`;
+}
+
 export default function QueueTable({ items }: QueueTableProps) {
   if (items.length === 0) {
     return <p className="text-gray-400 text-sm">No active downloads.</p>;
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="text-left text-gray-600 dark:text-gray-400 border-b-2 border-black">
-            <th className="pb-2 font-bold">Artist</th>
-            <th className="pb-2 font-bold">Album</th>
-            <th className="pb-2 font-bold">Quality</th>
-            <th className="pb-2 font-bold">Progress</th>
-            <th className="pb-2 font-bold">Status</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y-2 divide-gray-200 dark:divide-gray-700">
-          {items.map((item, index) => (
-            <tr
-              key={item.id}
-              className="stagger-fade-in"
-              style={{ "--stagger-index": index } as React.CSSProperties}
-            >
-              <td className="py-2 text-gray-600 dark:text-gray-400">
-                {item.artist?.artistName || "Unknown"}
-              </td>
-              <td className="py-2 text-gray-900 dark:text-gray-100">
-                {item.album?.title || item.title || "Unknown"}
-              </td>
-              <td className="py-2 text-gray-500 dark:text-gray-400">
-                {item.quality?.quality?.name || "—"}
-              </td>
-              <td
-                data-testid="queue-progress"
-                className="py-2 text-gray-600 dark:text-gray-400"
-              >
-                {item.sizeleft != null && item.size
-                  ? `${Math.round(((item.size - item.sizeleft) / item.size) * 100)}%`
-                  : "—"}
-              </td>
-              <td className="py-2">
-                <StatusBadge
-                  status={
-                    item.trackedDownloadStatus?.toLowerCase() || "downloading"
-                  }
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="space-y-2">
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          className="stagger-fade-in flex items-center justify-between bg-white dark:bg-gray-800 rounded-xl px-4 py-3 border-2 border-black shadow-cartoon-md hover:translate-y-[-2px] hover:shadow-cartoon-lg transition-all"
+          style={{ "--stagger-index": index } as React.CSSProperties}
+        >
+          <div>
+            <p className="text-gray-900 dark:text-gray-100 font-medium">
+              {item.album?.title || item.title || "Unknown"}
+            </p>
+            <p className="text-gray-500 dark:text-gray-400 text-sm">
+              {item.artist?.artistName || "Unknown"}
+            </p>
+            <p className="text-gray-400 text-xs mt-1">
+              {item.quality?.quality?.name || "—"} · {formatProgress(item)}
+            </p>
+          </div>
+          <StatusBadge
+            status={
+              item.trackedDownloadStatus?.toLowerCase() || "downloading"
+            }
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/pages/StatusPage/components/RecentImports.tsx
+++ b/src/pages/StatusPage/components/RecentImports.tsx
@@ -40,6 +40,9 @@ export default function RecentImports({ items }: RecentImportsProps) {
             <p className="text-gray-400 text-xs mt-1">
               {new Date(item.date).toLocaleString()}
             </p>
+            {item.sourceIndexer && (
+              <p className="text-gray-400 text-xs">via {item.sourceIndexer}</p>
+            )}
           </div>
           <StatusBadge status="imported" />
         </div>

--- a/src/pages/StatusPage/components/__tests__/QueueTable.test.tsx
+++ b/src/pages/StatusPage/components/__tests__/QueueTable.test.tsx
@@ -27,18 +27,17 @@ describe("QueueTable", () => {
     render(<QueueTable items={[makeQueueItem()]} />);
     expect(screen.getByText("Test Artist")).toBeInTheDocument();
     expect(screen.getByText("Test Album")).toBeInTheDocument();
-    expect(screen.getByText("FLAC")).toBeInTheDocument();
   });
 
-  it("calculates progress percentage", () => {
+  it("shows quality and progress", () => {
     render(
       <QueueTable items={[makeQueueItem({ size: 1000, sizeleft: 250 })]} />
     );
-    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.getByText("FLAC · 75%")).toBeInTheDocument();
   });
 
   it("shows dash when size data is missing", () => {
     render(<QueueTable items={[makeQueueItem({ size: 0, sizeleft: 0 })]} />);
-    expect(screen.getByTestId("queue-progress")).toHaveTextContent("—");
+    expect(screen.getByText("FLAC · —")).toBeInTheDocument();
   });
 });

--- a/src/pages/StatusPage/components/__tests__/RecentImports.test.tsx
+++ b/src/pages/StatusPage/components/__tests__/RecentImports.test.tsx
@@ -7,6 +7,7 @@ function makeImport(overrides: Partial<RecentImport> = {}): RecentImport {
     id: 1,
     albumId: 100,
     date: "2025-01-15T12:00:00Z",
+    sourceIndexer: null,
     artist: { artistName: "Test Artist", id: 1 },
     album: { id: 100, title: "Test Album" },
     ...overrides,
@@ -45,5 +46,19 @@ describe("RecentImports", () => {
   it("shows imported status badge", () => {
     render(<RecentImports items={[makeImport()]} />);
     expect(screen.getByText("imported")).toBeInTheDocument();
+  });
+
+  it("displays source indexer when present", () => {
+    render(
+      <RecentImports items={[makeImport({ sourceIndexer: "Prowlarr" })]} />
+    );
+    expect(screen.getByText("via Prowlarr")).toBeInTheDocument();
+  });
+
+  it("does not display via text when sourceIndexer is null", () => {
+    render(
+      <RecentImports items={[makeImport({ sourceIndexer: null })]} />
+    );
+    expect(screen.queryByText(/^via /)).not.toBeInTheDocument();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface RecentImport {
   id: number;
   albumId: number;
   date: string;
+  sourceIndexer: string | null;
   artist: {
     artistName: string;
     id: number;


### PR DESCRIPTION
Enrich history endpoint to correlate grabbed/imported events by downloadId, exposing the indexer name. Redesign Download Queue from table to card layout matching other sections, and add a refresh button.

Closes #26 