### PR TITLE
Add customizable recommendation algorithm settings

### DIFF
--- a/server/api/lidarr/config.test.ts
+++ b/server/api/lidarr/config.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getLidarrConfig } from "./config";
+import { DEFAULT_PROMOTED_ALBUM } from "../../config";
 
-vi.mock("../../config", () => ({
-  getConfig: vi.fn(),
-}));
+vi.mock("../../config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 import { getConfig } from "../../config";
 
 const mockGetConfig = vi.mocked(getConfig);
+
+const baseConfig = {
+  lidarrUrl: "",
+  lidarrApiKey: "",
+  lidarrQualityProfileId: 1,
+  lidarrRootFolderPath: "",
+  lidarrMetadataProfileId: 1,
+  lastfmApiKey: "",
+  plexUrl: "",
+  plexToken: "",
+  importPath: "",
+  slskdUrl: "",
+  slskdApiKey: "",
+  slskdDownloadPath: "",
+  theme: "system" as const,
+  promotedAlbum: DEFAULT_PROMOTED_ALBUM,
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -16,19 +35,10 @@ beforeEach(() => {
 describe("getLidarrConfig", () => {
   it("returns url and headers when configured", () => {
     mockGetConfig.mockReturnValue({
+      ...baseConfig,
       lidarrUrl: "http://lidarr:8686",
       lidarrApiKey: "test-api-key",
-      lidarrQualityProfileId: 1,
       lidarrRootFolderPath: "/music",
-      lidarrMetadataProfileId: 1,
-      lastfmApiKey: "",
-      plexUrl: "",
-      plexToken: "",
-      importPath: "",
-      slskdUrl: "",
-      slskdApiKey: "",
-      slskdDownloadPath: "",
-      theme: "system",
     });
 
     const config = getLidarrConfig();
@@ -38,40 +48,15 @@ describe("getLidarrConfig", () => {
   });
 
   it("throws when lidarr is not configured", () => {
-    mockGetConfig.mockReturnValue({
-      lidarrUrl: "",
-      lidarrApiKey: "",
-      lidarrQualityProfileId: 1,
-      lidarrRootFolderPath: "",
-      lidarrMetadataProfileId: 1,
-      lastfmApiKey: "",
-      plexUrl: "",
-      plexToken: "",
-      importPath: "",
-      slskdUrl: "",
-      slskdApiKey: "",
-      slskdDownloadPath: "",
-      theme: "system",
-    });
+    mockGetConfig.mockReturnValue(baseConfig);
 
     expect(() => getLidarrConfig()).toThrow("Lidarr not configured");
   });
 
   it("throws when only url is set but not api key", () => {
     mockGetConfig.mockReturnValue({
+      ...baseConfig,
       lidarrUrl: "http://lidarr:8686",
-      lidarrApiKey: "",
-      lidarrQualityProfileId: 1,
-      lidarrRootFolderPath: "",
-      lidarrMetadataProfileId: 1,
-      lastfmApiKey: "",
-      plexUrl: "",
-      plexToken: "",
-      importPath: "",
-      slskdUrl: "",
-      slskdApiKey: "",
-      slskdDownloadPath: "",
-      theme: "system",
     });
 
     expect(() => getLidarrConfig()).toThrow("Lidarr not configured");

--- a/server/api/plex/config.test.ts
+++ b/server/api/plex/config.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getPlexConfig } from "./config";
+import { DEFAULT_PROMOTED_ALBUM } from "../../config";
 
-vi.mock("../../config", () => ({
-  getConfig: vi.fn(),
-}));
+vi.mock("../../config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 import { getConfig } from "../../config";
 
@@ -23,6 +25,7 @@ const fullConfig = {
   slskdApiKey: "",
   slskdDownloadPath: "",
   theme: "system" as const,
+  promotedAlbum: DEFAULT_PROMOTED_ALBUM,
 };
 
 beforeEach(() => {

--- a/server/api/slskd/config.test.ts
+++ b/server/api/slskd/config.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getSlskdConfig } from "./config";
+import { DEFAULT_PROMOTED_ALBUM } from "../../config";
 
-vi.mock("../../config", () => ({
-  getConfig: vi.fn(),
-}));
+vi.mock("../../config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 import { getConfig } from "../../config";
 
@@ -23,6 +25,7 @@ const fullConfig = {
   slskdApiKey: "slskd-api-key-123",
   slskdDownloadPath: "/downloads",
   theme: "system" as const,
+  promotedAlbum: DEFAULT_PROMOTED_ALBUM,
 };
 
 beforeEach(() => {

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -123,3 +123,115 @@ describe("getConfigValue", () => {
     expect(getConfigValue("lidarrQualityProfileId")).toBe(1);
   });
 });
+
+describe("promotedAlbum config", () => {
+  it("returns full defaults when no promotedAlbum in saved config", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({ lidarrUrl: "http://test:8686" })
+    );
+
+    const { getConfig, DEFAULT_PROMOTED_ALBUM } = await loadConfig();
+    const config = getConfig();
+
+    expect(config.promotedAlbum).toEqual(DEFAULT_PROMOTED_ALBUM);
+  });
+
+  it("deep merges partial promotedAlbum with defaults", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        promotedAlbum: { topArtistsCount: 20, cacheDurationMinutes: 60 },
+      })
+    );
+
+    const { getConfig, DEFAULT_PROMOTED_ALBUM } = await loadConfig();
+    const config = getConfig();
+
+    expect(config.promotedAlbum.topArtistsCount).toBe(20);
+    expect(config.promotedAlbum.cacheDurationMinutes).toBe(60);
+    expect(config.promotedAlbum.pickedArtistsCount).toBe(
+      DEFAULT_PROMOTED_ALBUM.pickedArtistsCount
+    );
+    expect(config.promotedAlbum.genericTags).toEqual(
+      DEFAULT_PROMOTED_ALBUM.genericTags
+    );
+  });
+
+  it("deep merges promotedAlbum on setConfig", async () => {
+    const { setConfig, getConfig } = await loadConfig();
+
+    setConfig({ promotedAlbum: { topArtistsCount: 25 } as never });
+    const config = getConfig();
+
+    expect(config.promotedAlbum.topArtistsCount).toBe(25);
+    expect(config.promotedAlbum.pickedArtistsCount).toBe(3);
+  });
+
+  it("validates positive integers", async () => {
+    const { setConfig } = await loadConfig();
+
+    expect(() =>
+      setConfig({ promotedAlbum: { topArtistsCount: 0 } as never })
+    ).toThrow("topArtistsCount must be a positive integer");
+
+    expect(() =>
+      setConfig({ promotedAlbum: { pickedArtistsCount: -1 } as never })
+    ).toThrow("pickedArtistsCount must be a positive integer");
+  });
+
+  it("validates deepPageMax >= deepPageMin", async () => {
+    const { setConfig } = await loadConfig();
+
+    expect(() =>
+      setConfig({
+        promotedAlbum: { deepPageMin: 5, deepPageMax: 3 } as never,
+      })
+    ).toThrow("deepPageMax must be >= deepPageMin");
+  });
+
+  it("validates cacheDurationMinutes is non-negative", async () => {
+    const { setConfig } = await loadConfig();
+
+    expect(() =>
+      setConfig({ promotedAlbum: { cacheDurationMinutes: -1 } as never })
+    ).toThrow("cacheDurationMinutes must be a non-negative number");
+  });
+
+  it("validates libraryPreference enum", async () => {
+    const { setConfig } = await loadConfig();
+
+    expect(() =>
+      setConfig({ promotedAlbum: { libraryPreference: "invalid" } as never })
+    ).toThrow("libraryPreference must be one of");
+  });
+
+  it("validates genericTags is an array", async () => {
+    const { setConfig } = await loadConfig();
+
+    expect(() =>
+      setConfig({ promotedAlbum: { genericTags: "not-array" } as never })
+    ).toThrow("genericTags must be an array");
+  });
+
+  it("allows valid promotedAlbum config", async () => {
+    const { setConfig, getConfig } = await loadConfig();
+
+    setConfig({
+      promotedAlbum: {
+        cacheDurationMinutes: 0,
+        topArtistsCount: 5,
+        pickedArtistsCount: 2,
+        tagsPerArtist: 3,
+        deepPageMin: 1,
+        deepPageMax: 5,
+        genericTags: ["rock"],
+        libraryPreference: "prefer_library",
+      },
+    });
+
+    const config = getConfig();
+    expect(config.promotedAlbum.cacheDurationMinutes).toBe(0);
+    expect(config.promotedAlbum.libraryPreference).toBe("prefer_library");
+  });
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -8,6 +8,19 @@ const log = createLogger("Config");
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+export type LibraryPreference = "prefer_new" | "prefer_library" | "no_preference";
+
+export type PromotedAlbumConfig = {
+  cacheDurationMinutes: number;
+  topArtistsCount: number;
+  pickedArtistsCount: number;
+  tagsPerArtist: number;
+  deepPageMin: number;
+  deepPageMax: number;
+  genericTags: string[];
+  libraryPreference: LibraryPreference;
+};
+
 export type IConfig = {
   lidarrUrl: string;
   lidarrApiKey: string;
@@ -22,6 +35,36 @@ export type IConfig = {
   slskdApiKey: string;
   slskdDownloadPath: string;
   theme: "light" | "dark" | "system";
+  promotedAlbum: PromotedAlbumConfig;
+};
+
+/** Input type for setConfig — promotedAlbum is optional since defaults are deep-merged */
+export type IConfigInput = Omit<IConfig, "promotedAlbum"> & {
+  promotedAlbum?: Partial<PromotedAlbumConfig>;
+};
+
+export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
+  cacheDurationMinutes: 30,
+  topArtistsCount: 10,
+  pickedArtistsCount: 3,
+  tagsPerArtist: 5,
+  deepPageMin: 2,
+  deepPageMax: 10,
+  genericTags: [
+    "seen live",
+    "favorites",
+    "favourite",
+    "my favorite",
+    "love",
+    "awesome",
+    "beautiful",
+    "cool",
+    "check out",
+    "spotify",
+    "under 2000 listeners",
+    "all",
+  ],
+  libraryPreference: "prefer_new",
 };
 
 const DEFAULT_CONFIG: IConfig = {
@@ -38,6 +81,7 @@ const DEFAULT_CONFIG: IConfig = {
   slskdApiKey: "",
   slskdDownloadPath: "",
   theme: "system",
+  promotedAlbum: DEFAULT_PROMOTED_ALBUM,
 };
 
 const CONFIG_DIR =
@@ -47,20 +91,76 @@ const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 export const getConfig = (): IConfig => {
   try {
     const data = fs.readFileSync(CONFIG_PATH, "utf-8");
-    return { ...DEFAULT_CONFIG, ...JSON.parse(data) };
+    const saved = JSON.parse(data);
+    return {
+      ...DEFAULT_CONFIG,
+      ...saved,
+      promotedAlbum: {
+        ...DEFAULT_PROMOTED_ALBUM,
+        ...(saved.promotedAlbum ?? {}),
+      },
+    };
   } catch {
-    return { ...DEFAULT_CONFIG };
+    return { ...DEFAULT_CONFIG, promotedAlbum: { ...DEFAULT_PROMOTED_ALBUM } };
   }
 };
 
-export const setConfig = (newConfig: Partial<IConfig>) => {
+const VALID_LIBRARY_PREFERENCES: LibraryPreference[] = [
+  "prefer_new",
+  "prefer_library",
+  "no_preference",
+];
+
+function validatePositiveInt(value: unknown, name: string) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
+  if (
+    typeof config.cacheDurationMinutes !== "number" ||
+    config.cacheDurationMinutes < 0
+  ) {
+    throw new Error("cacheDurationMinutes must be a non-negative number");
+  }
+  validatePositiveInt(config.topArtistsCount, "topArtistsCount");
+  validatePositiveInt(config.pickedArtistsCount, "pickedArtistsCount");
+  validatePositiveInt(config.tagsPerArtist, "tagsPerArtist");
+  validatePositiveInt(config.deepPageMin, "deepPageMin");
+  validatePositiveInt(config.deepPageMax, "deepPageMax");
+  if (config.deepPageMax < config.deepPageMin) {
+    throw new Error("deepPageMax must be >= deepPageMin");
+  }
+  if (!Array.isArray(config.genericTags)) {
+    throw new Error("genericTags must be an array");
+  }
+  if (
+    !VALID_LIBRARY_PREFERENCES.includes(
+      config.libraryPreference as LibraryPreference
+    )
+  ) {
+    throw new Error(
+      `libraryPreference must be one of: ${VALID_LIBRARY_PREFERENCES.join(", ")}`
+    );
+  }
+}
+
+export const setConfig = (newConfig: Partial<IConfigInput>) => {
   if (!fs.existsSync(CONFIG_DIR)) {
     log.info(`Config directory missing, creating it in ${CONFIG_DIR}`);
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
   }
 
   const currentConfig = getConfig();
-  const mergedConfig = { ...currentConfig, ...newConfig };
+  const mergedConfig = {
+    ...currentConfig,
+    ...newConfig,
+    promotedAlbum: {
+      ...currentConfig.promotedAlbum,
+      ...(newConfig.promotedAlbum ?? {}),
+    },
+  };
 
   if (typeof mergedConfig.lidarrUrl !== "string") {
     throw new Error("lidarrUrl must be a string");
@@ -100,6 +200,10 @@ export const setConfig = (newConfig: Partial<IConfig>) => {
   }
   if (!["light", "dark", "system"].includes(mergedConfig.theme)) {
     throw new Error("theme must be 'light', 'dark', or 'system'");
+  }
+
+  if (newConfig.promotedAlbum !== undefined) {
+    validatePromotedAlbumConfig(mergedConfig.promotedAlbum);
   }
 
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(mergedConfig, null, 2));

--- a/server/promotedAlbum/types.ts
+++ b/server/promotedAlbum/types.ts
@@ -26,7 +26,10 @@ export type TraceAlbumPoolInfo = {
 
 export type TraceSelectionReason =
   | "preferred_non_library"
-  | "fallback_in_library";
+  | "preferred_library"
+  | "fallback_in_library"
+  | "fallback_non_library"
+  | "no_preference";
 
 export type RecommendationTrace = {
   plexArtists: TraceArtistEntry[];

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -3,6 +3,7 @@ import express from "express";
 import fs from "fs";
 import { getConfig, setConfig } from "../config";
 import { lidarrFetch } from "../api/lidarr/fetch";
+import { clearPromotedAlbumCache } from "../promotedAlbum/getPromotedAlbum";
 
 const router = express.Router();
 
@@ -22,6 +23,10 @@ router.put("/", (req: Request, res: Response) => {
   }
 
   setConfig(partialConfig);
+
+  if (partialConfig.promotedAlbum) {
+    clearPromotedAlbumCache();
+  }
 
   res.json({ success: true });
 });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout() {
   return (
     <div className="flex min-h-screen bg-amber-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <Sidebar />
-      <main className="flex-1 px-4 md:px-8 pt-20 md:pt-6 pb-24 md:pb-6">
+      <main className="flex-1 min-w-0 px-4 md:px-8 pt-20 md:pt-6 pb-24 md:pb-6">
         <div className="max-w-6xl mx-auto">
           <Outlet />
         </div>

--- a/src/context/LidarrContext.tsx
+++ b/src/context/LidarrContext.tsx
@@ -5,6 +5,7 @@ import {
   type LidarrOptions,
   type LidarrContextValue,
 } from "./lidarrContextDef";
+import { DEFAULT_PROMOTED_ALBUM } from "./promotedAlbumDefaults";
 
 interface LidarrContextProviderProps {
   children: ReactNode;
@@ -33,6 +34,10 @@ async function loadSettings(
         slskdApiKey: data.slskdApiKey || "",
         slskdDownloadPath: data.slskdDownloadPath || "",
         theme: data.theme || "system",
+        promotedAlbum: {
+          ...DEFAULT_PROMOTED_ALBUM,
+          ...(data.promotedAlbum ?? {}),
+        },
       });
 
       if (data.lidarrUrl && data.lidarrApiKey) {
@@ -103,6 +108,7 @@ export const LidarrContextProvider = ({
     slskdApiKey: "",
     slskdDownloadPath: "",
     theme: "system",
+    promotedAlbum: DEFAULT_PROMOTED_ALBUM,
   });
   const [options, setOptions] = useState<LidarrOptions>({
     qualityProfiles: [],

--- a/src/context/lidarrContextDef.ts
+++ b/src/context/lidarrContextDef.ts
@@ -1,5 +1,18 @@
 import { createContext } from "react";
 
+export type LibraryPreference = "prefer_new" | "prefer_library" | "no_preference";
+
+export interface PromotedAlbumSettings {
+  cacheDurationMinutes: number;
+  topArtistsCount: number;
+  pickedArtistsCount: number;
+  tagsPerArtist: number;
+  deepPageMin: number;
+  deepPageMax: number;
+  genericTags: string[];
+  libraryPreference: LibraryPreference;
+}
+
 export interface LidarrSettings {
   lidarrUrl: string;
   lidarrApiKey: string;
@@ -14,6 +27,7 @@ export interface LidarrSettings {
   slskdApiKey: string;
   slskdDownloadPath: string;
   theme: "light" | "dark" | "system";
+  promotedAlbum?: PromotedAlbumSettings;
 }
 
 export type LidarrOptions = {

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -1,0 +1,25 @@
+import type { PromotedAlbumSettings } from "./lidarrContextDef";
+
+export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
+  cacheDurationMinutes: 30,
+  topArtistsCount: 10,
+  pickedArtistsCount: 3,
+  tagsPerArtist: 5,
+  deepPageMin: 2,
+  deepPageMax: 10,
+  genericTags: [
+    "seen live",
+    "favorites",
+    "favourite",
+    "my favorite",
+    "love",
+    "awesome",
+    "beautiful",
+    "cool",
+    "check out",
+    "spotify",
+    "under 2000 listeners",
+    "all",
+  ],
+  libraryPreference: "prefer_new",
+};

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -14,6 +14,7 @@ const IMMEDIATE_FIELDS: Set<keyof LidarrSettings> = new Set([
   "lidarrRootFolderPath",
   "lidarrMetadataProfileId",
   "theme",
+  "promotedAlbum",
 ]);
 
 function isImmediateField(key: keyof LidarrSettings): boolean {

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -7,6 +7,8 @@ import LastfmSection from "./components/LastfmSection";
 import PlexSection from "./components/PlexSection";
 import SlskdSection from "./components/SlskdSection";
 import ImportSection from "./components/ImportSection";
+import RecommendationsSection from "./components/RecommendationsSection";
+import { DEFAULT_PROMOTED_ALBUM } from "@/context/promotedAlbumDefaults";
 import ThemeToggle from "@/components/ThemeToggle";
 import Skeleton from "@/components/Skeleton";
 import SettingsTabs from "./components/SettingsTabs";
@@ -25,11 +27,17 @@ type TestResult = {
   error?: string;
 };
 
+const TAB_LABELS: Record<SettingsTab, string> = {
+  general: "General",
+  integrations: "Integrations",
+  recommendations: "Recommendations",
+};
+
 function SectionBadge({ section }: { section: SettingsSection }) {
   const meta = SECTION_META[section];
   return (
     <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
-      {meta.tab === "general" ? "General" : "Integrations"}
+      {TAB_LABELS[meta.tab]}
     </span>
   );
 }
@@ -239,6 +247,18 @@ export default function SettingsPage() {
               onUrlChange={(v) => updateField("slskdUrl", v)}
               onApiKeyChange={(v) => updateField("slskdApiKey", v)}
               onDownloadPathChange={(v) => updateField("slskdDownloadPath", v)}
+            />
+          </div>
+        )}
+
+        {visible("recommendations") && (
+          <div>
+            {isSearching && <SectionBadge section="recommendations" />}
+            <RecommendationsSection
+              config={fields.promotedAlbum ?? DEFAULT_PROMOTED_ALBUM}
+              onConfigChange={(updated) =>
+                updateField("promotedAlbum", updated)
+              }
             />
           </div>
         )}

--- a/src/pages/SettingsPage/components/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/components/RecommendationsSection.tsx
@@ -1,0 +1,203 @@
+import type {
+  PromotedAlbumSettings,
+  LibraryPreference,
+} from "@/context/lidarrContextDef";
+import { DEFAULT_PROMOTED_ALBUM } from "@/context/promotedAlbumDefaults";
+import TagListEditor from "./TagListEditor";
+
+interface RecommendationsSectionProps {
+  config: PromotedAlbumSettings;
+  onConfigChange: (config: PromotedAlbumSettings) => void;
+}
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  description?: string;
+}
+
+const LIBRARY_PREFERENCE_OPTIONS: {
+  value: LibraryPreference;
+  label: string;
+}[] = [
+  { value: "prefer_new", label: "Prefer New" },
+  { value: "prefer_library", label: "Prefer Library" },
+  { value: "no_preference", label: "No Preference" },
+];
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  description,
+}: NumberFieldProps) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">
+        {label}
+      </label>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => {
+          const parsed = Number(e.target.value);
+          if (!Number.isNaN(parsed)) onChange(Math.max(min, Math.min(max, parsed)));
+        }}
+        min={min}
+        max={max}
+        step={step}
+        className="w-full px-3 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-amber-400 shadow-cartoon-md text-[16px]"
+      />
+      {description && (
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function RecommendationsSection({
+  config,
+  onConfigChange,
+}: RecommendationsSectionProps) {
+  const update = <K extends keyof PromotedAlbumSettings>(
+    key: K,
+    value: PromotedAlbumSettings[K]
+  ) => {
+    onConfigChange({ ...config, [key]: value });
+  };
+
+  const handleReset = () => {
+    onConfigChange({ ...DEFAULT_PROMOTED_ALBUM });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          Recommendations
+        </h2>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="px-3 py-1.5 text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+        >
+          Reset to Defaults
+        </button>
+      </div>
+
+      <NumberField
+        label="Cache Duration (minutes)"
+        value={config.cacheDurationMinutes}
+        onChange={(v) => update("cacheDurationMinutes", v)}
+        min={0}
+        max={120}
+        step={5}
+        description="How long to cache a promoted album before picking a new one. Set to 0 to disable caching."
+      />
+
+      <NumberField
+        label="Top Artists Count"
+        value={config.topArtistsCount}
+        onChange={(v) => update("topArtistsCount", v)}
+        min={1}
+        max={50}
+        description="Number of top artists to fetch from Plex for tag analysis."
+      />
+
+      <NumberField
+        label="Picked Artists Count"
+        value={config.pickedArtistsCount}
+        onChange={(v) => update("pickedArtistsCount", v)}
+        min={1}
+        max={config.topArtistsCount}
+        description="Number of artists randomly selected (weighted by play count) for tag extraction."
+      />
+
+      <NumberField
+        label="Tags per Artist"
+        value={config.tagsPerArtist}
+        onChange={(v) => update("tagsPerArtist", v)}
+        min={1}
+        max={20}
+        description="Maximum number of tags to use per artist after filtering generic tags."
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <NumberField
+          label="Deep Page Min"
+          value={config.deepPageMin}
+          onChange={(v) => {
+            const updated = { ...config, deepPageMin: v };
+            if (v > config.deepPageMax) updated.deepPageMax = v;
+            onConfigChange(updated);
+          }}
+          min={1}
+          max={50}
+        />
+        <NumberField
+          label="Deep Page Max"
+          value={config.deepPageMax}
+          onChange={(v) => {
+            const updated = { ...config, deepPageMax: v };
+            if (v < config.deepPageMin) updated.deepPageMin = v;
+            onConfigChange(updated);
+          }}
+          min={1}
+          max={50}
+        />
+      </div>
+      <p className="text-gray-400 dark:text-gray-500 text-xs -mt-2">
+        Range of Last.fm tag album pages to sample from for variety.
+      </p>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+          Library Preference
+        </label>
+        <div className="flex rounded-lg border-2 border-black overflow-hidden shadow-cartoon-sm">
+          {LIBRARY_PREFERENCE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => update("libraryPreference", opt.value)}
+              className={`flex-1 px-3 py-2 text-sm font-bold transition-colors ${
+                config.libraryPreference === opt.value
+                  ? "bg-pink-400 text-black"
+                  : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-pink-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          Whether to prefer albums from new artists, artists already in your
+          library, or no preference.
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+          Generic Tags (filtered out)
+        </label>
+        <TagListEditor
+          tags={config.genericTags}
+          onTagsChange={(tags) => update("genericTags", tags)}
+        />
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          Tags that are too generic to be useful for recommendations. These are
+          filtered out during tag analysis.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/SettingsTabs.tsx
+++ b/src/pages/SettingsPage/components/SettingsTabs.tsx
@@ -1,4 +1,4 @@
-export type SettingsTab = "general" | "integrations";
+export type SettingsTab = "general" | "integrations" | "recommendations";
 
 interface SettingsTabsProps {
   activeTab: SettingsTab;
@@ -8,6 +8,7 @@ interface SettingsTabsProps {
 const TABS: { id: SettingsTab; label: string }[] = [
   { id: "general", label: "General" },
   { id: "integrations", label: "Integrations" },
+  { id: "recommendations", label: "Recommendations" },
 ];
 
 export default function SettingsTabs({
@@ -15,14 +16,17 @@ export default function SettingsTabs({
   onTabChange,
 }: SettingsTabsProps) {
   return (
-    <div className="flex gap-2" role="tablist">
+    <div
+      className="flex gap-2 overflow-x-auto snap-x snap-mandatory overlay-scrollbar p-1"
+      role="tablist"
+    >
       {TABS.map((tab) => (
         <button
           key={tab.id}
           role="tab"
           aria-selected={activeTab === tab.id}
           onClick={() => onTabChange(tab.id)}
-          className={`px-4 py-2 text-sm font-bold rounded-lg border-2 border-black transition-all ${
+          className={`shrink-0 snap-start px-4 py-2 text-sm font-bold rounded-lg border-2 border-black transition-all ${
             activeTab === tab.id
               ? "bg-pink-400 text-black shadow-cartoon-sm dark:text-black"
               : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-pink-50 dark:hover:bg-gray-700"

--- a/src/pages/SettingsPage/components/TagListEditor.tsx
+++ b/src/pages/SettingsPage/components/TagListEditor.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+
+interface TagListEditorProps {
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+}
+
+function isDuplicate(tags: string[], newTag: string): boolean {
+  const lower = newTag.toLowerCase();
+  return tags.some((t) => t.toLowerCase() === lower);
+}
+
+export default function TagListEditor({
+  tags,
+  onTagsChange,
+}: TagListEditorProps) {
+  const [input, setInput] = useState("");
+
+  const handleAdd = () => {
+    const trimmed = input.trim();
+    if (!trimmed || isDuplicate(tags, trimmed)) return;
+    onTagsChange([...tags, trimmed]);
+    setInput("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  const handleRemove = (index: number) => {
+    onTagsChange(tags.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag, i) => (
+          <span
+            key={`${tag}-${i}`}
+            className="inline-flex items-center gap-1 px-2 py-1 text-sm bg-pink-100 dark:bg-pink-900/30 text-pink-800 dark:text-pink-200 rounded-lg border border-pink-300 dark:border-pink-700"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => handleRemove(i)}
+              className="ml-0.5 text-pink-500 hover:text-pink-700 dark:hover:text-pink-300 font-bold"
+              aria-label={`Remove ${tag}`}
+            >
+              &times;
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add a tag..."
+          className="flex-1 px-3 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-200 dark:placeholder-gray-600 focus:outline-none focus:border-amber-400 shadow-cartoon-md text-[16px]"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="px-3 py-2 text-sm font-bold bg-pink-400 text-black border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-pink-500 transition-colors"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/components/__tests__/RecommendationsSection.test.tsx
+++ b/src/pages/SettingsPage/components/__tests__/RecommendationsSection.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RecommendationsSection from "../RecommendationsSection";
+import type { PromotedAlbumSettings } from "@/context/lidarrContextDef";
+
+const defaultConfig: PromotedAlbumSettings = {
+  cacheDurationMinutes: 30,
+  topArtistsCount: 10,
+  pickedArtistsCount: 3,
+  tagsPerArtist: 5,
+  deepPageMin: 2,
+  deepPageMax: 10,
+  genericTags: ["seen live", "favorites"],
+  libraryPreference: "prefer_new",
+};
+
+function getInputByLabel(label: string): HTMLInputElement {
+  const labelEl = screen.getByText(label);
+  const container = labelEl.closest("div")!;
+  return within(container).getByRole("spinbutton") as HTMLInputElement;
+}
+
+describe("RecommendationsSection", () => {
+  it("renders the heading and all controls", () => {
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Recommendations")).toBeInTheDocument();
+    expect(screen.getByText("Cache Duration (minutes)")).toBeInTheDocument();
+    expect(screen.getByText("Top Artists Count")).toBeInTheDocument();
+    expect(screen.getByText("Picked Artists Count")).toBeInTheDocument();
+    expect(screen.getByText("Tags per Artist")).toBeInTheDocument();
+    expect(screen.getByText("Deep Page Min")).toBeInTheDocument();
+    expect(screen.getByText("Deep Page Max")).toBeInTheDocument();
+    expect(screen.getByText("Library Preference")).toBeInTheDocument();
+    expect(screen.getByText("Generic Tags (filtered out)")).toBeInTheDocument();
+  });
+
+  it("displays current config values in the correct fields", () => {
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={vi.fn()}
+      />
+    );
+
+    expect(getInputByLabel("Cache Duration (minutes)").value).toBe("30");
+    expect(getInputByLabel("Top Artists Count").value).toBe("10");
+    expect(getInputByLabel("Picked Artists Count").value).toBe("3");
+    expect(getInputByLabel("Tags per Artist").value).toBe("5");
+    expect(getInputByLabel("Deep Page Min").value).toBe("2");
+    expect(getInputByLabel("Deep Page Max").value).toBe("10");
+  });
+
+  it("calls onConfigChange when a number field changes", async () => {
+    const onConfigChange = vi.fn();
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={onConfigChange}
+      />
+    );
+
+    const topArtistsInput = getInputByLabel("Top Artists Count");
+    await userEvent.type(topArtistsInput, "5");
+
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ topArtistsCount: 50 })
+    );
+  });
+
+  it("calls onConfigChange when library preference changes", async () => {
+    const onConfigChange = vi.fn();
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={onConfigChange}
+      />
+    );
+
+    await userEvent.click(screen.getByText("Prefer Library"));
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ libraryPreference: "prefer_library" })
+    );
+  });
+
+  it("highlights the active library preference button", () => {
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={vi.fn()}
+      />
+    );
+
+    const preferNewBtn = screen.getByText("Prefer New");
+    expect(preferNewBtn.className).toContain("bg-pink-400");
+
+    const preferLibBtn = screen.getByText("Prefer Library");
+    expect(preferLibBtn.className).not.toContain("bg-pink-400");
+  });
+
+  it("renders generic tags", () => {
+    render(
+      <RecommendationsSection
+        config={defaultConfig}
+        onConfigChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("seen live")).toBeInTheDocument();
+    expect(screen.getByText("favorites")).toBeInTheDocument();
+  });
+
+  it("resets to defaults when reset button is clicked", async () => {
+    const onConfigChange = vi.fn();
+    const customConfig: PromotedAlbumSettings = {
+      ...defaultConfig,
+      topArtistsCount: 25,
+      cacheDurationMinutes: 60,
+      libraryPreference: "no_preference",
+    };
+
+    render(
+      <RecommendationsSection
+        config={customConfig}
+        onConfigChange={onConfigChange}
+      />
+    );
+
+    await userEvent.click(screen.getByText("Reset to Defaults"));
+
+    const resetCall = onConfigChange.mock.calls[0][0];
+    expect(resetCall.topArtistsCount).toBe(10);
+    expect(resetCall.cacheDurationMinutes).toBe(30);
+    expect(resetCall.libraryPreference).toBe("prefer_new");
+  });
+
+  it("adjusts deepPageMax when deepPageMin exceeds it", async () => {
+    const onConfigChange = vi.fn();
+    const config = { ...defaultConfig, deepPageMin: 3, deepPageMax: 5 };
+
+    render(
+      <RecommendationsSection
+        config={config}
+        onConfigChange={onConfigChange}
+      />
+    );
+
+    const minInput = getInputByLabel("Deep Page Min");
+    // Typing "5" appends to "3" making "35", clamped to 35 which exceeds deepPageMax=5
+    await userEvent.type(minInput, "5");
+
+    const lastCall =
+      onConfigChange.mock.calls[onConfigChange.mock.calls.length - 1][0];
+    expect(lastCall.deepPageMin).toBe(35);
+    expect(lastCall.deepPageMax).toBe(35);
+  });
+});

--- a/src/pages/SettingsPage/components/__tests__/TagListEditor.test.tsx
+++ b/src/pages/SettingsPage/components/__tests__/TagListEditor.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TagListEditor from "../TagListEditor";
+
+describe("TagListEditor", () => {
+  const defaultProps = {
+    tags: ["rock", "jazz", "pop"],
+    onTagsChange: vi.fn(),
+  };
+
+  it("renders all tags as removable pills", () => {
+    render(<TagListEditor {...defaultProps} />);
+
+    expect(screen.getByText("rock")).toBeInTheDocument();
+    expect(screen.getByText("jazz")).toBeInTheDocument();
+    expect(screen.getByText("pop")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(3);
+  });
+
+  it("removes a tag when its remove button is clicked", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={["rock", "jazz", "pop"]} onTagsChange={onTagsChange} />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove jazz" }));
+    expect(onTagsChange).toHaveBeenCalledWith(["rock", "pop"]);
+  });
+
+  it("adds a tag via the Add button", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={["rock"]} onTagsChange={onTagsChange} />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText("Add a tag..."), "blues");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onTagsChange).toHaveBeenCalledWith(["rock", "blues"]);
+  });
+
+  it("adds a tag on Enter key", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={["rock"]} onTagsChange={onTagsChange} />
+    );
+
+    const input = screen.getByPlaceholderText("Add a tag...");
+    await userEvent.type(input, "blues{Enter}");
+
+    expect(onTagsChange).toHaveBeenCalledWith(["rock", "blues"]);
+  });
+
+  it("clears input after adding a tag", async () => {
+    render(
+      <TagListEditor tags={[]} onTagsChange={vi.fn()} />
+    );
+
+    const input = screen.getByPlaceholderText("Add a tag...");
+    await userEvent.type(input, "blues{Enter}");
+
+    expect(input).toHaveValue("");
+  });
+
+  it("rejects duplicate tags case-insensitively", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={["Rock"]} onTagsChange={onTagsChange} />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText("Add a tag..."), "rock{Enter}");
+    expect(onTagsChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty input", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={[]} onTagsChange={onTagsChange} />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(onTagsChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only input", async () => {
+    const onTagsChange = vi.fn();
+    render(
+      <TagListEditor tags={[]} onTagsChange={onTagsChange} />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText("Add a tag..."), "   {Enter}");
+    expect(onTagsChange).not.toHaveBeenCalled();
+  });
+
+  it("renders empty state with no tags", () => {
+    render(<TagListEditor tags={[]} onTagsChange={vi.fn()} />);
+
+    expect(screen.queryAllByRole("button", { name: /remove/i })).toHaveLength(0);
+    expect(screen.getByPlaceholderText("Add a tag...")).toBeInTheDocument();
+  });
+});

--- a/src/pages/SettingsPage/settingsSearchConfig.ts
+++ b/src/pages/SettingsPage/settingsSearchConfig.ts
@@ -7,7 +7,8 @@ export type SettingsSection =
   | "lidarrOptions"
   | "lastfm"
   | "plex"
-  | "slskd";
+  | "slskd"
+  | "recommendations";
 
 type SectionMeta = {
   label: string;
@@ -58,6 +59,22 @@ export const SECTION_META: Record<SettingsSection, SectionMeta> = {
     label: "slskd",
     tab: "integrations",
     keywords: ["slskd", "soulseek", "download", "api", "key", "path"],
+  },
+  recommendations: {
+    label: "Recommendations",
+    tab: "recommendations",
+    keywords: [
+      "recommendation",
+      "promoted",
+      "algorithm",
+      "cache",
+      "tags",
+      "discovery",
+      "artist",
+      "library",
+      "preference",
+      "generic",
+    ],
   },
 };
 


### PR DESCRIPTION
Make the promoted album recommendation algorithm configurable via a new Recommendations tab in Settings. All previously hardcoded parameters (artist counts, tag limits, cache duration, generic tags, library preference, deep page range) are now user-tunable with validation and auto-save. Config changes clear the promoted album cache.

Also fixes mobile layout: adds scrollable pill tabs and min-w-0 on the main layout flex child to prevent horizontal page overflow.