### PR TITLE
fix: include audio format tag in torznab release titles for Lidarr qu…

### DIFF
--- a/server/api/slskd/groupResults.test.ts
+++ b/server/api/slskd/groupResults.test.ts
@@ -105,21 +105,44 @@ describe("groupSearchResults", () => {
 
     const results = groupSearchResults([response]);
     expect(results[0].category).toBe(3040);
+    expect(results[0].formatTag).toBe("FLAC");
   });
 
   it("categorizes other lossless formats as 3040", () => {
     const response = makeResponse("user1", [
       makeFile("D:\\Audio\\Album\\01.ape"),
-      makeFile("D:\\Audio\\Album\\02.wv"),
-      makeFile("D:\\Audio\\Album\\03.wav"),
-      makeFile("D:\\Audio\\Album\\04.aiff"),
+      makeFile("D:\\Audio\\Album\\02.ape"),
+      makeFile("D:\\Audio\\Album\\03.ape"),
     ]);
 
     const results = groupSearchResults([response]);
     expect(results[0].category).toBe(3040);
+    expect(results[0].formatTag).toBe("APE");
+  });
+
+  it("tags FLAC 24bit when bitDepth >= 24", () => {
+    const response = makeResponse("user1", [
+      makeFile("C:\\Music\\Album\\01.flac", { bitDepth: 24 }),
+      makeFile("C:\\Music\\Album\\02.flac", { bitDepth: 24 }),
+    ]);
+
+    const results = groupSearchResults([response]);
+    expect(results[0].category).toBe(3040);
+    expect(results[0].formatTag).toBe("FLAC 24bit");
   });
 
   it("categorizes all-MP3 directories as 3010", () => {
+    const response = makeResponse("user1", [
+      makeFile("C:\\Music\\Album\\01.mp3", { bitRate: 320 }),
+      makeFile("C:\\Music\\Album\\02.mp3", { bitRate: 320 }),
+    ]);
+
+    const results = groupSearchResults([response]);
+    expect(results[0].category).toBe(3010);
+    expect(results[0].formatTag).toBe("MP3-320");
+  });
+
+  it("formats MP3 without bitrate as plain MP3", () => {
     const response = makeResponse("user1", [
       makeFile("C:\\Music\\Album\\01.mp3"),
       makeFile("C:\\Music\\Album\\02.mp3"),
@@ -127,6 +150,7 @@ describe("groupSearchResults", () => {
 
     const results = groupSearchResults([response]);
     expect(results[0].category).toBe(3010);
+    expect(results[0].formatTag).toBe("MP3");
   });
 
   it("categorizes mixed audio directories as 3000", () => {
@@ -139,14 +163,15 @@ describe("groupSearchResults", () => {
     expect(results[0].category).toBe(3000);
   });
 
-  it("categorizes non-lossless non-MP3 audio as 3000", () => {
+  it("categorizes non-lossless non-MP3 audio as 3000 with format tag", () => {
     const response = makeResponse("user1", [
       makeFile("C:\\Music\\Album\\01.ogg"),
-      makeFile("C:\\Music\\Album\\02.opus"),
+      makeFile("C:\\Music\\Album\\02.ogg"),
     ]);
 
     const results = groupSearchResults([response]);
     expect(results[0].category).toBe(3000);
+    expect(results[0].formatTag).toBe("OGG");
   });
 
   it("sorts results with free upload slots first", () => {

--- a/server/api/slskd/types.ts
+++ b/server/api/slskd/types.ts
@@ -68,6 +68,7 @@ export type GroupedSearchResult = {
   uploadSpeed: number;
   bitRate: number;
   category: number;
+  formatTag: string;
 };
 
 // --- NZB metadata (encoded into NZB XML for transport) ---

--- a/server/services/torznab/releaseTitle.test.ts
+++ b/server/services/torznab/releaseTitle.test.ts
@@ -31,4 +31,28 @@ describe("buildReleaseTitle", () => {
   it("handles single directory", () => {
     expect(buildReleaseTitle("Album")).toBe("Album");
   });
+
+  it("appends format tag when provided", () => {
+    expect(buildReleaseTitle("Music\\Radiohead\\OK Computer", "FLAC")).toBe(
+      "Radiohead - OK Computer [FLAC]"
+    );
+  });
+
+  it("appends format tag to dash-separated titles", () => {
+    expect(
+      buildReleaseTitle("Music\\Radiohead - OK Computer", "MP3-320")
+    ).toBe("Radiohead - OK Computer [MP3-320]");
+  });
+
+  it("appends format tag to generic parent fallback", () => {
+    expect(buildReleaseTitle("music\\downloads\\Album", "FLAC 24bit")).toBe(
+      "Album [FLAC 24bit]"
+    );
+  });
+
+  it("does not append tag when formatTag is empty", () => {
+    expect(buildReleaseTitle("Music\\Radiohead\\OK Computer", "")).toBe(
+      "Radiohead - OK Computer"
+    );
+  });
 });

--- a/server/services/torznab/releaseTitle.ts
+++ b/server/services/torznab/releaseTitle.ts
@@ -12,17 +12,21 @@ const GENERIC_DIR_NAMES = new Set([
   "my music",
 ]);
 
-export function buildReleaseTitle(directory: string): string {
+export function buildReleaseTitle(
+  directory: string,
+  formatTag?: string
+): string {
   const parts = directory.split(/[/\\]/).filter(Boolean);
   const lastPart = parts[parts.length - 1] || directory;
+  const suffix = formatTag ? ` [${formatTag}]` : "";
 
-  if (lastPart.includes(" - ")) return lastPart;
+  if (lastPart.includes(" - ")) return lastPart + suffix;
 
   for (let i = parts.length - 2; i >= 0; i--) {
     if (!GENERIC_DIR_NAMES.has(parts[i].toLowerCase())) {
-      return `${parts[i]} - ${lastPart}`;
+      return `${parts[i]} - ${lastPart}${suffix}`;
     }
   }
 
-  return lastPart;
+  return lastPart + suffix;
 }

--- a/server/services/torznab/xml.test.ts
+++ b/server/services/torznab/xml.test.ts
@@ -53,6 +53,7 @@ describe("buildResultsXml", () => {
         uploadSpeed: 1000,
         bitRate: 320,
         category: 3040,
+        formatTag: "FLAC",
       },
     ];
 
@@ -61,7 +62,7 @@ describe("buildResultsXml", () => {
     expect(xml).toContain("<rss");
     expect(xml).toContain('offset="0" total="1"');
     expect(xml).toContain("<item>");
-    expect(xml).toContain("Radiohead - OK Computer");
+    expect(xml).toContain("Radiohead - OK Computer [FLAC]");
     expect(xml).toContain('value="3040"');
     expect(xml).toContain("http://localhost:3001/api/torznab/download/abc123");
   });
@@ -78,6 +79,7 @@ describe("buildResultsXml", () => {
         uploadSpeed: 100,
         bitRate: 0,
         category: 3040,
+        formatTag: "FLAC",
       },
     ];
 

--- a/server/services/torznab/xml.ts
+++ b/server/services/torznab/xml.ts
@@ -47,7 +47,7 @@ export function buildTestResultXml(): string {
 }
 
 function buildItemXml(result: GroupedSearchResult, baseUrl: string): string {
-  const title = escapeXml(buildReleaseTitle(result.directory));
+  const title = escapeXml(buildReleaseTitle(result.directory, result.formatTag));
   const downloadUrl = `${baseUrl}/api/torznab/download/${result.guid}`;
 
   return [


### PR DESCRIPTION
…ality detection

Lidarr parses quality from release titles, not Newznab category codes alone. Without format tokens like [FLAC] or [MP3-320] in the title, all slskd results showed as "unknown" quality. Now computes a format tag from file metadata (extension, bitrate, bit depth) and appends it to the release title.

Closes #59 