### PR TITLE
fix: focus and clear search input when search nav tapped on /search

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,6 +26,23 @@ const mobileLinks: NavItem[] = [
   { to: "/settings", label: "Account", icon: UserCircleIcon },
 ];
 
+function isOnSearchPath(pathname: string): boolean {
+  return pathname === "/search" || pathname.startsWith("/search/");
+}
+
+function makeSearchClickHandler(
+  to: string,
+  pathname: string
+): ((e: React.MouseEvent<HTMLAnchorElement>) => void) | undefined {
+  if (to !== "/search") return undefined;
+  return (e) => {
+    if (isOnSearchPath(pathname)) {
+      e.preventDefault();
+      window.dispatchEvent(new CustomEvent("search:reset"));
+    }
+  };
+}
+
 function MobileNav() {
   const { user } = useAuth();
   const { pathname } = useLocation();
@@ -91,6 +108,7 @@ function MobileNav() {
               <NavLink
                 to={link.to}
                 end={link.to === "/"}
+                onClick={makeSearchClickHandler(link.to, pathname)}
                 className={({ isActive }) =>
                   `relative flex flex-col items-center justify-center gap-1 py-3 text-xs font-bold transition-colors ${
                     isActive
@@ -127,6 +145,7 @@ function DesktopNavLink({ link }: { link: NavItem }) {
   return (
     <NavLink
       to={link.to}
+      onClick={makeSearchClickHandler(link.to, pathname)}
       className={`flex items-center gap-3 px-4 py-3 rounded-lg text-base font-bold transition-all border-2 ${
         isActive
           ? "bg-amber-300 text-black border-black shadow-cartoon-sm dark:text-black"

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AuthContext, type AuthContextValue } from "@/context/authContextDef";
 import Sidebar from "../Sidebar";
@@ -106,5 +106,36 @@ describe("Sidebar", () => {
     const searchLinks = screen.getAllByRole("link", { name: /Search/ });
     expect(searchLinks[0]).toHaveClass("hover:bg-amber-50");
     expect(searchLinks[0]).not.toHaveClass("bg-amber-300");
+  });
+
+  it("dispatches search:reset and prevents navigation when clicking Search while on /search", () => {
+    const handler = vi.fn();
+    window.addEventListener("search:reset", handler);
+    try {
+      renderSidebar("/search");
+      const searchLinks = screen.getAllByRole("link", { name: /Search/ });
+      const event = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+      });
+      const wasDefaultPrevented = !searchLinks[0].dispatchEvent(event);
+      expect(wasDefaultPrevented).toBe(true);
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("search:reset", handler);
+    }
+  });
+
+  it("does not dispatch search:reset when clicking Search from another page", () => {
+    const handler = vi.fn();
+    window.addEventListener("search:reset", handler);
+    try {
+      renderSidebar("/");
+      const searchLinks = screen.getAllByRole("link", { name: /Search/ });
+      fireEvent.click(searchLinks[0]);
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("search:reset", handler);
+    }
   });
 });

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import SearchBar from "./components/SearchBar";
 import ReleaseGroupCard from "@/components/ReleaseGroupCard";
@@ -12,6 +12,7 @@ export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { results, loading, error, search } = useSearch();
   const { isAlbumInLibrary } = useLibraryAlbums();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const query = searchParams.get("q") ?? "";
   const searchType = searchParams.get("searchType") ?? "album";
@@ -21,6 +22,15 @@ export default function SearchPage() {
       search(query, searchType);
     }
   }, [query, searchType, search]);
