### PR TITLE
fix: wait for artist refresh before monitoring album for new artists (#52)

### DIFF
--- a/server/api/lidarr/types.ts
+++ b/server/api/lidarr/types.ts
@@ -109,6 +109,12 @@ export type LidarrRootFolder = {
   path: string;
 };
 
+export type LidarrCommand = {
+  id: number;
+  name: string;
+  status: string;
+};
+
 /** Extracts a human-readable error message from Lidarr's error responses (array or object format) */
 export function extractLidarrError(data: unknown): string {
   if (Array.isArray(data) && data.length > 0) {


### PR DESCRIPTION
When adding an album for a new artist, Lidarr's background RefreshArtist command would overwrite our album monitoring status. Poll GET /command until the refresh completes before returning from addArtistToLidarr, so the subsequent album monitor call persists.