### PR TITLE
feat: show release year on promoted album banner

### DIFF
--- a/server/api/musicbrainz/releaseGroups.test.ts
+++ b/server/api/musicbrainz/releaseGroups.test.ts
@@ -109,7 +109,28 @@ describe("searchArtistReleaseGroups", () => {
 });
 
 describe("getReleaseGroupIdFromRelease", () => {
-  it("returns release-group ID from release MBID", async () => {
+  it("returns release-group info from release MBID", async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: "release-123",
+        title: "OK Computer",
+        "release-group": {
+          id: "rg-456",
+          title: "OK Computer",
+          "first-release-date": "1997-06-16",
+        },
+      })
+    );
+
+    const result = await getReleaseGroupIdFromRelease("release-123");
+    expect(result).toEqual({ id: "rg-456", firstReleaseDate: "1997-06-16" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://musicbrainz.test/ws/2/release/release-123?inc=release-groups&fmt=json",
+      { headers: { "User-Agent": "test" } }
+    );
+  });
+
+  it("returns empty firstReleaseDate when not present", async () => {
     mockFetch.mockResolvedValue(
       okResponse({
         id: "release-123",
@@ -122,11 +143,7 @@ describe("getReleaseGroupIdFromRelease", () => {
     );
 
     const result = await getReleaseGroupIdFromRelease("release-123");
-    expect(result).toBe("rg-456");
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://musicbrainz.test/ws/2/release/release-123?inc=release-groups&fmt=json",
-      { headers: { "User-Agent": "test" } }
-    );
+    expect(result).toEqual({ id: "rg-456", firstReleaseDate: "" });
   });
 
   it("returns null when release not found", async () => {

--- a/server/api/musicbrainz/releaseGroups.ts
+++ b/server/api/musicbrainz/releaseGroups.ts
@@ -4,6 +4,7 @@ import type {
   MusicBrainzArtistSearchResponse,
   ReleaseGroupSearchResult,
   MusicBrainzRelease,
+  ReleaseGroupInfo,
 } from "./types";
 
 /** Search for release groups (albums/EPs) by text query */
@@ -77,10 +78,10 @@ export async function searchArtistReleaseGroups(
   };
 }
 
-/** Convert a release MBID to its release-group MBID */
+/** Convert a release MBID to its release-group ID and first release date */
 export async function getReleaseGroupIdFromRelease(
   releaseMbid: string
-): Promise<string | null> {
+): Promise<ReleaseGroupInfo | null> {
   const url = `${MB_BASE}/release/${releaseMbid}?inc=release-groups&fmt=json`;
   const response = await rateLimitedMbFetch(url, { headers: MB_HEADERS });
 
@@ -89,5 +90,11 @@ export async function getReleaseGroupIdFromRelease(
   }
 
   const data: MusicBrainzRelease = await response.json();
-  return data["release-group"]?.id || null;
+  const rg = data["release-group"];
+  if (!rg?.id) return null;
+
+  return {
+    id: rg.id,
+    firstReleaseDate: rg["first-release-date"] ?? "",
+  };
 }

--- a/server/api/musicbrainz/types.ts
+++ b/server/api/musicbrainz/types.ts
@@ -61,5 +61,11 @@ export type MusicBrainzRelease = {
   "release-group": {
     id: string;
     title: string;
+    "first-release-date"?: string;
   };
+};
+
+export type ReleaseGroupInfo = {
+  id: string;
+  firstReleaseDate: string;
 };

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
   vi.spyOn(Math, "random").mockReturnValue(0.1);
   mockGetConfigValue.mockReturnValue(defaultPromotedAlbumConfig);
   mockGetReleaseGroupIdFromRelease.mockImplementation((mbid: string) =>
-    Promise.resolve(`rg-${mbid}`)
+    Promise.resolve({ id: `rg-${mbid}`, firstReleaseDate: "1997-06-16" })
   );
 });
 
@@ -117,6 +117,7 @@ describe("getPromotedAlbum", () => {
       coverUrl: expect.stringMatching(
         /^https:\/\/coverartarchive\.org\/release-group\//
       ),
+      year: "1997",
     });
     expect(result!.tag).toBe("alternative");
     expect(result!.inLibrary).toBe(false);

--- a/server/promotedAlbum/types.ts
+++ b/server/promotedAlbum/types.ts
@@ -46,6 +46,7 @@ export type PromotedAlbumResult = {
     artistName: string;
     artistMbid: string;
     coverUrl: string;
+    year: string;
   };
   tag: string;
   inLibrary: boolean;

--- a/server/routes/promotedAlbum.test.ts
+++ b/server/routes/promotedAlbum.test.ts
@@ -26,6 +26,7 @@ describe("GET /", () => {
         artistName: "Radiohead",
         artistMbid: "art-1",
         coverUrl: "https://coverartarchive.org/release-group/alb-1/front-500",
+        year: "1997",
       },
       tag: "alternative",
       inLibrary: false,

--- a/src/hooks/__tests__/usePromotedAlbum.test.ts
+++ b/src/hooks/__tests__/usePromotedAlbum.test.ts
@@ -16,6 +16,7 @@ const albumData = {
     artistName: "Radiohead",
     artistMbid: "art-1",
     coverUrl: "https://coverartarchive.org/release-group/alb-1/front-500",
+    year: "1997",
   },
   tag: "alternative",
   inLibrary: false,

--- a/src/hooks/usePromotedAlbum.ts
+++ b/src/hooks/usePromotedAlbum.ts
@@ -45,6 +45,7 @@ export type PromotedAlbumData = {
     artistName: string;
     artistMbid: string;
     coverUrl: string;
+    year: string;
   };
   tag: string;
   inLibrary: boolean;

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -182,12 +182,17 @@ export default function PromotedAlbum({
                     <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 truncate">
                       {album.name}
                     </h3>
-                    <Link
-                      to={`/search?q=${encodeURIComponent(album.artistName)}&searchType=artist`}
-                      className="text-gray-500 dark:text-gray-400 text-sm truncate block hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
-                    >
-                      {album.artistName}
-                    </Link>
+                    <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
+                      <Link
+                        to={`/search?q=${encodeURIComponent(album.artistName)}&searchType=artist`}
+                        className="hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
+                      >
+                        {album.artistName}
+                      </Link>
+                      {album.year && (
+                        <span className="ml-1.5">· {album.year}</span>
+                      )}
+                    </p>
                     {tag && (
                       <button
                         onClick={() => setIsTraceOpen(true)}

--- a/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
@@ -87,6 +87,7 @@ const albumData: PromotedAlbumData = {
     artistName: "Radiohead",
     artistMbid: "art-1",
     coverUrl: "https://coverartarchive.org/release-group/alb-1/front-500",
+    year: "1997",
   },
   tag: "alternative",
   inLibrary: false,
@@ -141,9 +142,22 @@ describe("PromotedAlbum", () => {
     );
     expect(screen.getByText("OK Computer")).toBeInTheDocument();
     expect(screen.getByText("Radiohead")).toBeInTheDocument();
+    expect(screen.getByText("· 1997")).toBeInTheDocument();
     expect(
       screen.getByText("Because you listen to alternative")
     ).toBeInTheDocument();
+  });
+
+  it("does not render year separator when year is empty", () => {
+    const noYearData: PromotedAlbumData = {
+      ...albumData,
+      album: { ...albumData.album, year: "" },
+    };
+    renderWithRouter(
+      <PromotedAlbum data={noYearData} loading={false} onRefresh={mockRefresh} />
+    );
+    expect(screen.getByText("Radiohead")).toBeInTheDocument();
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
   });
 
   it("links artist name to search page with artist search type", () => {


### PR DESCRIPTION
Fetches first-release-date from MusicBrainz when resolving release groups and displays the year next to the artist name on the Discover page promoted album card.

Closes #43