+
+  useEffect(() => {
+    const handleReset = () => {
+      setSearchParams({});
+      inputRef.current?.focus();
+    };
+    window.addEventListener("search:reset", handleReset);
+    return () => window.removeEventListener("search:reset", handleReset);
+  }, [setSearchParams]);
 
   const handleSearch = useCallback(
     (newQuery: string, newSearchType: string) => {
@@ -37,6 +47,7 @@ export default function SearchPage() {
         onSearch={handleSearch}
         initialQuery={query}
         initialSearchType={searchType}
+        inputRef={inputRef}
       />
 
       {loading && (

--- a/src/pages/SearchPage/__tests__/SearchPage.test.tsx
+++ b/src/pages/SearchPage/__tests__/SearchPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import SearchPage from "../SearchPage";
 
@@ -40,6 +40,19 @@ describe("SearchPage", () => {
   it("shows empty state when no query", () => {
     renderSearchPage();
     expect(screen.getByText("Search for music")).toBeInTheDocument();
+  });
+
+  it("clears input and focuses it on search:reset event", () => {
+    renderSearchPage("Radiohead");
+    const input = screen.getByTestId("search-input") as HTMLInputElement;
+    expect(input.value).toBe("Radiohead");
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("search:reset"));
+    });
+
+    expect(input.value).toBe("");
+    expect(document.activeElement).toBe(input);
   });
 });
 

--- a/src/pages/SearchPage/components/SearchBar.tsx
+++ b/src/pages/SearchPage/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useState, SubmitEvent } from "react";
+import { useEffect, useState, SubmitEvent, RefObject } from "react";
 import Dropdown from "@/components/Dropdown";
 import { SearchIcon } from "@/components/icons";
 import useHaptics from "@/hooks/useHaptics";
@@ -7,16 +7,22 @@ interface SearchBarProps {
   onSearch: (query: string, searchType: string) => void;
   initialQuery?: string;
   initialSearchType?: string;
+  inputRef?: RefObject<HTMLInputElement | null>;
 }
 
 export default function SearchBar({
   onSearch,
   initialQuery = "",
   initialSearchType = "album",
+  inputRef,
 }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery);
   const [searchType, setSearchType] = useState(initialSearchType);
   const haptics = useHaptics();
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
 
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
@@ -48,6 +54,7 @@ export default function SearchBar({
 
       <div className="flex gap-2">
         <input
+          ref={inputRef}
           data-testid="search-input"
           type="text"
           value={query}

--- a/src/pages/SearchPage/components/__tests__/SearchBar.test.tsx
+++ b/src/pages/SearchPage/components/__tests__/SearchBar.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import SearchBar from "../SearchBar";
 
@@ -44,5 +45,22 @@ describe("SearchBar", () => {
     fireEvent.submit(screen.getByTestId("search-form"));
 
     expect(onSearch).toHaveBeenCalledWith("Bjork", "artist");
+  });
+
+  it("syncs input value when initialQuery prop changes", () => {
+    const { rerender } = render(
+      <SearchBar onSearch={vi.fn()} initialQuery="Radiohead" />
+    );
+    const input = screen.getByTestId("search-input") as HTMLInputElement;
+    expect(input.value).toBe("Radiohead");
+
+    rerender(<SearchBar onSearch={vi.fn()} initialQuery="" />);
+    expect(input.value).toBe("");
+  });
+
+  it("forwards inputRef to the underlying input element", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<SearchBar onSearch={vi.fn()} inputRef={ref} />);
+    expect(ref.current).toBe(screen.getByTestId("search-input"));
   });
 });


### PR DESCRIPTION
## Summary
- Tapping the Search icon in the sidebar/bottom-nav while already on `/search` now clears the query and focuses the input
- Implemented via a `search:reset` window event dispatched from the nav and handled by `SearchPage`
- `SearchBar` now syncs its local query state with the `initialQuery` prop and forwards an `inputRef` so the page can focus it

Closes #124

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (773 passed)
- [x] `pnpm test:server` (798 passed)
- [x] `pnpm format:check`
- [ ] Manual: on desktop, navigate to `/search?q=foo`, click sidebar Search → input clears, gets focus, URL becomes `/search`
- [ ] Manual: on mobile, repeat with bottom-nav search icon
- [ ] Manual: from another page, click Search → still navigates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)