### PR TITLE
fix: enable mobile audio preview playback

### DIFF
--- a/src/hooks/__tests__/useAudioPreview.test.ts
+++ b/src/hooks/__tests__/useAudioPreview.test.ts
@@ -187,4 +187,64 @@ describe("useAudioPreview", () => {
       hookA.result.current.isTrackPlaying("https://example.com/track1.mp3")
     ).toBe(true);
   });
+
+  it("ignores AbortError from play() without resetting state", async () => {
+    const abortError = new DOMException("aborted", "AbortError");
+    mockPlay.mockRejectedValueOnce(abortError);
+
+    const useAudioPreview = await loadHook();
+    const { result } = renderHook(() => useAudioPreview());
+
+    await act(async () => {
+      result.current.toggle("https://example.com/preview.mp3");
+      await Promise.resolve();
+    });
+
+    expect(
+      result.current.isTrackPlaying("https://example.com/preview.mp3")
+    ).toBe(true);
+  });
+
+  it("clears playing state when play() rejects with NotAllowedError", async () => {
+    const notAllowed = new DOMException("blocked", "NotAllowedError");
+    mockPlay.mockRejectedValueOnce(notAllowed);
+
+    const useAudioPreview = await loadHook();
+    const { result } = renderHook(() => useAudioPreview());
+
+    await act(async () => {
+      result.current.toggle("https://example.com/preview.mp3");
+      await Promise.resolve();
+    });
+
+    expect(
+      result.current.isTrackPlaying("https://example.com/preview.mp3")
+    ).toBe(false);
+  });
+
+  it("pauses before swapping src to avoid load races", async () => {
+    const useAudioPreview = await loadHook();
+    const { result } = renderHook(() => useAudioPreview());
+
+    act(() => result.current.toggle("https://example.com/track1.mp3"));
+    mockAudioInstance.paused = false;
+    mockPause.mockClear();
+
+    act(() => result.current.toggle("https://example.com/track2.mp3"));
+
+    expect(mockPause).toHaveBeenCalled();
+    expect(mockAudioInstance.src).toBe("https://example.com/track2.mp3");
+  });
+
+  it("does not create the audio element until first user interaction", async () => {
+    const audioCtor = vi.fn(function () {
+      return mockAudioInstance;
+    });
+    vi.stubGlobal("Audio", audioCtor);
+
+    const useAudioPreview = await loadHook();
+    renderHook(() => useAudioPreview());
+
+    expect(audioCtor).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useAudioPreview.ts
+++ b/src/hooks/useAudioPreview.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 
-const audio = new Audio();
+let audio: HTMLAudioElement | null = null;
 const listeners = new Set<() => void>();
 let activeUrl: string | null = null;
 let activeOwner: symbol | null = null;
@@ -20,11 +20,23 @@ function emit() {
   listeners.forEach((fn) => fn());
 }
 
-audio.addEventListener("ended", () => {
-  activeUrl = null;
-  activeOwner = null;
-  emit();
-});
+/**
+ * Lazily creates the shared HTMLAudioElement on first use. Mobile Safari
+ * requires the element to be instantiated inside a user gesture for
+ * `play()` to be allowed; creating it at module load time triggers
+ * NotAllowedError on the first playback attempt.
+ */
+function getAudio(): HTMLAudioElement {
+  if (!audio) {
+    audio = new Audio();
+    audio.addEventListener("ended", () => {
+      activeUrl = null;
+      activeOwner = null;
+      emit();
+    });
+  }
+  return audio;
+}
 
 export default function useAudioPreview() {
   const playingUrl = useSyncExternalStore(subscribe, getSnapshot);
@@ -33,7 +45,7 @@ export default function useAudioPreview() {
   useEffect(() => {
     const id = ownerId.current;
     return () => {
-      if (activeOwner === id) {
+      if (activeOwner === id && audio) {
         audio.pause();
         audio.src = "";
         activeUrl = null;
@@ -44,25 +56,35 @@ export default function useAudioPreview() {
   }, []);
 
   const toggle = useCallback((previewUrl: string) => {
-    if (activeUrl === previewUrl && !audio.paused) {
-      audio.pause();
+    const a = getAudio();
+    if (activeUrl === previewUrl && !a.paused) {
+      a.pause();
       activeUrl = null;
       activeOwner = null;
-    } else {
-      audio.src = previewUrl;
-      activeUrl = previewUrl;
-      activeOwner = ownerId.current;
-      audio.play().catch(() => {
+      emit();
+      return;
+    }
+
+    a.pause();
+    a.src = previewUrl;
+    activeUrl = previewUrl;
+    activeOwner = ownerId.current;
+    emit();
+
+    const playPromise = a.play();
+    if (playPromise) {
+      playPromise.catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (activeUrl !== previewUrl) return;
         activeUrl = null;
         activeOwner = null;
         emit();
       });
     }
-    emit();
   }, []);
 
   const stop = useCallback(() => {
-    if (activeOwner !== ownerId.current) return;
+    if (activeOwner !== ownerId.current || !audio) return;
     audio.pause();
     audio.src = "";
     activeUrl = null;


### PR DESCRIPTION
Lazily instantiate the shared HTMLAudioElement so creation occurs inside a user gesture. Mobile Safari rejects play() with NotAllowedError when the element is constructed at module load, causing the play button to flash and no audio to play.

Pause before swapping src to avoid AbortError races, and ignore AbortError in the play() rejection path so the UI does not flip back to the play icon when a transient load is interrupted.

Closes #123