### PR TITLE
fix: add resilientFetch wrapper with timeout and retry

### DIFF
--- a/server/api/apple/artists.test.ts
+++ b/server/api/apple/artists.test.ts
@@ -48,7 +48,8 @@ describe("getArtistArtwork", () => {
       "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/75/9c/ff/759cff39-7fe4-a20a-3e63-d6a95db02b8c/cover.jpg/600x600bb.jpg"
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://itunes.apple.com/search?term=Radiohead&entity=album&limit=1"
+      "https://itunes.apple.com/search?term=Radiohead&entity=album&limit=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 
@@ -183,7 +184,8 @@ describe("getAlbumArtwork", () => {
 
     expect(result).toBe("https://example.com/okcomputer/600x600bb.jpg");
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://itunes.apple.com/search?term=Radiohead+OK+Computer&entity=album&limit=1"
+      "https://itunes.apple.com/search?term=Radiohead+OK+Computer&entity=album&limit=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 

--- a/server/api/apple/artists.ts
+++ b/server/api/apple/artists.ts
@@ -1,5 +1,6 @@
 import NodeCache from "node-cache";
 import { withCache } from "../../cache";
+import { resilientFetch } from "../resilientFetch";
 import { createLogger } from "../../logger";
 import type { AppleSearchResponse } from "./types";
 
@@ -25,7 +26,7 @@ const fetchArtistArtwork = async (artistName: string): Promise<string> => {
     });
 
     const url = `${ITUNES_SEARCH_BASE}?${params.toString()}`;
-    const response = await fetch(url);
+    const response = await resilientFetch(url);
 
     if (!response.ok) {
       log.error(
@@ -71,7 +72,7 @@ const fetchAlbumArtwork = async (
     });
 
     const url = `${ITUNES_SEARCH_BASE}?${params.toString()}`;
-    const response = await fetch(url);
+    const response = await resilientFetch(url);
 
     if (!response.ok) {
       log.error(

--- a/server/api/deezer/artists.test.ts
+++ b/server/api/deezer/artists.test.ts
@@ -39,7 +39,8 @@ describe("getArtistImage", () => {
       "https://e-cdns-images.dzcdn.net/images/artist/9508a2/1000x1000-000000-80-0-0.jpg"
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.deezer.com/search/artist?q=Radiohead&limit=1"
+      "https://api.deezer.com/search/artist?q=Radiohead&limit=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 

--- a/server/api/deezer/artists.ts
+++ b/server/api/deezer/artists.ts
@@ -1,5 +1,6 @@
 import NodeCache from "node-cache";
 import { withCache } from "../../cache";
+import { resilientFetch } from "../resilientFetch";
 import { createLogger } from "../../logger";
 import type { DeezerArtistSearchResponse } from "./types";
 
@@ -22,7 +23,7 @@ const fetchArtistImage = async (artistName: string): Promise<string> => {
     });
 
     const url = `${DEEZER_SEARCH_BASE}?${params.toString()}`;
-    const response = await fetch(url);
+    const response = await resilientFetch(url);
 
     if (!response.ok) {
       log.error(`Failed to fetch image for ${artistName}: ${response.status}`);

--- a/server/api/deezer/tracks.test.ts
+++ b/server/api/deezer/tracks.test.ts
@@ -37,7 +37,8 @@ describe("getTrackPreview", () => {
 
     expect(result).toBe("https://cdns-preview.dzcdn.net/stream/creep.mp3");
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.deezer.com/search/track?q=Radiohead+Creep&limit=1"
+      "https://api.deezer.com/search/track?q=Radiohead+Creep&limit=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 

--- a/server/api/deezer/tracks.ts
+++ b/server/api/deezer/tracks.ts
@@ -1,5 +1,6 @@
 import NodeCache from "node-cache";
 import { withCache } from "../../cache";
+import { resilientFetch } from "../resilientFetch";
 import { createLogger } from "../../logger";
 import type { DeezerTrackSearchResponse } from "./types";
 
@@ -22,7 +23,7 @@ const fetchTrackPreview = async (
     });
 
     const url = `${DEEZER_SEARCH_BASE}?${params.toString()}`;
-    const response = await fetch(url);
+    const response = await resilientFetch(url);
 
     if (!response.ok) {
       log.error(

--- a/server/api/lastfm/albums.ts
+++ b/server/api/lastfm/albums.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../resilientFetch";
 import { buildUrl } from "./config";
 import type { LastfmTagAlbumsResponse } from "./types";
 
@@ -7,7 +8,7 @@ export const getTopAlbumsByTag = async (
   limit = "50"
 ) => {
   const url = buildUrl("tag.getTopAlbums", { tag, page, limit });
-  const response = await fetch(url);
+  const response = await resilientFetch(url);
   const data: LastfmTagAlbumsResponse = await response.json();
 
   if (data.error) {

--- a/server/api/lastfm/artists.ts
+++ b/server/api/lastfm/artists.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../resilientFetch";
 import { buildUrl } from "./config";
 import type {
   LastfmSimilarResponse,
@@ -7,7 +8,7 @@ import type {
 
 export const getSimilarArtists = async (artist: string) => {
   const url = buildUrl("artist.getSimilar", { artist, limit: "30" });
-  const response = await fetch(url);
+  const response = await resilientFetch(url);
   const data: LastfmSimilarResponse = await response.json();
 
   if (data.error) {
@@ -30,7 +31,7 @@ export const getSimilarArtists = async (artist: string) => {
 
 export const getArtistTopTags = async (artist: string) => {
   const url = buildUrl("artist.getTopTags", { artist });
-  const response = await fetch(url);
+  const response = await resilientFetch(url);
   const data: LastfmTopTagsResponse = await response.json();
 
   if (data.error) {
@@ -45,7 +46,7 @@ export const getArtistTopTags = async (artist: string) => {
 
 const fetchSingleTagArtists = async (tag: string, page = "1", limit = "30") => {
   const url = buildUrl("tag.getTopArtists", { tag, limit, page });
-  const response = await fetch(url);
+  const response = await resilientFetch(url);
   const data: LastfmTagArtistsResponse = await response.json();
 
   if (data.error) {

--- a/server/api/lidarr/fetch.ts
+++ b/server/api/lidarr/fetch.ts
@@ -1,14 +1,23 @@
 import { Agent } from "undici";
+import { resilientFetch } from "../resilientFetch";
 
 const agent = new Agent({ connect: { rejectUnauthorized: false } });
 
-/** fetch wrapper for lidarr so we can skip TLS verification for self-signed/local certs */
-export function lidarrFetch(
-  url: string,
+/** fetch via undici agent so we can skip TLS verification for self-signed/local certs */
+function rawFetch(
+  url: string | URL | Request,
   init?: RequestInit
 ): Promise<Response> {
   return fetch(url, {
     ...init,
     dispatcher: agent,
   } as RequestInit & { dispatcher: Agent });
+}
+
+/** Resilient fetch wrapper for Lidarr with TLS skip + timeout + retry */
+export function lidarrFetch(
+  url: string,
+  init?: RequestInit
+): Promise<Response> {
+  return resilientFetch(url, init, { fetchFn: rawFetch });
 }

--- a/server/api/musicbrainz/config.ts
+++ b/server/api/musicbrainz/config.ts
@@ -1,3 +1,5 @@
+import { resilientFetch } from "../resilientFetch";
+
 export const MB_BASE = "https://musicbrainz.org/ws/2";
 
 export const MB_HEADERS = {
@@ -22,5 +24,5 @@ export async function rateLimitedMbFetch(
   }
 
   lastMbRequestTime = Date.now();
-  return fetch(url, options);
+  return resilientFetch(url, options);
 }

--- a/server/api/musicbrainz/releaseGroups.ts
+++ b/server/api/musicbrainz/releaseGroups.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../resilientFetch";
 import { MB_BASE, MB_HEADERS, rateLimitedMbFetch } from "./config";
 import type {
   MusicBrainzSearchResponse,
@@ -12,7 +13,7 @@ export async function searchReleaseGroups(
   query: string
 ): Promise<ReleaseGroupSearchResult> {
   const url = `${MB_BASE}/release-group/?query=${encodeURIComponent(query)}&limit=20&fmt=json`;
-  const response = await fetch(url, { headers: MB_HEADERS });
+  const response = await resilientFetch(url, { headers: MB_HEADERS });
 
   if (!response.ok) {
     throw new Error(`MusicBrainz returned ${response.status}`);
@@ -33,7 +34,7 @@ export async function searchArtistReleaseGroups(
   artistName: string
 ): Promise<ReleaseGroupSearchResult> {
   const artistUrl = `${MB_BASE}/artist/?query=${encodeURIComponent(artistName)}&limit=1&fmt=json`;
-  const artistResponse = await fetch(artistUrl, { headers: MB_HEADERS });
+  const artistResponse = await resilientFetch(artistUrl, { headers: MB_HEADERS });
 
   if (!artistResponse.ok) {
     throw new Error(`MusicBrainz returned ${artistResponse.status}`);
@@ -48,7 +49,7 @@ export async function searchArtistReleaseGroups(
 
   const artistId = artistData.artists[0].id;
   const url = `${MB_BASE}/release-group?artist=${artistId}&type=album|ep&limit=50&inc=artist-credits&fmt=json`;
-  const response = await fetch(url, { headers: MB_HEADERS });
+  const response = await resilientFetch(url, { headers: MB_HEADERS });
 
   if (!response.ok) {
     throw new Error(`MusicBrainz returned ${response.status}`);

--- a/server/api/musicbrainz/tracks.ts
+++ b/server/api/musicbrainz/tracks.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../resilientFetch";
 import { MB_BASE, MB_HEADERS } from "./config";
 import type { MusicBrainzReleasesResponse, TrackMedia } from "./types";
 
@@ -6,7 +7,7 @@ export async function getReleaseTracks(
   releaseGroupId: string
 ): Promise<TrackMedia[]> {
   const url = `${MB_BASE}/release?release-group=${releaseGroupId}&inc=recordings+media&limit=1&fmt=json`;
-  const response = await fetch(url, { headers: MB_HEADERS });
+  const response = await resilientFetch(url, { headers: MB_HEADERS });
 
   if (!response.ok) {
     throw new Error(`MusicBrainz returned ${response.status}`);

--- a/server/api/plex/account.test.ts
+++ b/server/api/plex/account.test.ts
@@ -30,13 +30,13 @@ describe("getPlexAccount", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "https://plex.tv/users/account.json",
-      {
+      expect.objectContaining({
         headers: {
           Accept: "application/json",
           "X-Plex-Token": "test-token",
           "X-Plex-Client-Identifier": "client-123",
         },
-      }
+      })
     );
   });
 

--- a/server/api/plex/account.ts
+++ b/server/api/plex/account.ts
@@ -1,3 +1,5 @@
+import { resilientFetch } from "../resilientFetch";
+
 export type PlexAccount = {
   username: string;
   thumb: string;
@@ -7,7 +9,7 @@ export async function getPlexAccount(
   token: string,
   clientId: string
 ): Promise<PlexAccount> {
-  const res = await fetch("https://plex.tv/users/account.json", {
+  const res = await resilientFetch("https://plex.tv/users/account.json", {
     headers: {
       Accept: "application/json",
       "X-Plex-Token": token,

--- a/server/api/plex/servers.test.ts
+++ b/server/api/plex/servers.test.ts
@@ -43,13 +43,13 @@ describe("getPlexServers", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "https://plex.tv/api/v2/resources?includeHttps=1",
-      {
+      expect.objectContaining({
         headers: {
           Accept: "application/json",
           "X-Plex-Token": "test-token",
           "X-Plex-Client-Identifier": "client-123",
         },
-      }
+      })
     );
   });
 

--- a/server/api/plex/servers.ts
+++ b/server/api/plex/servers.ts
@@ -1,3 +1,5 @@
+import { resilientFetch } from "../resilientFetch";
+
 type PlexResource = {
   name: string;
   provides: string;
@@ -14,7 +16,7 @@ export async function getPlexServers(
   token: string,
   clientId: string
 ): Promise<PlexServer[]> {
-  const res = await fetch("https://plex.tv/api/v2/resources?includeHttps=1", {
+  const res = await resilientFetch("https://plex.tv/api/v2/resources?includeHttps=1", {
     headers: {
       Accept: "application/json",
       "X-Plex-Token": token,

--- a/server/api/plex/topArtists.ts
+++ b/server/api/plex/topArtists.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../resilientFetch";
 import { getPlexConfig } from "./config";
 import type {
   PlexSectionsResponse,
@@ -10,7 +11,7 @@ const getMusicSectionKey = async (
   baseUrl: string,
   headers: Record<string, string>
 ): Promise<string> => {
-  const res = await fetch(`${baseUrl}/library/sections`, { headers });
+  const res = await resilientFetch(`${baseUrl}/library/sections`, { headers });
   if (!res.ok) throw new Error(`Plex returned ${res.status}`);
 
   const data: PlexSectionsResponse = await res.json();
@@ -26,7 +27,7 @@ export async function getTopArtists(limit: number): Promise<PlexTopArtist[]> {
   const sectionKey = await getMusicSectionKey(baseUrl, headers);
 
   const url = `${baseUrl}/library/sections/${sectionKey}/all?type=8&sort=viewCount:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=${limit}`;
-  const response = await fetch(url, { headers });
+  const response = await resilientFetch(url, { headers });
 
   if (!response.ok) {
     throw new Error(`Plex returned ${response.status}`);

--- a/server/api/resilientFetch.test.ts
+++ b/server/api/resilientFetch.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resilientFetch } from "./resilientFetch";
+
+function mockResponse(body = "ok", status = 200): Response {
+  return new Response(body, { status });
+}
+
+describe("resilientFetch", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns a Response on success", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse("hello"));
+
+    const res = await resilientFetch("https://example.com");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello");
+  });
+
+  it("passes through custom fetchFn", async () => {
+    const customFetch = vi.fn().mockResolvedValue(mockResponse("custom"));
+
+    const res = await resilientFetch("https://example.com", undefined, {
+      fetchFn: customFetch,
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+    expect(await res.text()).toBe("custom");
+    expect(globalThis.fetch).not.toBe(customFetch);
+  });
+
+  it("retries on TypeError (network failure)", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue(mockResponse("recovered"));
+
+    const promise = resilientFetch("https://example.com");
+    await vi.advanceTimersByTimeAsync(500);
+    const res = await promise;
+
+    expect(await res.text()).toBe("recovered");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on ECONNRESET", async () => {
+    const econnreset = Object.assign(new Error("connection reset"), {
+      code: "ECONNRESET",
+    });
+
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(econnreset)
+      .mockResolvedValue(mockResponse("recovered"));
+
+    const promise = resilientFetch("https://example.com");
+    await vi.advanceTimersByTimeAsync(500);
+    const res = await promise;
+
+    expect(await res.text()).toBe("recovered");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on non-retryable errors", async () => {
+    const error = new Error("bad request");
+    globalThis.fetch = vi.fn().mockRejectedValue(error);
+
+    await expect(resilientFetch("https://example.com")).rejects.toThrow(
+      "bad request"
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips retry when retry is false", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(
+      resilientFetch("https://example.com", undefined, { retry: false })
+    ).rejects.toThrow("fetch failed");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies AbortSignal.timeout to each fetch call", async () => {
+    vi.useRealTimers();
+
+    const customFetch = vi.fn().mockImplementation((_url, init) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Promise.resolve(mockResponse("ok"));
+    });
+
+    await resilientFetch("https://example.com", undefined, {
+      timeoutMs: 5000,
+      fetchFn: customFetch,
+      retry: false,
+    });
+
+    expect(customFetch).toHaveBeenCalledOnce();
+
+    vi.useFakeTimers();
+  });
+
+  it("passes init options through to fetch", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse());
+
+    await resilientFetch(
+      "https://example.com",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"key":"value"}',
+      },
+      { retry: false }
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"key":"value"}',
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+});

--- a/server/api/resilientFetch.ts
+++ b/server/api/resilientFetch.ts
@@ -1,0 +1,30 @@
+import { withRetry, type RetryOptions } from "./retry";
+
+export interface ResilientFetchOptions {
+  timeoutMs?: number;
+  retry?: RetryOptions | boolean;
+  fetchFn?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+export function resilientFetch(
+  url: string,
+  init?: RequestInit,
+  options?: ResilientFetchOptions
+): Promise<Response> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = options?.fetchFn ?? fetch;
+  const retryOpt = options?.retry ?? true;
+
+  const retryOptions: RetryOptions | undefined =
+    retryOpt === true ? {} : retryOpt === false ? undefined : retryOpt;
+
+  const doFetch = () => {
+    const signal = AbortSignal.timeout(timeoutMs);
+    return fetchFn(url, { ...init, signal });
+  };
+
+  if (!retryOptions) return doFetch();
+  return withRetry(doFetch, retryOptions);
+}

--- a/server/api/slskd/search.test.ts
+++ b/server/api/slskd/search.test.ts
@@ -79,7 +79,7 @@ describe("waitForSearch", () => {
     expect(result).toEqual({ completed: true, fileCount: 20 });
     expect(mockFetch).toHaveBeenCalledWith(
       "http://slskd:5030/api/v0/searches/abc",
-      { headers: CONFIG.headers }
+      expect.objectContaining({ headers: CONFIG.headers })
     );
   });
 
@@ -105,7 +105,7 @@ describe("getSearchResponses", () => {
     expect(result).toEqual(responses);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://slskd:5030/api/v0/searches/abc/responses",
-      { headers: CONFIG.headers }
+      expect.objectContaining({ headers: CONFIG.headers })
     );
   });
 
@@ -124,7 +124,7 @@ describe("deleteSearch", () => {
     await deleteSearch("abc");
     expect(mockFetch).toHaveBeenCalledWith(
       "http://slskd:5030/api/v0/searches/abc",
-      { method: "DELETE", headers: CONFIG.headers }
+      expect.objectContaining({ method: "DELETE", headers: CONFIG.headers })
     );
   });
 });

--- a/server/api/slskd/search.ts
+++ b/server/api/slskd/search.ts
@@ -1,5 +1,6 @@
 import type { SlskdSearchState, SlskdSearchResponse } from "./types";
 import { getSlskdConfig } from "./config";
+import { resilientFetch } from "../resilientFetch";
 import { AsyncLock } from "../asyncLock";
 import { createLogger } from "../../logger";
 
@@ -17,7 +18,7 @@ export function startSearch(searchText: string): Promise<SlskdSearchState> {
     log.info(
       `POST ${baseUrl}/api/v0/searches (id=${id}, query="${searchText}")`
     );
-    const response = await fetch(`${baseUrl}/api/v0/searches`, {
+    const response = await resilientFetch(`${baseUrl}/api/v0/searches`, {
       method: "POST",
       headers,
       body: JSON.stringify({ id, searchText }),
@@ -43,7 +44,7 @@ export async function waitForSearch(searchId: string): Promise<WaitResult> {
   const deadline = Date.now() + MAX_POLL_DURATION_MS;
 
   while (Date.now() < deadline) {
-    const response = await fetch(`${baseUrl}/api/v0/searches/${searchId}`, {
+    const response = await resilientFetch(`${baseUrl}/api/v0/searches/${searchId}`, {
       headers,
     });
 
@@ -97,7 +98,7 @@ export async function getSearchResponses(
 export async function deleteSearch(searchId: string): Promise<void> {
   const { baseUrl, headers } = getSlskdConfig();
 
-  await fetch(`${baseUrl}/api/v0/searches/${searchId}`, {
+  await resilientFetch(`${baseUrl}/api/v0/searches/${searchId}`, {
     method: "DELETE",
     headers,
   });

--- a/server/api/slskd/transfer.test.ts
+++ b/server/api/slskd/transfer.test.ts
@@ -64,7 +64,7 @@ describe("getDownloadTransfers", () => {
     expect(result).toEqual(groups);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://slskd:5030/api/v0/transfers/downloads",
-      { headers: CONFIG.headers }
+      expect.objectContaining({ headers: CONFIG.headers })
     );
   });
 
@@ -84,7 +84,7 @@ describe("cancelDownload", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "http://slskd:5030/api/v0/transfers/downloads/testuser/transfer-123",
-      { method: "DELETE", headers: CONFIG.headers }
+      expect.objectContaining({ method: "DELETE", headers: CONFIG.headers })
     );
   });
 

--- a/server/api/slskd/transfer.ts
+++ b/server/api/slskd/transfer.ts
@@ -1,5 +1,6 @@
 import type { SlskdTransferGroup } from "./types";
 import { getSlskdConfig } from "./config";
+import { resilientFetch } from "../resilientFetch";
 
 export async function enqueueDownload(
   username: string,
@@ -7,7 +8,7 @@ export async function enqueueDownload(
 ): Promise<void> {
   const { baseUrl, headers } = getSlskdConfig();
 
-  const response = await fetch(
+  const response = await resilientFetch(
     `${baseUrl}/api/v0/transfers/downloads/${encodeURIComponent(username)}`,
     {
       method: "POST",
@@ -26,7 +27,7 @@ export async function enqueueDownload(
 export async function getDownloadTransfers(): Promise<SlskdTransferGroup[]> {
   const { baseUrl, headers } = getSlskdConfig();
 
-  const response = await fetch(`${baseUrl}/api/v0/transfers/downloads`, {
+  const response = await resilientFetch(`${baseUrl}/api/v0/transfers/downloads`, {
     headers,
   });
 
@@ -43,7 +44,7 @@ export async function cancelDownload(
 ): Promise<void> {
   const { baseUrl, headers } = getSlskdConfig();
 
-  const response = await fetch(
+  const response = await resilientFetch(
     `${baseUrl}/api/v0/transfers/downloads/${encodeURIComponent(username)}/${encodeURIComponent(id)}`,
     { method: "DELETE", headers }
   );

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,4 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
+import { createLogger } from "../logger";
+
+const log = createLogger("ErrorHandler");
 
 /** Generic error handler — must be registered after all routes */
 export function errorHandler(
@@ -23,5 +26,8 @@ export function errorHandler(
         : typeof (err as { message?: unknown })?.message === "string"
           ? (err as { message: string }).message
           : "Unknown error";
+
+  log.error(`${status} ${message}`, err);
+
   res.status(status).json({ error: message });
 }

--- a/server/services/plex.test.ts
+++ b/server/services/plex.test.ts
@@ -37,7 +37,9 @@ describe("fetchPlexThumbnail", () => {
     }
     expect(mockFetch).toHaveBeenCalledWith(
       "http://plex:32400/library/metadata/123/thumb",
-      { headers: { "X-Plex-Token": "token123" } }
+      expect.objectContaining({
+        headers: { "X-Plex-Token": "token123" },
+      })
     );
   });
 

--- a/server/services/plex.ts
+++ b/server/services/plex.ts
@@ -1,3 +1,4 @@
+import { resilientFetch } from "../api/resilientFetch";
 import { getPlexConfig } from "../api/plex/config";
 
 type PlexThumbnailResult =
@@ -8,7 +9,7 @@ export async function fetchPlexThumbnail(
   path: string
 ): Promise<PlexThumbnailResult> {
   const { baseUrl, headers } = getPlexConfig();
-  const upstream = await fetch(`${baseUrl}${path}`, { headers });
+  const upstream = await resilientFetch(`${baseUrl}${path}`, { headers });
 
   if (!upstream.ok) {
     return { ok: false, status: upstream.status };


### PR DESCRIPTION
Prevents random ECONNRESET 500 errors by wrapping all external HTTP calls with AbortSignal.timeout (10s default) and retry logic. Adds detection for Node.js network error codes (ECONNRESET, ECONNREFUSED, ETIMEDOUT, etc.) to the retry system, and logs errors server-side in the error handler.

Closes #54