### PR TITLE
Add recommendation trace modal showing algorithm decision pipeline

### DIFF
--- a/server/promotedAlbum/types.ts
+++ b/server/promotedAlbum/types.ts
@@ -1,0 +1,48 @@
+export type TraceArtistTagContribution = {
+  tagName: string;
+  rawCount: number;
+  weight: number;
+};
+
+export type TraceArtistEntry = {
+  name: string;
+  viewCount: number;
+  picked: boolean;
+  tagContributions: TraceArtistTagContribution[];
+};
+
+export type TraceWeightedTag = {
+  name: string;
+  weight: number;
+  fromArtists: string[];
+};
+
+export type TraceAlbumPoolInfo = {
+  page1Count: number;
+  deepPage: number;
+  deepPageCount: number;
+  totalAfterDedup: number;
+};
+
+export type TraceSelectionReason = "preferred_non_library" | "fallback_in_library";
+
+export type RecommendationTrace = {
+  plexArtists: TraceArtistEntry[];
+  weightedTags: TraceWeightedTag[];
+  chosenTag: { name: string; weight: number };
+  albumPool: TraceAlbumPoolInfo;
+  selectionReason: TraceSelectionReason;
+};
+
+export type PromotedAlbumResult = {
+  album: {
+    name: string;
+    mbid: string;
+    artistName: string;
+    artistMbid: string;
+    coverUrl: string;
+  };
+  tag: string;
+  inLibrary: boolean;
+  trace: RecommendationTrace;
+} | null;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -5,9 +5,15 @@ interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
+  panelClassName?: string;
 }
 
