### PR TITLE
fix: not copying shared folder in image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,9 @@ name: Publish Docker image
 on:
   push:
     branches: [main]
-
+  schedule:
+    - cron: "0 4 * * 1"
+    
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -13,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      sha: ${{ steps.push.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,12 +39,14 @@ jobs:
         run: pnpm run format
 
       - name: Commit formatting changes
+        id: push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "style: auto-format with Prettier [skip ci]"
           git push
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Lint
         run: pnpm run lint
@@ -61,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.ci.outputs.sha }}
 
       - uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:22-alpine AS build
+FROM node:22.22.0-alpine3.23 AS build
 
+RUN apk upgrade --no-cache
 RUN apk add --no-cache build-base python3
 RUN corepack enable pnpm
 
@@ -10,7 +11,9 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build
 
-FROM node:22-alpine
+FROM node:22.22.0-alpine3.23
+
+RUN apk upgrade --no-cache
 
 WORKDIR /app
 


### PR DESCRIPTION
- fix dockerfile not copying `shared` folder to final build
- auto-build new image every monday to help with potential security vulnerabilities
- now publish always builds the exact commit that ci finished on (the ci job now outputs the SHA of the commit after the auto-formatter potentially pushes a new commit)