-export default function Modal({ isOpen, onClose, children }: ModalProps) {
+export default function Modal({
+  isOpen,
+  onClose,
+  children,
+  panelClassName,
+}: ModalProps) {
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const [closing, setClosing] = useState(false);
 
@@ -25,7 +31,7 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
       onClick={onClose}
     >
       <div
-        className={`bg-white dark:bg-gray-800 w-full h-full p-6 md:h-auto md:max-w-md md:rounded-xl md:border-4 md:border-black md:shadow-cartoon-lg ${closing ? "animate-pop-out" : "animate-pop"}`}
+        className={`bg-white dark:bg-gray-800 w-full h-full p-6 md:h-auto ${panelClassName ?? "md:max-w-md"} md:rounded-xl md:border-4 md:border-black md:shadow-cartoon-lg ${closing ? "animate-pop-out" : "animate-pop"}`}
         onAnimationEnd={() => {
           if (closing) setClosing(false);
         }}

--- a/src/hooks/usePromotedAlbum.ts
+++ b/src/hooks/usePromotedAlbum.ts
@@ -1,5 +1,43 @@
 import { useState, useEffect, useCallback } from "react";
 
+export type TraceArtistTagContribution = {
+  tagName: string;
+  rawCount: number;
+  weight: number;
+};
+
+export type TraceArtistEntry = {
+  name: string;
+  viewCount: number;
+  picked: boolean;
+  tagContributions: TraceArtistTagContribution[];
+};
+
+export type TraceWeightedTag = {
+  name: string;
+  weight: number;
+  fromArtists: string[];
+};
+
+export type TraceAlbumPoolInfo = {
+  page1Count: number;
+  deepPage: number;
+  deepPageCount: number;
+  totalAfterDedup: number;
+};
+
+export type TraceSelectionReason =
+  | "preferred_non_library"
+  | "fallback_in_library";
+
+export type RecommendationTrace = {
+  plexArtists: TraceArtistEntry[];
+  weightedTags: TraceWeightedTag[];
+  chosenTag: { name: string; weight: number };
+  albumPool: TraceAlbumPoolInfo;
+  selectionReason: TraceSelectionReason;
+};
+
 export type PromotedAlbumData = {
   album: {
     name: string;
@@ -10,6 +48,7 @@ export type PromotedAlbumData = {
   };
   tag: string;
   inLibrary: boolean;
+  trace: RecommendationTrace;
 };
 
 export default function usePromotedAlbum() {

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -4,6 +4,7 @@ import type { PromotedAlbumData } from "@/hooks/usePromotedAlbum";
 import type { MonitorState } from "@/types";
 import MonitorButton from "@/components/MonitorButton";
 import PurchaseLinksModal from "@/components/PurchaseLinksModal";
+import RecommendationTraceModal from "./RecommendationTraceModal";
 import { RefreshIcon } from "@/components/icons";
 import useLidarr from "@/hooks/useLidarr";
 import ImageWithShimmer from "@/components/ImageWithShimmer";
@@ -32,6 +33,7 @@ export default function PromotedAlbum({
 }: PromotedAlbumProps) {
   const [coverError, setCoverError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isTraceOpen, setIsTraceOpen] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const { state, errorMsg, addToLidarr } = useLidarr();
 
@@ -137,9 +139,12 @@ export default function PromotedAlbum({
                     {album.artistName}
                   </Link>
                   {tag && (
-                    <span className="inline-block mt-2 px-2 py-0.5 bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 text-xs font-medium rounded-full border border-violet-200 dark:border-violet-700">
+                    <button
+                      onClick={() => setIsTraceOpen(true)}
+                      className="inline-block mt-2 px-2 py-0.5 bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 text-xs font-medium rounded-full border border-violet-200 dark:border-violet-700 hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors cursor-pointer"
+                    >
                       Because you listen to {tag}
-                    </span>
+                    </button>
                   )}
                 </div>
 
@@ -164,6 +169,16 @@ export default function PromotedAlbum({
           albumTitle={album.name}
           albumMbid={album.mbid}
           onAddToLibrary={handleAddToLibrary}
+        />
+      )}
+
+      {data?.trace && album && (
+        <RecommendationTraceModal
+          isOpen={isTraceOpen}
+          onClose={() => setIsTraceOpen(false)}
+          trace={data.trace}
+          albumName={album.name}
+          artistName={album.artistName}
         />
       )}
     </>

--- a/src/pages/DiscoverPage/components/RecommendationTraceModal.tsx
+++ b/src/pages/DiscoverPage/components/RecommendationTraceModal.tsx
@@ -1,0 +1,261 @@
+import type { RecommendationTrace } from "@/hooks/usePromotedAlbum";
+import Modal from "@/components/Modal";
+
+interface RecommendationTraceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  trace: RecommendationTrace;
+  albumName: string;
+  artistName: string;
+}
+
+function FlowConnector() {
+  return (
+    <div className="flex flex-col items-center py-1">
+      <div className="w-0.5 h-4 bg-gray-300 dark:bg-gray-600" />
+      <div className="text-gray-400 dark:text-gray-500 text-xs leading-none">
+        ▼
+      </div>
+    </div>
+  );
+}
+
+function StageCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-testid="stage-card"
+      className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black p-4"
+    >
+      <h4 className="text-xs font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+        {title}
+      </h4>
+      {children}
+    </div>
+  );
+}
+
+function PlexArtistsStage({
+  artists,
+}: {
+  artists: RecommendationTrace["plexArtists"];
+}) {
+  return (
+    <StageCard title="Plex Listening History">
+      <div className="flex flex-wrap gap-1.5">
+        {artists.map((a) => (
+          <span
+            key={a.name}
+            data-testid={a.picked ? "picked-artist" : "artist"}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border ${
+              a.picked
+                ? "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 border-amber-300 dark:border-amber-700 font-bold"
+                : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-600"
+            }`}
+          >
+            {a.name}
+            <span className="text-[10px] opacity-70">({a.viewCount})</span>
+          </span>
+        ))}
+      </div>
+    </StageCard>
+  );
+}
+
+function TagContributionsStage({
+  artists,
+}: {
+  artists: RecommendationTrace["plexArtists"];
+}) {
+  const picked = artists.filter((a) => a.picked);
+
+  return (
+    <StageCard title="Tag Contributions">
+      <div className="space-y-2">
+        {picked.map((a) => (
+          <div key={a.name}>
+            <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
+              {a.name}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {a.tagContributions.map((tc) => (
+                <span
+                  key={tc.tagName}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-600"
+                >
+                  {tc.tagName}
+                  <span className="text-[10px] opacity-70">w:{tc.weight}</span>
+                </span>
+              ))}
+              {a.tagContributions.length === 0 && (
+                <span className="text-[11px] text-gray-400 dark:text-gray-500 italic">
+                  No tags
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </StageCard>
+  );
+}
+
+function TagPoolStage({
+  tags,
+  chosenTagName,
+}: {
+  tags: RecommendationTrace["weightedTags"];
+  chosenTagName: string;
+}) {
+  return (
+    <StageCard title="Merged Tag Pool">
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((t) => (
+          <span
+            key={t.name}
+            data-testid={
+              t.name === chosenTagName ? "chosen-tag" : "pool-tag"
+            }
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border ${
+              t.name === chosenTagName
+                ? "bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-200 border-violet-300 dark:border-violet-700 font-bold"
+                : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-600"
+            }`}
+          >
+            {t.name}
+            <span className="text-[10px] opacity-70">
+              w:{Math.round(t.weight)}
+            </span>
+          </span>
+        ))}
+      </div>
+    </StageCard>
+  );
+}
+
+function AlbumPoolStage({ pool }: { pool: RecommendationTrace["albumPool"] }) {
+  return (
+    <StageCard title="Album Pool">
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-2">
+          <p className="text-gray-500 dark:text-gray-400">Page 1</p>
+          <p
+            data-testid="page1-count"
+            className="font-bold text-gray-900 dark:text-gray-100"
+          >
+            {pool.page1Count} albums
+          </p>
+        </div>
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-2">
+          <p className="text-gray-500 dark:text-gray-400">
+            Page {pool.deepPage}
+          </p>
+          <p
+            data-testid="deep-page-count"
+            className="font-bold text-gray-900 dark:text-gray-100"
+          >
+            {pool.deepPageCount} albums
+          </p>
+        </div>
+        <div className="col-span-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg p-2">
+          <p className="text-gray-500 dark:text-gray-400">After dedup</p>
+          <p
+            data-testid="total-after-dedup"
+            className="font-bold text-gray-900 dark:text-gray-100"
+          >
+            {pool.totalAfterDedup} unique albums
+          </p>
+        </div>
+      </div>
+    </StageCard>
+  );
+}
+
+function ResultStage({
+  albumName,
+  artistName,
+  selectionReason,
+}: {
+  albumName: string;
+  artistName: string;
+  selectionReason: RecommendationTrace["selectionReason"];
+}) {
+  const reasonLabel =
+    selectionReason === "preferred_non_library"
+      ? "New discovery"
+      : "Already in library";
+  const reasonColor =
+    selectionReason === "preferred_non_library"
+      ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700"
+      : "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700";
+
+  return (
+    <StageCard title="Result">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-bold text-gray-900 dark:text-gray-100 text-sm truncate">
+            {albumName}
+          </p>
+          <p className="text-gray-500 dark:text-gray-400 text-xs truncate">
+            {artistName}
+          </p>
+        </div>
+        <span
+          data-testid="selection-reason"
+          className={`shrink-0 px-2 py-0.5 rounded-full text-[11px] font-medium border ${reasonColor}`}
+        >
+          {reasonLabel}
+        </span>
+      </div>
+    </StageCard>
+  );
+}
+
+export default function RecommendationTraceModal({
+  isOpen,
+  onClose,
+  trace,
+  albumName,
+  artistName,
+}: RecommendationTraceModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} panelClassName="md:max-w-2xl">
+      <div className="overflow-y-auto max-h-[80vh] px-1 -mx-1 pb-1">
+        <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-4">
+          How this was recommended
+        </h3>
+
+        <div className="flex flex-col">
+          <PlexArtistsStage artists={trace.plexArtists} />
+          <FlowConnector />
+          <TagContributionsStage artists={trace.plexArtists} />
+          <FlowConnector />
+          <TagPoolStage
+            tags={trace.weightedTags}
+            chosenTagName={trace.chosenTag.name}
+          />
+          <FlowConnector />
+          <AlbumPoolStage pool={trace.albumPool} />
+          <FlowConnector />
+          <ResultStage
+            albumName={albumName}
+            artistName={artistName}
+            selectionReason={trace.selectionReason}
+          />
+        </div>
+
+        <button
+          onClick={onClose}
+          className="mt-4 w-full bg-gray-100 dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300 font-medium py-2 px-4 rounded-xl border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all"
+        >
+          Close
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/DiscoverPage/components/__tests__/RecommendationTraceModal.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/RecommendationTraceModal.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationTraceModal from "../RecommendationTraceModal";
+import type { RecommendationTrace } from "@/hooks/usePromotedAlbum";
+
+vi.mock("@/components/Modal", () => ({
+  default: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) => (isOpen ? <div data-testid="modal">{children}</div> : null),
+}));
+
+const trace: RecommendationTrace = {
+  plexArtists: [
+    {
+      name: "Radiohead",
+      viewCount: 100,
+      picked: true,
+      tagContributions: [
+        { tagName: "alternative", rawCount: 100, weight: 10000 },
+        { tagName: "rock", rawCount: 80, weight: 8000 },
+      ],
+    },
+    {
+      name: "Bjork",
+      viewCount: 50,
+      picked: true,
+      tagContributions: [
+        { tagName: "electronic", rawCount: 90, weight: 4500 },
+      ],
+    },
+    {
+      name: "Portishead",
+      viewCount: 30,
+      picked: false,
+      tagContributions: [],
+    },
+  ],
+  weightedTags: [
+    { name: "alternative", weight: 10000, fromArtists: ["Radiohead"] },
+    { name: "rock", weight: 8000, fromArtists: ["Radiohead"] },
+    { name: "electronic", weight: 4500, fromArtists: ["Bjork"] },
+  ],
+  chosenTag: { name: "alternative", weight: 10000 },
+  albumPool: {
+    page1Count: 50,
+    deepPage: 4,
+    deepPageCount: 48,
+    totalAfterDedup: 95,
+  },
+  selectionReason: "preferred_non_library",
+};
+
+function renderModal(overrides?: Partial<RecommendationTrace>) {
+  return render(
+    <RecommendationTraceModal
+      isOpen={true}
+      onClose={vi.fn()}
+      trace={{ ...trace, ...overrides }}
+      albumName="OK Computer"
+      artistName="Radiohead"
+    />
+  );
+}
+
+describe("RecommendationTraceModal", () => {
+  it("renders all stage cards", () => {
+    renderModal();
+    const stageCards = screen.getAllByTestId("stage-card");
+    expect(stageCards).toHaveLength(5);
+  });
+
+  it("highlights picked artists vs non-picked", () => {
+    renderModal();
+    const pickedArtists = screen.getAllByTestId("picked-artist");
+    const regularArtists = screen.getAllByTestId("artist");
+    expect(pickedArtists).toHaveLength(2);
+    expect(regularArtists).toHaveLength(1);
+    expect(pickedArtists[0]).toHaveTextContent("Radiohead");
+    expect(pickedArtists[1]).toHaveTextContent("Bjork");
+    expect(regularArtists[0]).toHaveTextContent("Portishead");
+  });
+
+  it("highlights chosen tag in pool", () => {
+    renderModal();
+    const chosenTag = screen.getByTestId("chosen-tag");
+    expect(chosenTag).toHaveTextContent("alternative");
+    const poolTags = screen.getAllByTestId("pool-tag");
+    expect(poolTags).toHaveLength(2);
+  });
+
+  it("shows correct album pool counts", () => {
+    renderModal();
+    expect(screen.getByTestId("page1-count")).toHaveTextContent("50 albums");
+    expect(screen.getByTestId("deep-page-count")).toHaveTextContent(
+      "48 albums"
+    );
+    expect(screen.getByTestId("total-after-dedup")).toHaveTextContent(
+      "95 unique albums"
+    );
+  });
+
+  it("shows correct selection reason for non-library", () => {
+    renderModal();
+    const reason = screen.getByTestId("selection-reason");
+    expect(reason).toHaveTextContent("New discovery");
+  });
+
+  it("shows correct selection reason for fallback", () => {
+    renderModal({ selectionReason: "fallback_in_library" });
+    const reason = screen.getByTestId("selection-reason");
+    expect(reason).toHaveTextContent("Already in library");
+  });
+
+  it("shows album name and artist in result stage", () => {
+    renderModal();
+    expect(screen.getByText("OK Computer")).toBeInTheDocument();
+    const resultStage = screen.getByTestId("selection-reason").closest("[data-testid='stage-card']")!;
+    expect(resultStage).toHaveTextContent("Radiohead");
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <RecommendationTraceModal
+        isOpen={false}
+        onClose={vi.fn()}
+        trace={trace}
+        albumName="OK Computer"
+        artistName="Radiohead"
+      />
+    );
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Clicking the "Because you listen to {tag}" chip on the promoted album now opens a flow-diagram modal revealing each stage of the recommendation algorithm: Plex listening history, tag contributions, merged tag pool, album pool stats, and final selection reason.

Backend collects trace data during the recommendation pipeline and includes it in the API response. Tag accumulation now merges same tags from multiple artists with combined weights.