### PR TITLE
feat(following): follow artists and surface new releases

### DIFF
--- a/server/api/apple/albums.test.ts
+++ b/server/api/apple/albums.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockResilientFetch = vi.fn();
+
+vi.mock("../resilientFetch", () => ({
+  resilientFetch: (...args: unknown[]) => mockResilientFetch(...args),
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { getArtistAlbumsByName } from "./albums";
+
+function okResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function errResponse(status = 500) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getArtistAlbumsByName", () => {
+  it("returns [] when artist not found", async () => {
+    mockResilientFetch.mockResolvedValueOnce(
+      okResponse({ resultCount: 0, results: [] })
+    );
+    const result = await getArtistAlbumsByName("Nobody");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] on artist search HTTP error", async () => {
+    mockResilientFetch.mockResolvedValueOnce(errResponse());
+    const result = await getArtistAlbumsByName("Foo");
+    expect(result).toEqual([]);
+  });
+
+  it("maps lookup results to AppleAlbum, filtering non-collections", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(
+        okResponse({
+          resultCount: 1,
+          results: [{ wrapperType: "artist", artistId: 12345 }],
+        })
+      )
+      .mockResolvedValueOnce(
+        okResponse({
+          resultCount: 3,
+          results: [
+            { wrapperType: "artist", artistId: 12345 },
+            {
+              wrapperType: "collection",
+              collectionId: 1,
+              collectionName: "Album A",
+              releaseDate: "2025-01-01T00:00:00Z",
+              collectionType: "Album",
+              artistName: "Test",
+            },
+            {
+              wrapperType: "collection",
+              collectionId: 2,
+              collectionName: "Album B",
+              releaseDate: "2024-06-01T00:00:00Z",
+              artistName: "Test",
+            },
+          ],
+        })
+      );
+
+    const result = await getArtistAlbumsByName("Test");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      collectionId: 1,
+      collectionName: "Album A",
+      releaseDate: "2025-01-01T00:00:00Z",
+      collectionType: "Album",
+      artistName: "Test",
+    });
+  });
+
+  it("returns [] when album lookup fails", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(
+        okResponse({
+          resultCount: 1,
+          results: [{ wrapperType: "artist", artistId: 99 }],
+        })
+      )
+      .mockResolvedValueOnce(errResponse(503));
+
+    const result = await getArtistAlbumsByName("X");
+    expect(result).toEqual([]);
+  });
+
+  it("passes limit through to lookup query", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(
+        okResponse({
+          resultCount: 1,
+          results: [{ wrapperType: "artist", artistId: 7 }],
+        })
+      )
+      .mockResolvedValueOnce(okResponse({ resultCount: 0, results: [] }));
+
+    await getArtistAlbumsByName("X", 5);
+    const lookupUrl = mockResilientFetch.mock.calls[1][0] as string;
+    expect(lookupUrl).toContain("limit=5");
+    expect(lookupUrl).toContain("entity=album");
+  });
+
+  it("returns [] when fetch throws", async () => {
+    mockResilientFetch.mockRejectedValueOnce(new Error("net"));
+    const result = await getArtistAlbumsByName("Z");
+    expect(result).toEqual([]);
+  });
+});

--- a/server/api/apple/albums.ts
+++ b/server/api/apple/albums.ts
@@ -1,0 +1,73 @@
+import { resilientFetch } from "../resilientFetch";
+import { createLogger } from "../../logger";
+import type { AppleAlbum, AppleSearchResponse } from "./types";
+
+const log = createLogger("Apple Albums");
+
+const ITUNES_SEARCH = "https://itunes.apple.com/search";
+const ITUNES_LOOKUP = "https://itunes.apple.com/lookup";
+
+async function findAppleArtistId(artistName: string): Promise<number | null> {
+  try {
+    const params = new URLSearchParams({
+      term: artistName,
+      entity: "musicArtist",
+      limit: "1",
+    });
+    const response = await resilientFetch(
+      `${ITUNES_SEARCH}?${params.toString()}`
+    );
+    if (!response.ok) return null;
+    const data: AppleSearchResponse = await response.json();
+    if (data.resultCount > 0 && data.results[0].artistId) {
+      return data.results[0].artistId;
+    }
+    return null;
+  } catch (error) {
+    log.error(`Error looking up Apple artist for ${artistName}`, error);
+    return null;
+  }
+}
+
+/**
+ * Fetch albums for an Apple Music artist by name (best-effort lookup).
+ * Filters out the artist row that the lookup endpoint also returns.
+ */
+export async function getArtistAlbumsByName(
+  artistName: string,
+  limit = 25
+): Promise<AppleAlbum[]> {
+  const artistId = await findAppleArtistId(artistName);
+  if (artistId === null) return [];
+
+  try {
+    const params = new URLSearchParams({
+      id: String(artistId),
+      entity: "album",
+      limit: String(limit),
+      sort: "recent",
+    });
+    const response = await resilientFetch(
+      `${ITUNES_LOOKUP}?${params.toString()}`
+    );
+    if (!response.ok) {
+      log.error(
+        `Failed to fetch albums for Apple artist ${artistId}: ${response.status}`
+      );
+      return [];
+    }
+    const data: AppleSearchResponse = await response.json();
+    return data.results
+      .filter((r) => r.wrapperType === "collection" && r.collectionId)
+      .map((r) => ({
+        collectionId: r.collectionId as number,
+        collectionName: r.collectionName ?? "",
+        releaseDate: r.releaseDate,
+        collectionType: r.collectionType,
+        artistName: r.artistName,
+      }));
+  } catch (error) {
+    log.error(`Error fetching Apple albums for ${artistName}`, error);
+    return [];
+  }
+}

--- a/server/api/apple/types.ts
+++ b/server/api/apple/types.ts
@@ -5,6 +5,8 @@ export type AppleMusicResult = {
   artistLinkUrl?: string;
   collectionId?: number;
   collectionName?: string;
+  collectionType?: string;
+  releaseDate?: string;
   artworkUrl100?: string;
   artworkUrl60?: string;
 };
@@ -12,4 +14,12 @@ export type AppleMusicResult = {
 export type AppleSearchResponse = {
   resultCount: number;
   results: AppleMusicResult[];
+};
+
+export type AppleAlbum = {
+  collectionId: number;
+  collectionName: string;
+  releaseDate?: string;
+  collectionType?: string;
+  artistName?: string;
 };

--- a/server/api/deezer/albums.test.ts
+++ b/server/api/deezer/albums.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockResilientFetch = vi.fn();
+
+vi.mock("../resilientFetch", () => ({
+  resilientFetch: (...args: unknown[]) => mockResilientFetch(...args),
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { getArtistAlbumsByName } from "./albums";
+
+function okResponse(body: unknown) {
+  return { ok: true, json: async () => body, status: 200 };
+}
+
+function notFoundResponse() {
+  return { ok: false, status: 404, json: async () => ({}) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getArtistAlbumsByName", () => {
+  it("returns empty array when artist lookup fails", async () => {
+    mockResilientFetch.mockResolvedValueOnce(okResponse({ data: [] }));
+
+    const result = await getArtistAlbumsByName("Unknown Artist");
+    expect(result).toEqual([]);
+    expect(mockResilientFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns empty array on artist search HTTP error", async () => {
+    mockResilientFetch.mockResolvedValueOnce(notFoundResponse());
+    const result = await getArtistAlbumsByName("Some Artist");
+    expect(result).toEqual([]);
+  });
+
+  it("fetches albums for resolved artist id", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(
+        okResponse({ data: [{ id: 42, name: "Radiohead" }] })
+      )
+      .mockResolvedValueOnce(
+        okResponse({
+          data: [
+            { id: 1, title: "OK Computer", release_date: "1997-06-16" },
+            { id: 2, title: "Kid A", release_date: "2000-10-02" },
+          ],
+        })
+      );
+
+    const result = await getArtistAlbumsByName("Radiohead");
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("OK Computer");
+    const secondCallUrl = mockResilientFetch.mock.calls[1][0] as string;
+    expect(secondCallUrl).toContain("/artist/42/albums");
+  });
+
+  it("returns empty array when album fetch fails", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(okResponse({ data: [{ id: 42, name: "Foo" }] }))
+      .mockResolvedValueOnce(notFoundResponse());
+
+    const result = await getArtistAlbumsByName("Foo");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array if resilientFetch throws on artist search", async () => {
+    mockResilientFetch.mockRejectedValueOnce(new Error("network"));
+    const result = await getArtistAlbumsByName("Foo");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array if resilientFetch throws on album fetch", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(okResponse({ data: [{ id: 1, name: "Bar" }] }))
+      .mockRejectedValueOnce(new Error("network"));
+    const result = await getArtistAlbumsByName("Bar");
+    expect(result).toEqual([]);
+  });
+
+  it("respects limit query param", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(okResponse({ data: [{ id: 7, name: "X" }] }))
+      .mockResolvedValueOnce(okResponse({ data: [] }));
+
+    await getArtistAlbumsByName("X", 5);
+    const url = mockResilientFetch.mock.calls[1][0] as string;
+    expect(url).toContain("limit=5");
+  });
+});

--- a/server/api/deezer/albums.ts
+++ b/server/api/deezer/albums.ts
@@ -1,0 +1,57 @@
+import { resilientFetch } from "../resilientFetch";
+import { createLogger } from "../../logger";
+import type {
+  DeezerArtistSearchResponse,
+  DeezerAlbum,
+  DeezerAlbumsResponse,
+} from "./types";
+
+const log = createLogger("Deezer Albums");
+
+const DEEZER_BASE = "https://api.deezer.com";
+
+async function findDeezerArtistId(artistName: string): Promise<number | null> {
+  try {
+    const params = new URLSearchParams({ q: artistName, limit: "1" });
+    const response = await resilientFetch(
+      `${DEEZER_BASE}/search/artist?${params.toString()}`
+    );
+    if (!response.ok) return null;
+    const data: DeezerArtistSearchResponse = await response.json();
+    if (data.data?.length > 0) {
+      return data.data[0].id;
+    }
+    return null;
+  } catch (error) {
+    log.error(`Error looking up Deezer artist for ${artistName}`, error);
+    return null;
+  }
+}
+
+/**
+ * Fetch the most recent albums for an artist on Deezer.
+ * Resolves the Deezer artist id by name (best-effort).
+ */
+export async function getArtistAlbumsByName(
+  artistName: string,
+  limit = 25
+): Promise<DeezerAlbum[]> {
+  const artistId = await findDeezerArtistId(artistName);
+  if (artistId === null) return [];
+
+  try {
+    const url = `${DEEZER_BASE}/artist/${artistId}/albums?limit=${limit}`;
+    const response = await resilientFetch(url);
+    if (!response.ok) {
+      log.error(
+        `Failed to fetch albums for Deezer artist ${artistId}: ${response.status}`
+      );
+      return [];
+    }
+    const data: DeezerAlbumsResponse = await response.json();
+    return data.data ?? [];
+  } catch (error) {
+    log.error(`Error fetching Deezer albums for ${artistName}`, error);
+    return [];
+  }
+}

--- a/server/api/deezer/types.ts
+++ b/server/api/deezer/types.ts
@@ -24,3 +24,20 @@ export type DeezerTrackSearchResponse = {
   data: DeezerTrack[];
   total: number;
 };
+
+export type DeezerAlbum = {
+  id: number;
+  title: string;
+  release_date?: string;
+  record_type?: string;
+  explicit_lyrics?: boolean;
+  cover?: string;
+  cover_xl?: string;
+  link?: string;
+};
+
+export type DeezerAlbumsResponse = {
+  data: DeezerAlbum[];
+  total: number;
+  next?: string;
+};

--- a/server/api/lidarr/config.test.ts
+++ b/server/api/lidarr/config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROMOTED_ALBUM,
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
+  DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -31,6 +32,7 @@ const baseConfig = {
   promotedAlbum: DEFAULT_PROMOTED_ALBUM,
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
+  followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/api/musicbrainz/releaseGroups.ts
+++ b/server/api/musicbrainz/releaseGroups.ts
@@ -32,7 +32,7 @@ export async function searchReleaseGroups(
 }
 
 /** Fetch all release groups (albums/EPs/singles) for a single artist MBID */
-async function fetchReleaseGroupsForArtist(
+export async function fetchReleaseGroupsForArtist(
   artistId: string
 ): Promise<MusicBrainzReleaseGroup[]> {
   const url = `${MB_BASE}/release-group?artist=${artistId}&type=album|ep|single&limit=100&inc=artist-credits&fmt=json`;

--- a/server/api/plex/config.test.ts
+++ b/server/api/plex/config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROMOTED_ALBUM,
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
+  DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -31,6 +32,7 @@ const fullConfig = {
   promotedAlbum: DEFAULT_PROMOTED_ALBUM,
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
+  followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/api/slskd/config.test.ts
+++ b/server/api/slskd/config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROMOTED_ALBUM,
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
+  DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -31,6 +32,7 @@ const fullConfig = {
   promotedAlbum: DEFAULT_PROMOTED_ALBUM,
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
+  followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -50,6 +50,7 @@ export type IConfig = {
   promotedAlbum: PromotedAlbumConfig;
   purchaseDecision: PurchaseDecisionConfig;
   spending: SpendingConfig;
+  followedArtistPollIntervalMs: number;
 };
 
 /** Input type for setConfig — nested objects are optional since defaults are deep-merged */
@@ -71,6 +72,8 @@ export const DEFAULT_SPENDING: SpendingConfig = {
   currency: "USD",
   monthlyLimit: null,
 };
+
+export const DEFAULT_FOLLOWED_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
@@ -111,6 +114,7 @@ const DEFAULT_CONFIG: IConfig = {
   promotedAlbum: DEFAULT_PROMOTED_ALBUM,
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
+  followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
 };
 
 type RawStatement = {
@@ -272,6 +276,14 @@ function validateConfig(mergedConfig: IConfig) {
   }
   if (typeof mergedConfig.slskdDownloadPath !== "string") {
     throw new Error("slskdDownloadPath must be a string");
+  }
+  if (
+    typeof mergedConfig.followedArtistPollIntervalMs !== "number" ||
+    mergedConfig.followedArtistPollIntervalMs < 60_000
+  ) {
+    throw new Error(
+      "followedArtistPollIntervalMs must be a number >= 60000 (1 minute)"
+    );
   }
 }
 

--- a/server/db/dataSource.ts
+++ b/server/db/dataSource.ts
@@ -7,10 +7,14 @@ import { Request } from "./entity/Request";
 import { WantedItem } from "./entity/WantedItem";
 import { Purchase } from "./entity/Purchase";
 import { Config } from "./entity/Config";
+import { FollowedArtist } from "./entity/FollowedArtist";
+import { SeenRelease } from "./entity/SeenRelease";
 import { InitialSchema1709000000000 } from "./migration/1_InitialSchema";
 import { ConfigTable1710000000000 } from "./migration/2_ConfigTable";
 import { WantedItems1711000000000 } from "./migration/3_WantedItems";
 import { Purchases1712000000000 } from "./migration/4_Purchases";
+import { FollowedArtists1713000000000 } from "./migration/5_FollowedArtists";
+import { FollowedLastViewedAt1714000000000 } from "./migration/6_FollowedLastViewedAt";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,12 +31,23 @@ export function createDataSource(dbPath?: string): DataSource {
   return new DataSource({
     type: "better-sqlite3",
     database: resolvedPath,
-    entities: [User, Session, Request, WantedItem, Purchase, Config],
+    entities: [
+      User,
+      Session,
+      Request,
+      WantedItem,
+      Purchase,
+      Config,
+      FollowedArtist,
+      SeenRelease,
+    ],
     migrations: [
       InitialSchema1709000000000,
       ConfigTable1710000000000,
       WantedItems1711000000000,
       Purchases1712000000000,
+      FollowedArtists1713000000000,
+      FollowedLastViewedAt1714000000000,
     ],
     synchronize: false,
     migrationsRun: true,

--- a/server/db/entity/FollowedArtist.ts
+++ b/server/db/entity/FollowedArtist.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from "typeorm";
+import { User } from "./User";
+
+@Entity("followed_artists")
+@Unique("uq_followed_user_artist", ["user_id", "artist_mbid"])
+export class FollowedArtist {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Index("idx_followed_user_id")
+  @Column({ type: "integer" })
+  user_id!: number;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  @Index("idx_followed_artist_mbid")
+  @Column({ type: "text" })
+  artist_mbid!: string;
+
+  @Column({ type: "text" })
+  artist_name!: string;
+
+  @Column({ type: "text", nullable: true })
+  last_checked_at!: string | null;
+
+  @CreateDateColumn({ type: "text" })
+  created_at!: string;
+}

--- a/server/db/entity/SeenRelease.ts
+++ b/server/db/entity/SeenRelease.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from "typeorm";
+import { FollowedArtist } from "./FollowedArtist";
+
+export type ReleaseSource = "musicbrainz" | "deezer" | "apple";
+
+@Entity("seen_releases")
+@Unique("uq_seen_follow_release", ["followed_artist_id", "release_key"])
+export class SeenRelease {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Index("idx_seen_followed_artist_id")
+  @Column({ type: "integer" })
+  followed_artist_id!: number;
+
+  @ManyToOne(() => FollowedArtist, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "followed_artist_id" })
+  followed_artist!: FollowedArtist;
+
+  @Column({ type: "text" })
+  release_key!: string;
+
+  @Column({ type: "text" })
+  source!: ReleaseSource;
+
+  @Column({ type: "text" })
+  album_title!: string;
+
+  @Column({ type: "text", nullable: true })
+  release_date!: string | null;
+
+  @Column({ type: "text", nullable: true })
+  external_id!: string | null;
+
+  @CreateDateColumn({ type: "text" })
+  notified_at!: string;
+}

--- a/server/db/entity/User.ts
+++ b/server/db/entity/User.ts
@@ -54,4 +54,7 @@ export class User {
 
   @Column({ type: "text", default: "local" })
   user_type!: UserType;
+
+  @Column({ type: "text", nullable: true })
+  followed_last_viewed_at!: string | null;
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -48,3 +48,6 @@ export { Request } from "./entity/Request";
 export { WantedItem } from "./entity/WantedItem";
 export { Purchase } from "./entity/Purchase";
 export { Config } from "./entity/Config";
+export { FollowedArtist } from "./entity/FollowedArtist";
+export type { ReleaseSource } from "./entity/SeenRelease";
+export { SeenRelease } from "./entity/SeenRelease";

--- a/server/db/migration.test.ts
+++ b/server/db/migration.test.ts
@@ -42,6 +42,7 @@ describe("InitialSchema migration", () => {
       "plex_username",
       "plex_token",
       "user_type",
+      "followed_last_viewed_at",
     ]);
   });
 
@@ -146,5 +147,111 @@ describe("constraint enforcement", () => {
     expect(user.enabled).toBe(1);
     expect(user.created_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
     expect(user.updated_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe("FollowedArtists migration", () => {
+  it("creates followed_artists and seen_releases tables", async () => {
+    const db = await initTestDb();
+
+    const followedCols = (await db.query(
+      "PRAGMA table_info(followed_artists)"
+    )) as { name: string }[];
+    expect(followedCols.map((c) => c.name)).toEqual([
+      "id",
+      "user_id",
+      "artist_mbid",
+      "artist_name",
+      "last_checked_at",
+      "created_at",
+    ]);
+
+    const seenCols = (await db.query("PRAGMA table_info(seen_releases)")) as {
+      name: string;
+    }[];
+    expect(seenCols.map((c) => c.name)).toEqual([
+      "id",
+      "followed_artist_id",
+      "release_key",
+      "source",
+      "album_title",
+      "release_date",
+      "external_id",
+      "notified_at",
+    ]);
+  });
+
+  it("enforces unique (user_id, artist_mbid)", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["alice"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["alice"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO followed_artists (user_id, artist_mbid, artist_name) VALUES (?, ?, ?)",
+      [userId, "mbid-1", "Artist"]
+    );
+
+    await expect(
+      db.query(
+        "INSERT INTO followed_artists (user_id, artist_mbid, artist_name) VALUES (?, ?, ?)",
+        [userId, "mbid-1", "Artist"]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("cascades seen_releases when followed_artist is deleted", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["bob"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["bob"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO followed_artists (user_id, artist_mbid, artist_name) VALUES (?, ?, ?)",
+      [userId, "mbid-1", "Artist"]
+    );
+    const [{ id: followedId }] = (await db.query(
+      "SELECT id FROM followed_artists WHERE artist_mbid = ?",
+      ["mbid-1"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO seen_releases (followed_artist_id, release_key, source, album_title) VALUES (?, ?, ?, ?)",
+      [followedId, "key-1", "musicbrainz", "Album"]
+    );
+
+    await db.query("DELETE FROM followed_artists WHERE id = ?", [followedId]);
+
+    const rows = (await db.query(
+      "SELECT * FROM seen_releases WHERE followed_artist_id = ?",
+      [followedId]
+    )) as unknown[];
+    expect(rows).toHaveLength(0);
+  });
+
+  it("cascades followed_artists when user is deleted", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["carol"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["carol"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO followed_artists (user_id, artist_mbid, artist_name) VALUES (?, ?, ?)",
+      [userId, "mbid-2", "Artist 2"]
+    );
+
+    await db.query("DELETE FROM users WHERE id = ?", [userId]);
+
+    const rows = (await db.query(
+      "SELECT * FROM followed_artists WHERE user_id = ?",
+      [userId]
+    )) as unknown[];
+    expect(rows).toHaveLength(0);
   });
 });

--- a/server/db/migration/5_FollowedArtists.ts
+++ b/server/db/migration/5_FollowedArtists.ts
@@ -1,0 +1,49 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FollowedArtists1713000000000 implements MigrationInterface {
+  name = "FollowedArtists1713000000000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "followed_artists" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "user_id" INTEGER NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "artist_mbid" TEXT NOT NULL,
+        "artist_name" TEXT NOT NULL,
+        "last_checked_at" TEXT,
+        "created_at" TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE ("user_id", "artist_mbid")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_followed_user_id" ON "followed_artists"("user_id")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_followed_artist_mbid" ON "followed_artists"("artist_mbid")`
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "seen_releases" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "followed_artist_id" INTEGER NOT NULL REFERENCES "followed_artists"("id") ON DELETE CASCADE,
+        "release_key" TEXT NOT NULL,
+        "source" TEXT NOT NULL,
+        "album_title" TEXT NOT NULL,
+        "release_date" TEXT,
+        "external_id" TEXT,
+        "notified_at" TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE ("followed_artist_id", "release_key")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_seen_followed_artist_id" ON "seen_releases"("followed_artist_id")`
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "seen_releases"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "followed_artists"`);
+  }
+}

--- a/server/db/migration/6_FollowedLastViewedAt.ts
+++ b/server/db/migration/6_FollowedLastViewedAt.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FollowedLastViewedAt1714000000000 implements MigrationInterface {
+  name = "FollowedLastViewedAt1714000000000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "followed_last_viewed_at" TEXT`
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "followed_last_viewed_at"`
+    );
+  }
+}

--- a/server/dev/seed.ts
+++ b/server/dev/seed.ts
@@ -5,6 +5,8 @@ import {
   getDataSource,
   User,
   Request,
+  WantedItem,
+  Purchase,
   closeDatabase,
 } from "../db/index";
 import { hashPassword } from "../auth/password";
@@ -26,6 +28,24 @@ type SeedRequest = {
   album_title: string;
   status: "pending" | "approved" | "declined";
   created_at: string;
+};
+
+type SeedWantedItem = {
+  username: string;
+  album_mbid: string;
+  artist_name: string;
+  album_title: string;
+  created_at: string;
+};
+
+type SeedPurchase = {
+  username: string;
+  album_mbid: string;
+  artist_name: string;
+  album_title: string;
+  price: number;
+  currency: string;
+  purchased_at: string;
 };
 
 const USERS: SeedUser[] = [
@@ -198,6 +218,133 @@ const REQUESTS: SeedRequest[] = [
   },
 ];
 
+const WANTED_ITEMS: SeedWantedItem[] = [
+  {
+    username: "requester",
+    album_mbid: "deadbeef-want-4000-8000-000000000001",
+    artist_name: "Tame Impala",
+    album_title: "Currents",
+    created_at: "2026-03-20T10:00:00Z",
+  },
+  {
+    username: "requester",
+    album_mbid: "deadbeef-want-4000-8000-000000000002",
+    artist_name: "Kendrick Lamar",
+    album_title: "To Pimp a Butterfly",
+    created_at: "2026-03-19T11:00:00Z",
+  },
+  {
+    username: "plex_alice",
+    album_mbid: "deadbeef-want-4000-8000-000000000003",
+    artist_name: "FKA twigs",
+    album_title: "Magdalene",
+    created_at: "2026-03-21T14:30:00Z",
+  },
+  {
+    username: "plex_alice",
+    album_mbid: "deadbeef-want-4000-8000-000000000004",
+    artist_name: "Caroline Polachek",
+    album_title: "Desire, I Want to Turn Into You",
+    created_at: "2026-03-18T09:15:00Z",
+  },
+  {
+    username: "plex_bob",
+    album_mbid: "deadbeef-want-4000-8000-000000000005",
+    artist_name: "Mount Kimbie",
+    album_title: "Cold Spring Fault Less Youth",
+    created_at: "2026-03-17T16:45:00Z",
+  },
+  {
+    username: "manager",
+    album_mbid: "deadbeef-want-4000-8000-000000000006",
+    artist_name: "Jamie xx",
+    album_title: "In Colour",
+    created_at: "2026-03-22T12:00:00Z",
+  },
+  {
+    username: "viewer",
+    album_mbid: "deadbeef-want-4000-8000-000000000007",
+    artist_name: "Arca",
+    album_title: "KICK i",
+    created_at: "2026-03-16T18:00:00Z",
+  },
+];
+
+const PURCHASES: SeedPurchase[] = [
+  {
+    username: "requester",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000001",
+    artist_name: "Daft Punk",
+    album_title: "Discovery",
+    price: 1499,
+    currency: "USD",
+    purchased_at: "2026-04-02T10:00:00Z",
+  },
+  {
+    username: "requester",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000002",
+    artist_name: "The Strokes",
+    album_title: "Is This It",
+    price: 999,
+    currency: "USD",
+    purchased_at: "2026-03-28T14:00:00Z",
+  },
+  {
+    username: "plex_alice",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000003",
+    artist_name: "Mitski",
+    album_title: "Be the Cowboy",
+    price: 1199,
+    currency: "USD",
+    purchased_at: "2026-04-10T09:30:00Z",
+  },
+  {
+    username: "plex_alice",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000004",
+    artist_name: "Phoebe Bridgers",
+    album_title: "Punisher",
+    price: 1299,
+    currency: "USD",
+    purchased_at: "2026-03-25T11:00:00Z",
+  },
+  {
+    username: "plex_bob",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000005",
+    artist_name: "Beach House",
+    album_title: "Once Twice Melody",
+    price: 1799,
+    currency: "USD",
+    purchased_at: "2026-04-15T16:00:00Z",
+  },
+  {
+    username: "plex_bob",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000006",
+    artist_name: "King Krule",
+    album_title: "The OOZ",
+    price: 1399,
+    currency: "USD",
+    purchased_at: "2026-02-20T13:00:00Z",
+  },
+  {
+    username: "manager",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000007",
+    artist_name: "Fleet Foxes",
+    album_title: "Helplessness Blues",
+    price: 1099,
+    currency: "USD",
+    purchased_at: "2026-04-18T08:00:00Z",
+  },
+  {
+    username: "autoapprover",
+    album_mbid: "deadbeef-buy0-4000-8000-000000000008",
+    artist_name: "Yves Tumor",
+    album_title: "Heaven to a Tortured Mind",
+    price: 1199,
+    currency: "USD",
+    purchased_at: "2026-04-20T19:30:00Z",
+  },
+];
+
 async function createSeedUser(
   userRepo: Repository<User>,
   seedUser: SeedUser
@@ -250,6 +397,38 @@ async function createSeedRequest(
   return requestRepo.save(request);
 }
 
+async function createSeedWantedItem(
+  wantedRepo: Repository<WantedItem>,
+  seedItem: SeedWantedItem,
+  userId: number
+): Promise<WantedItem> {
+  const item = wantedRepo.create({
+    user_id: userId,
+    album_mbid: seedItem.album_mbid,
+    artist_name: seedItem.artist_name,
+    album_title: seedItem.album_title,
+    created_at: seedItem.created_at,
+  });
+  return wantedRepo.save(item);
+}
+
+async function createSeedPurchase(
+  purchaseRepo: Repository<Purchase>,
+  seedItem: SeedPurchase,
+  userId: number
+): Promise<Purchase> {
+  const item = purchaseRepo.create({
+    user_id: userId,
+    album_mbid: seedItem.album_mbid,
+    artist_name: seedItem.artist_name,
+    album_title: seedItem.album_title,
+    price: seedItem.price,
+    currency: seedItem.currency,
+    purchased_at: seedItem.purchased_at,
+  });
+  return purchaseRepo.save(item);
+}
+
 async function seed() {
   console.log("Initializing database...");
   await initializeDatabase();
@@ -257,6 +436,8 @@ async function seed() {
   const ds = getDataSource();
   const userRepo = ds.getRepository(User);
   const requestRepo = ds.getRepository(Request);
+  const wantedRepo = ds.getRepository(WantedItem);
+  const purchaseRepo = ds.getRepository(Purchase);
 
   console.log("\nCreating users...");
   const userMap = new Map<string, User>();
@@ -293,8 +474,62 @@ async function seed() {
     created++;
   }
 
+  console.log("\nCreating wanted items...");
+  let wantedCreated = 0;
+  let wantedSkipped = 0;
+  for (const seedItem of WANTED_ITEMS) {
+    const user = userMap.get(seedItem.username);
+    if (!user) {
+      console.log(
+        `  Skipping wanted item: user "${seedItem.username}" not found`
+      );
+      wantedSkipped++;
+      continue;
+    }
+
+    const existing = await wantedRepo.findOne({
+      where: { album_mbid: seedItem.album_mbid, user_id: user.id },
+    });
+    if (existing) {
+      wantedSkipped++;
+      continue;
+    }
+
+    await createSeedWantedItem(wantedRepo, seedItem, user.id);
+    console.log(
+      `  wanted   "${seedItem.album_title}" by ${seedItem.artist_name} (${seedItem.username})`
+    );
+    wantedCreated++;
+  }
+
+  console.log("\nCreating purchases...");
+  let purchaseCreated = 0;
+  let purchaseSkipped = 0;
+  for (const seedItem of PURCHASES) {
+    const user = userMap.get(seedItem.username);
+    if (!user) {
+      console.log(`  Skipping purchase: user "${seedItem.username}" not found`);
+      purchaseSkipped++;
+      continue;
+    }
+
+    const existing = await purchaseRepo.findOne({
+      where: { album_mbid: seedItem.album_mbid, user_id: user.id },
+    });
+    if (existing) {
+      purchaseSkipped++;
+      continue;
+    }
+
+    await createSeedPurchase(purchaseRepo, seedItem, user.id);
+    console.log(
+      `  purchase "${seedItem.album_title}" by ${seedItem.artist_name} (${seedItem.username}, ${seedItem.price} ${seedItem.currency})`
+    );
+    purchaseCreated++;
+  }
+
   console.log(
-    `\nDone! Created ${created} requests, skipped ${skipped} duplicates.`
+    `\nDone! Created ${created} requests (skipped ${skipped}), ${wantedCreated} wanted items (skipped ${wantedSkipped}), ${purchaseCreated} purchases (skipped ${purchaseSkipped}).`
   );
   console.log("\nSeed accounts (password = username):");
   for (const u of USERS) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,9 @@ import torznabRoutes from "./routes/torznab";
 import usersRoutes from "./routes/users";
 import purchasesRoutes from "./routes/purchases";
 import wantedRoutes from "./routes/wanted";
+import followedRoutes from "./routes/followed";
+import { startFollowedArtistPoller } from "./services/followed/poller";
+import { getConfig } from "./config";
 
 const log = createLogger("Server");
 
@@ -49,6 +52,7 @@ app.use("/api/promoted-album", requireAuth, promotedAlbumRoutes);
 app.use("/api/requests", requestsRoutes);
 app.use("/api/purchases", purchasesRoutes);
 app.use("/api/wanted", wantedRoutes);
+app.use("/api/followed", followedRoutes);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "..", "build")));
@@ -61,6 +65,10 @@ app.use(errorHandler);
 
 await initializeDatabase();
 initializeConfig();
+
+const followedPollIntervalMs =
+  getConfig().followedArtistPollIntervalMs ?? 6 * 60 * 60 * 1000;
+startFollowedArtistPoller(followedPollIntervalMs);
 
 app.listen(PORT, () => {
   log.info(`Listening on port ${PORT}`);

--- a/server/routes/followed.test.ts
+++ b/server/routes/followed.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFollow = vi.fn();
+const mockUnfollow = vi.fn();
+const mockGetFollowed = vi.fn();
+const mockGetSeen = vi.fn();
+const mockGetUnseen = vi.fn();
+const mockMarkViewed = vi.fn();
+const mockRunPoll = vi.fn();
+
+vi.mock("../services/followed/followedService", () => ({
+  followArtist: (...args: unknown[]) => mockFollow(...args),
+  unfollowArtist: (...args: unknown[]) => mockUnfollow(...args),
+  getFollowedArtists: (...args: unknown[]) => mockGetFollowed(...args),
+  getSeenReleasesForUser: (...args: unknown[]) => mockGetSeen(...args),
+  getUnseenReleaseCount: (...args: unknown[]) => mockGetUnseen(...args),
+  markFollowedReleasesViewed: (...args: unknown[]) => mockMarkViewed(...args),
+}));
+
+vi.mock("../services/followed/poller", () => ({
+  runPollOnce: (...args: unknown[]) => mockRunPoll(...args),
+}));
+
+vi.mock("../middleware/requireAuth", () => ({
+  requireAuth: (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = {
+      id: 1,
+      permissions: 9,
+      username: "testuser",
+      userType: "local",
+      enabled: true,
+      theme: "system",
+      thumb: null,
+    };
+    next();
+  },
+}));
+
+import express from "express";
+import request from "supertest";
+import followedRouter from "./followed";
+
+const app = express();
+app.use(express.json());
+app.use("/", followedRouter);
+app.use(
+  (
+    err: Error,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction
+  ) => {
+    res.status(500).json({ error: err.message });
+  }
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /", () => {
+  it("returns sanitized follow list for the user", async () => {
+    mockGetFollowed.mockResolvedValue([
+      {
+        id: 1,
+        artist_mbid: "mbid-1",
+        artist_name: "Artist",
+        last_checked_at: null,
+        created_at: "2024-01-01",
+      },
+    ]);
+
+    const res = await request(app).get("/");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 1,
+        artistMbid: "mbid-1",
+        artistName: "Artist",
+        lastCheckedAt: null,
+        createdAt: "2024-01-01",
+      },
+    ]);
+    expect(mockGetFollowed).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("GET /releases", () => {
+  it("returns sanitized seen releases", async () => {
+    mockGetSeen.mockResolvedValue([
+      {
+        id: 5,
+        followed_artist_id: 1,
+        artist_mbid: "mbid-1",
+        artist_name: "Artist",
+        release_key: "k",
+        source: "musicbrainz",
+        album_title: "Album",
+        release_date: "2025-04-01",
+        external_id: "rg-1",
+        notified_at: "2025-04-02",
+      },
+    ]);
+
+    const res = await request(app).get("/releases?limit=10");
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toEqual({
+      id: 5,
+      followedArtistId: 1,
+      artistMbid: "mbid-1",
+      artistName: "Artist",
+      releaseKey: "k",
+      source: "musicbrainz",
+      albumTitle: "Album",
+      releaseDate: "2025-04-01",
+      externalId: "rg-1",
+      notifiedAt: "2025-04-02",
+    });
+    expect(mockGetSeen).toHaveBeenCalledWith(1, 10);
+  });
+
+  it("clamps limit to default when missing", async () => {
+    mockGetSeen.mockResolvedValue([]);
+    await request(app).get("/releases");
+    expect(mockGetSeen).toHaveBeenCalledWith(1, 50);
+  });
+
+  it("clamps oversized limit", async () => {
+    mockGetSeen.mockResolvedValue([]);
+    await request(app).get("/releases?limit=99999");
+    expect(mockGetSeen).toHaveBeenCalledWith(1, 200);
+  });
+});
+
+describe("POST /", () => {
+  it("returns 400 when artistMbid is missing", async () => {
+    const res = await request(app).post("/").send({ artistName: "X" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("artistMbid is required");
+  });
+
+  it("returns 400 when artistName is missing", async () => {
+    const res = await request(app).post("/").send({ artistMbid: "mbid-1" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("artistName is required");
+  });
+
+  it("creates a follow row", async () => {
+    mockFollow.mockResolvedValue({ status: "added", id: 7 });
+    const res = await request(app)
+      .post("/")
+      .send({ artistMbid: "mbid-1", artistName: "Artist" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: "added", id: 7 });
+    expect(mockFollow).toHaveBeenCalledWith(1, "mbid-1", "Artist");
+  });
+
+  it("returns already_following when row exists", async () => {
+    mockFollow.mockResolvedValue({ status: "already_following", id: 3 });
+    const res = await request(app)
+      .post("/")
+      .send({ artistMbid: "mbid-1", artistName: "Artist" });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("already_following");
+  });
+});
+
+describe("GET /unseen-count", () => {
+  it("returns the count from the service", async () => {
+    mockGetUnseen.mockResolvedValue(4);
+    const res = await request(app).get("/unseen-count");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ count: 4 });
+    expect(mockGetUnseen).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("POST /mark-viewed", () => {
+  it("calls service for current user", async () => {
+    mockMarkViewed.mockResolvedValue(undefined);
+    const res = await request(app).post("/mark-viewed");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: "ok" });
+    expect(mockMarkViewed).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("DELETE /:artistMbid", () => {
+  it("returns 404 when row missing", async () => {
+    mockUnfollow.mockResolvedValue({ status: "not_found" });
+    const res = await request(app).delete("/mbid-1");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Followed artist not found");
+  });
+
+  it("removes follow row", async () => {
+    mockUnfollow.mockResolvedValue({ status: "removed" });
+    const res = await request(app).delete("/mbid-1");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("removed");
+    expect(mockUnfollow).toHaveBeenCalledWith(1, "mbid-1");
+  });
+});

--- a/server/routes/followed.ts
+++ b/server/routes/followed.ts
@@ -1,0 +1,95 @@
+import express, { type Request, type Response } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import {
+  followArtist,
+  unfollowArtist,
+  getFollowedArtists,
+  getSeenReleasesForUser,
+  getUnseenReleaseCount,
+  markFollowedReleasesViewed,
+} from "../services/followed/followedService";
+import { runPollOnce } from "../services/followed/poller";
+
+const router = express.Router();
+
+router.use(requireAuth);
+
+router.get("/", async (req: Request, res: Response) => {
+  const items = await getFollowedArtists(req.user!.id);
+  res.json(
+    items.map((item) => ({
+      id: item.id,
+      artistMbid: item.artist_mbid,
+      artistName: item.artist_name,
+      lastCheckedAt: item.last_checked_at,
+      createdAt: item.created_at,
+    }))
+  );
+});
+
+router.get("/releases", async (req: Request, res: Response) => {
+  const limit = Math.min(
+    Math.max(parseInt(String(req.query.limit ?? "50"), 10) || 50, 1),
+    200
+  );
+  const rows = await getSeenReleasesForUser(req.user!.id, limit);
+  res.json(
+    rows.map((r) => ({
+      id: r.id,
+      followedArtistId: r.followed_artist_id,
+      artistMbid: r.artist_mbid,
+      artistName: r.artist_name,
+      releaseKey: r.release_key,
+      source: r.source,
+      albumTitle: r.album_title,
+      releaseDate: r.release_date,
+      externalId: r.external_id,
+      notifiedAt: r.notified_at,
+    }))
+  );
+});
+
+router.post("/", async (req: Request, res: Response) => {
+  const { artistMbid, artistName } = req.body ?? {};
+
+  if (typeof artistMbid !== "string" || artistMbid.trim() === "") {
+    return res.status(400).json({ error: "artistMbid is required" });
+  }
+  if (typeof artistName !== "string" || artistName.trim() === "") {
+    return res.status(400).json({ error: "artistName is required" });
+  }
+
+  const result = await followArtist(req.user!.id, artistMbid, artistName);
+  res.json(result);
+});
+
+router.get("/unseen-count", async (req: Request, res: Response) => {
+  const count = await getUnseenReleaseCount(req.user!.id);
+  res.json({ count });
+});
+
+router.post("/mark-viewed", async (req: Request, res: Response) => {
+  await markFollowedReleasesViewed(req.user!.id);
+  res.json({ status: "ok" });
+});
+
+router.post("/poll-now", async (_req: Request, res: Response) => {
+  if (process.env.NODE_ENV === "production") {
+    return res.status(404).json({ error: "Not found" });
+  }
+  await runPollOnce();
+  res.json({ status: "ok" });
+});
+
+router.delete("/:artistMbid", async (req: Request, res: Response) => {
+  const artistMbid = req.params.artistMbid as string;
+  const result = await unfollowArtist(req.user!.id, artistMbid);
+
+  if (result.status === "not_found") {
+    return res.status(404).json({ error: "Followed artist not found" });
+  }
+
+  res.json(result);
+});
+
+export default router;

--- a/server/services/followed/followedService.test.ts
+++ b/server/services/followed/followedService.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFind = vi.fn();
+const mockFindOne = vi.fn();
+const mockCreate = vi.fn();
+const mockSave = vi.fn();
+const mockRemove = vi.fn();
+const mockUpdate = vi.fn();
+const mockQuery = vi.fn();
+
+const mockSeenFind = vi.fn();
+const mockSeenFindOne = vi.fn();
+const mockSeenCreate = vi.fn();
+const mockSeenSave = vi.fn();
+
+const mockUserUpdate = vi.fn();
+
+vi.mock("../../db/index", () => ({
+  getDataSource: () => ({
+    getRepository: (entity: string) => {
+      if (entity === "SeenRelease") {
+        return {
+          find: (...args: unknown[]) => mockSeenFind(...args),
+          findOne: (...args: unknown[]) => mockSeenFindOne(...args),
+          create: (...args: unknown[]) => mockSeenCreate(...args),
+          save: (...args: unknown[]) => mockSeenSave(...args),
+        };
+      }
+      if (entity === "User") {
+        return {
+          update: (...args: unknown[]) => mockUserUpdate(...args),
+        };
+      }
+      return {
+        find: (...args: unknown[]) => mockFind(...args),
+        findOne: (...args: unknown[]) => mockFindOne(...args),
+        create: (...args: unknown[]) => mockCreate(...args),
+        save: (...args: unknown[]) => mockSave(...args),
+        remove: (...args: unknown[]) => mockRemove(...args),
+        update: (...args: unknown[]) => mockUpdate(...args),
+      };
+    },
+    query: (...args: unknown[]) => mockQuery(...args),
+  }),
+  FollowedArtist: "FollowedArtist",
+  SeenRelease: "SeenRelease",
+  User: "User",
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import {
+  followArtist,
+  unfollowArtist,
+  getFollowedArtists,
+  getAllFollowedArtists,
+  hasSeenRelease,
+  recordSeenRelease,
+  getSeenReleasesForUser,
+  updateLastCheckedAt,
+  getUnseenReleaseCount,
+  markFollowedReleasesViewed,
+} from "./followedService";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("followArtist", () => {
+  it("returns already_following when row exists", async () => {
+    mockFindOne.mockResolvedValue({ id: 5 });
+    const result = await followArtist(1, "mbid-1", "Artist");
+    expect(result).toEqual({ status: "already_following", id: 5 });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a new follow row", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockCreate.mockReturnValue({
+      user_id: 1,
+      artist_mbid: "mbid-1",
+      artist_name: "Artist",
+      last_checked_at: null,
+    });
+    mockSave.mockResolvedValue({ id: 10 });
+
+    const result = await followArtist(1, "mbid-1", "Artist");
+    expect(result).toEqual({ status: "added", id: 10 });
+    expect(mockCreate).toHaveBeenCalledWith({
+      user_id: 1,
+      artist_mbid: "mbid-1",
+      artist_name: "Artist",
+      last_checked_at: null,
+    });
+  });
+});
+
+describe("unfollowArtist", () => {
+  it("returns not_found when missing", async () => {
+    mockFindOne.mockResolvedValue(null);
+    const result = await unfollowArtist(1, "mbid-1");
+    expect(result).toEqual({ status: "not_found" });
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it("removes existing follow", async () => {
+    const item = { id: 5, artist_name: "Artist" };
+    mockFindOne.mockResolvedValue(item);
+    const result = await unfollowArtist(1, "mbid-1");
+    expect(result).toEqual({ status: "removed" });
+    expect(mockRemove).toHaveBeenCalledWith(item);
+  });
+});
+
+describe("getFollowedArtists", () => {
+  it("returns rows for user ordered by created_at DESC", async () => {
+    mockFind.mockResolvedValue([]);
+    const result = await getFollowedArtists(1);
+    expect(result).toEqual([]);
+    expect(mockFind).toHaveBeenCalledWith({
+      where: { user_id: 1 },
+      order: { created_at: "DESC" },
+    });
+  });
+});
+
+describe("getAllFollowedArtists", () => {
+  it("returns all rows ordered by created_at ASC", async () => {
+    mockFind.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    const result = await getAllFollowedArtists();
+    expect(result).toHaveLength(2);
+    expect(mockFind).toHaveBeenCalledWith({ order: { created_at: "ASC" } });
+  });
+});
+
+describe("seen releases", () => {
+  it("hasSeenRelease returns true when row exists", async () => {
+    mockSeenFindOne.mockResolvedValue({ id: 1 });
+    const result = await hasSeenRelease(1, "key-1");
+    expect(result).toBe(true);
+    expect(mockSeenFindOne).toHaveBeenCalledWith({
+      where: { followed_artist_id: 1, release_key: "key-1" },
+    });
+  });
+
+  it("hasSeenRelease returns false when row missing", async () => {
+    mockSeenFindOne.mockResolvedValue(null);
+    const result = await hasSeenRelease(1, "key-1");
+    expect(result).toBe(false);
+  });
+
+  it("recordSeenRelease inserts a row", async () => {
+    mockSeenCreate.mockImplementation((input) => input);
+    mockSeenSave.mockImplementation(async (input) => ({ ...input, id: 7 }));
+
+    const result = await recordSeenRelease({
+      followed_artist_id: 1,
+      release_key: "key-1",
+      source: "musicbrainz",
+      album_title: "Album",
+      release_date: "2025-01-01",
+      external_id: "ext-1",
+    });
+
+    expect(result.id).toBe(7);
+    expect(mockSeenCreate).toHaveBeenCalledWith({
+      followed_artist_id: 1,
+      release_key: "key-1",
+      source: "musicbrainz",
+      album_title: "Album",
+      release_date: "2025-01-01",
+      external_id: "ext-1",
+    });
+  });
+
+  it("getSeenReleasesForUser runs join query with limit", async () => {
+    mockQuery.mockResolvedValue([{ id: 1, artist_name: "A" }]);
+    const result = await getSeenReleasesForUser(3, 10);
+    expect(result).toHaveLength(1);
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [3, 10]);
+    const sqlArg = mockQuery.mock.calls[0][0] as string;
+    expect(sqlArg).toContain("seen_releases");
+    expect(sqlArg).toContain("followed_artists");
+  });
+});
+
+describe("updateLastCheckedAt", () => {
+  it("calls update with new timestamp", async () => {
+    mockUpdate.mockResolvedValue({});
+    await updateLastCheckedAt(5, "2025-05-15T12:00:00.000Z");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      { id: 5 },
+      { last_checked_at: "2025-05-15T12:00:00.000Z" }
+    );
+  });
+});
+
+describe("getUnseenReleaseCount", () => {
+  it("returns the count from the join query", async () => {
+    mockQuery.mockResolvedValue([{ count: 3 }]);
+    const result = await getUnseenReleaseCount(7);
+    expect(result).toBe(3);
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [7]);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("seen_releases");
+    expect(sql).toContain("followed_artists");
+    expect(sql).toContain("followed_last_viewed_at");
+  });
+
+  it("returns 0 when no rows", async () => {
+    mockQuery.mockResolvedValue([]);
+    const result = await getUnseenReleaseCount(7);
+    expect(result).toBe(0);
+  });
+});
+
+describe("markFollowedReleasesViewed", () => {
+  it("updates the user row with a current timestamp", async () => {
+    mockUserUpdate.mockResolvedValue({});
+    await markFollowedReleasesViewed(9);
+    expect(mockUserUpdate).toHaveBeenCalledTimes(1);
+    const [where, patch] = mockUserUpdate.mock.calls[0];
+    expect(where).toEqual({ id: 9 });
+    expect(
+      typeof (patch as { followed_last_viewed_at: string })
+        .followed_last_viewed_at
+    ).toBe("string");
+  });
+});

--- a/server/services/followed/followedService.ts
+++ b/server/services/followed/followedService.ts
@@ -1,0 +1,169 @@
+import {
+  getDataSource,
+  FollowedArtist,
+  SeenRelease,
+  User,
+  type ReleaseSource,
+} from "../../db/index";
+import { createLogger } from "../../logger";
+
+type AddFollowResult =
+  | { status: "added"; id: number }
+  | { status: "already_following"; id: number };
+
+type RemoveFollowResult = { status: "removed" } | { status: "not_found" };
+
+type RecordSeenInput = {
+  followed_artist_id: number;
+  release_key: string;
+  source: ReleaseSource;
+  album_title: string;
+  release_date: string | null;
+  external_id: string | null;
+};
+
+const log = createLogger("followed");
+
+function getFollowedRepo() {
+  return getDataSource().getRepository(FollowedArtist);
+}
+
+function getSeenRepo() {
+  return getDataSource().getRepository(SeenRelease);
+}
+
+export async function followArtist(
+  userId: number,
+  artistMbid: string,
+  artistName: string
+): Promise<AddFollowResult> {
+  const repo = getFollowedRepo();
+
+  const existing = await repo.findOne({
+    where: { user_id: userId, artist_mbid: artistMbid },
+  });
+
+  if (existing) {
+    return { status: "already_following", id: existing.id };
+  }
+
+  const item = repo.create({
+    user_id: userId,
+    artist_mbid: artistMbid,
+    artist_name: artistName,
+    last_checked_at: null,
+  });
+
+  const saved = await repo.save(item);
+  log.info(`User ${userId} followed "${artistName}" (${artistMbid})`);
+
+  return { status: "added", id: saved.id };
+}
+
+export async function unfollowArtist(
+  userId: number,
+  artistMbid: string
+): Promise<RemoveFollowResult> {
+  const repo = getFollowedRepo();
+
+  const item = await repo.findOne({
+    where: { user_id: userId, artist_mbid: artistMbid },
+  });
+
+  if (!item) {
+    return { status: "not_found" };
+  }
+
+  await repo.remove(item);
+  log.info(`User ${userId} unfollowed "${item.artist_name}"`);
+
+  return { status: "removed" };
+}
+
+export async function getFollowedArtists(
+  userId: number
+): Promise<FollowedArtist[]> {
+  const repo = getFollowedRepo();
+
+  return repo.find({
+    where: { user_id: userId },
+    order: { created_at: "DESC" },
+  });
+}
+
+export async function getAllFollowedArtists(): Promise<FollowedArtist[]> {
+  const repo = getFollowedRepo();
+  return repo.find({ order: { created_at: "ASC" } });
+}
+
+export async function hasSeenRelease(
+  followedArtistId: number,
+  releaseKey: string
+): Promise<boolean> {
+  const repo = getSeenRepo();
+  const existing = await repo.findOne({
+    where: { followed_artist_id: followedArtistId, release_key: releaseKey },
+  });
+  return existing !== null;
+}
+
+export async function recordSeenRelease(
+  input: RecordSeenInput
+): Promise<SeenRelease> {
+  const repo = getSeenRepo();
+  const row = repo.create(input);
+  return repo.save(row);
+}
+
+export async function getSeenReleasesForUser(
+  userId: number,
+  limit = 50
+): Promise<(SeenRelease & { artist_name: string; artist_mbid: string })[]> {
+  const ds = getDataSource();
+  const rows = (await ds.query(
+    `SELECT sr.*, fa.artist_name as artist_name, fa.artist_mbid as artist_mbid
+     FROM seen_releases sr
+     INNER JOIN followed_artists fa ON sr.followed_artist_id = fa.id
+     WHERE fa.user_id = ?
+     ORDER BY sr.notified_at DESC
+     LIMIT ?`,
+    [userId, limit]
+  )) as (SeenRelease & { artist_name: string; artist_mbid: string })[];
+  return rows;
+}
+
+export async function updateLastCheckedAt(
+  followedArtistId: number,
+  isoTimestamp: string
+): Promise<void> {
+  const repo = getFollowedRepo();
+  await repo.update(
+    { id: followedArtistId },
+    { last_checked_at: isoTimestamp }
+  );
+}
+
+export async function getUnseenReleaseCount(userId: number): Promise<number> {
+  const ds = getDataSource();
+  const rows = (await ds.query(
+    `SELECT COUNT(sr.id) as count
+     FROM seen_releases sr
+     INNER JOIN followed_artists fa ON sr.followed_artist_id = fa.id
+     LEFT JOIN users u ON u.id = fa.user_id
+     WHERE fa.user_id = ?
+       AND (u.followed_last_viewed_at IS NULL
+            OR sr.notified_at > u.followed_last_viewed_at)`,
+    [userId]
+  )) as { count: number }[];
+  return rows[0]?.count ?? 0;
+}
+
+export async function markFollowedReleasesViewed(
+  userId: number
+): Promise<void> {
+  const repo = getDataSource().getRepository(User);
+  await repo.update(
+    { id: userId },
+    { followed_last_viewed_at: new Date().toISOString() }
+  );
+}

--- a/server/services/followed/followedService.ts
+++ b/server/services/followed/followedService.ts
@@ -125,7 +125,7 @@ export async function getSeenReleasesForUser(
      FROM seen_releases sr
      INNER JOIN followed_artists fa ON sr.followed_artist_id = fa.id
      WHERE fa.user_id = ?
-     ORDER BY sr.notified_at DESC
+     ORDER BY sr.release_date IS NULL, sr.release_date DESC, sr.notified_at DESC
      LIMIT ?`,
     [userId, limit]
   )) as (SeenRelease & { artist_name: string; artist_mbid: string })[];

--- a/server/services/followed/poller.test.ts
+++ b/server/services/followed/poller.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetAll = vi.fn();
+const mockHasSeen = vi.fn();
+const mockRecord = vi.fn();
+const mockUpdateChecked = vi.fn();
+const mockAggregate = vi.fn();
+
+vi.mock("./followedService", () => ({
+  getAllFollowedArtists: () => mockGetAll(),
+  hasSeenRelease: (...args: unknown[]) => mockHasSeen(...args),
+  recordSeenRelease: (...args: unknown[]) => mockRecord(...args),
+  updateLastCheckedAt: (...args: unknown[]) => mockUpdateChecked(...args),
+}));
+
+vi.mock("./releaseAggregator", () => ({
+  aggregateArtistReleases: (...args: unknown[]) => mockAggregate(...args),
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import { runPollOnce } from "./poller";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runPollOnce", () => {
+  it("records new releases for established follows", async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        id: 1,
+        user_id: 10,
+        artist_mbid: "mbid-1",
+        artist_name: "Test Artist",
+        last_checked_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockAggregate.mockResolvedValue([
+      {
+        release_key: "key-1",
+        source: "musicbrainz",
+        album_title: "New Album",
+        release_date: "2025-04-01",
+        external_id: "rg-1",
+      },
+    ]);
+    mockHasSeen.mockResolvedValue(false);
+
+    await runPollOnce();
+
+    expect(mockRecord).toHaveBeenCalledWith({
+      followed_artist_id: 1,
+      release_key: "key-1",
+      source: "musicbrainz",
+      album_title: "New Album",
+      release_date: "2025-04-01",
+      external_id: "rg-1",
+    });
+    expect(mockUpdateChecked).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips releases already in seen_releases", async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        id: 1,
+        user_id: 10,
+        artist_mbid: "mbid-1",
+        artist_name: "X",
+        last_checked_at: "2025-01-01",
+      },
+    ]);
+    mockAggregate.mockResolvedValue([
+      {
+        release_key: "key-1",
+        source: "musicbrainz",
+        album_title: "A",
+        release_date: "2025-04-01",
+        external_id: "rg-1",
+      },
+    ]);
+    mockHasSeen.mockResolvedValue(true);
+
+    await runPollOnce();
+
+    expect(mockRecord).not.toHaveBeenCalled();
+    expect(mockUpdateChecked).toHaveBeenCalledTimes(1);
+  });
+
+  it("records every new release on first run regardless of date", async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        id: 1,
+        user_id: 10,
+        artist_mbid: "mbid-1",
+        artist_name: "Test Artist",
+        last_checked_at: null,
+      },
+    ]);
+    mockAggregate.mockResolvedValue([
+      {
+        release_key: "key-old",
+        source: "musicbrainz",
+        album_title: "Old Album",
+        release_date: "2010-01-01",
+        external_id: "rg-old",
+      },
+      {
+        release_key: "key-new",
+        source: "deezer",
+        album_title: "New Album",
+        release_date: "2025-04-01",
+        external_id: "1",
+      },
+    ]);
+    mockHasSeen.mockResolvedValue(false);
+
+    await runPollOnce();
+
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(mockUpdateChecked).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues other artists when one fails", async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        id: 1,
+        user_id: 1,
+        artist_mbid: "a",
+        artist_name: "A",
+        last_checked_at: null,
+      },
+      {
+        id: 2,
+        user_id: 2,
+        artist_mbid: "b",
+        artist_name: "B",
+        last_checked_at: "2025-01-01",
+      },
+    ]);
+    mockAggregate
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce([
+        {
+          release_key: "k",
+          source: "musicbrainz",
+          album_title: "Z",
+          release_date: "2025-04-01",
+          external_id: "rg",
+        },
+      ]);
+    mockHasSeen.mockResolvedValue(false);
+
+    await runPollOnce();
+
+    expect(mockUpdateChecked).toHaveBeenCalledTimes(1);
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/followed/poller.ts
+++ b/server/services/followed/poller.ts
@@ -1,0 +1,93 @@
+import {
+  getAllFollowedArtists,
+  hasSeenRelease,
+  recordSeenRelease,
+  updateLastCheckedAt,
+} from "./followedService";
+import { aggregateArtistReleases } from "./releaseAggregator";
+import { createLogger } from "../../logger";
+import type { FollowedArtist } from "../../db/index";
+
+const log = createLogger("followed-poller");
+
+const DEFAULT_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const FIRST_RUN_DELAY_MS = 30 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+async function pollOneArtist(follow: FollowedArtist): Promise<void> {
+  const releases = await aggregateArtistReleases(
+    follow.artist_mbid,
+    follow.artist_name
+  );
+
+  for (const rel of releases) {
+    const alreadySeen = await hasSeenRelease(follow.id, rel.release_key);
+    if (alreadySeen) continue;
+
+    await recordSeenRelease({
+      followed_artist_id: follow.id,
+      release_key: rel.release_key,
+      source: rel.source,
+      album_title: rel.album_title,
+      release_date: rel.release_date,
+      external_id: rel.external_id,
+    });
+  }
+
+  await updateLastCheckedAt(follow.id, isoNow());
+}
+
+export async function runPollOnce(): Promise<void> {
+  if (running) {
+    log.warn("Poll already running, skipping this tick");
+    return;
+  }
+  running = true;
+  try {
+    const follows = await getAllFollowedArtists();
+    log.info(`Polling ${follows.length} followed artist(s)`);
+    for (const f of follows) {
+      try {
+        await pollOneArtist(f);
+      } catch (error) {
+        log.error(`Poll failed for artist ${f.artist_name} (${f.id})`, error);
+      }
+    }
+  } finally {
+    running = false;
+  }
+}
+
+export function startFollowedArtistPoller(
+  intervalMs: number = DEFAULT_INTERVAL_MS
+): void {
+  if (timer) return;
+
+  const tick = async () => {
+    try {
+      await runPollOnce();
+    } catch (error) {
+      log.error("Poll tick failed", error);
+    } finally {
+      timer = setTimeout(tick, intervalMs);
+    }
+  };
+
+  timer = setTimeout(tick, FIRST_RUN_DELAY_MS);
+  log.info(
+    `Followed artist poller scheduled (interval: ${intervalMs / 1000}s)`
+  );
+}
+
+export function stopFollowedArtistPoller(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/server/services/followed/releaseAggregator.test.ts
+++ b/server/services/followed/releaseAggregator.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockMbFetch = vi.fn();
+const mockDeezerFetch = vi.fn();
+const mockAppleFetch = vi.fn();
+
+vi.mock("../../api/musicbrainz/releaseGroups", () => ({
+  fetchReleaseGroupsForArtist: (...args: unknown[]) => mockMbFetch(...args),
+}));
+vi.mock("../../api/deezer/albums", () => ({
+  getArtistAlbumsByName: (...args: unknown[]) => mockDeezerFetch(...args),
+}));
+vi.mock("../../api/apple/albums", () => ({
+  getArtistAlbumsByName: (...args: unknown[]) => mockAppleFetch(...args),
+}));
+vi.mock("../../logger", () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import { aggregateArtistReleases } from "./releaseAggregator";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("aggregateArtistReleases", () => {
+  it("merges releases across sources and dedupes by normalized key", async () => {
+    mockMbFetch.mockResolvedValue([
+      {
+        id: "rg-1",
+        title: "OK Computer",
+        "first-release-date": "1997-06-16",
+      },
+    ]);
+    mockDeezerFetch.mockResolvedValue([
+      {
+        id: 100,
+        title: "OK Computer (Remastered)".replace("(Remastered)", "").trim(),
+        release_date: "1997-06-16",
+      },
+      { id: 101, title: "Kid A", release_date: "2000-10-02" },
+    ]);
+    mockAppleFetch.mockResolvedValue([
+      {
+        collectionId: 200,
+        collectionName: "Amnesiac",
+        releaseDate: "2001-06-05T00:00:00Z",
+      },
+    ]);
+
+    const result = await aggregateArtistReleases("mbid-123", "Radiohead");
+    expect(result).toHaveLength(3);
+    const ok = result.find((r) => r.album_title === "OK Computer");
+    expect(ok?.source).toBe("musicbrainz");
+    const kid = result.find((r) => r.album_title === "Kid A");
+    expect(kid?.source).toBe("deezer");
+    const am = result.find((r) => r.album_title === "Amnesiac");
+    expect(am?.source).toBe("apple");
+    expect(am?.release_date).toBe("2001-06-05");
+  });
+
+  it("handles MB fetch failure gracefully", async () => {
+    mockMbFetch.mockRejectedValue(new Error("MB down"));
+    mockDeezerFetch.mockResolvedValue([
+      { id: 1, title: "Solo", release_date: "2025-03-01" },
+    ]);
+    mockAppleFetch.mockResolvedValue([]);
+
+    const result = await aggregateArtistReleases("mbid-x", "X");
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("deezer");
+  });
+
+  it("ignores releases with no usable title/date", async () => {
+    mockMbFetch.mockResolvedValue([
+      { id: "rg-empty", title: "", "first-release-date": "" },
+    ]);
+    mockDeezerFetch.mockResolvedValue([]);
+    mockAppleFetch.mockResolvedValue([]);
+
+    const result = await aggregateArtistReleases("mbid-x", "X");
+    expect(result).toEqual([]);
+  });
+
+  it("prefers MB row when same title+month surfaces from multiple sources", async () => {
+    mockMbFetch.mockResolvedValue([
+      { id: "rg-1", title: "Hello World", "first-release-date": "2025-05-01" },
+    ]);
+    mockDeezerFetch.mockResolvedValue([
+      { id: 1, title: "Hello World", release_date: "2025-05-15" },
+    ]);
+    mockAppleFetch.mockResolvedValue([
+      {
+        collectionId: 2,
+        collectionName: "Hello World",
+        releaseDate: "2025-05-20",
+      },
+    ]);
+
+    const result = await aggregateArtistReleases("mbid-x", "X");
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("musicbrainz");
+  });
+});

--- a/server/services/followed/releaseAggregator.ts
+++ b/server/services/followed/releaseAggregator.ts
@@ -1,0 +1,110 @@
+import { fetchReleaseGroupsForArtist } from "../../api/musicbrainz/releaseGroups";
+import { getArtistAlbumsByName as getDeezerAlbums } from "../../api/deezer/albums";
+import { getArtistAlbumsByName as getAppleAlbums } from "../../api/apple/albums";
+import { createLogger } from "../../logger";
+import type { ReleaseSource } from "../../db/index";
+
+export type AggregatedRelease = {
+  release_key: string;
+  source: ReleaseSource;
+  album_title: string;
+  release_date: string | null;
+  external_id: string | null;
+};
+
+const log = createLogger("releaseAggregator");
+
+const TITLE_NOISE = /[\s.,!?'"()[\]{}\-_:;]+/g;
+
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(TITLE_NOISE, "").trim();
+}
+
+function yearMonth(date: string | null | undefined): string {
+  if (!date) return "0000-00";
+  return date.slice(0, 7);
+}
+
+function buildKey(title: string, date: string | null | undefined): string {
+  return `${normalizeTitle(title)}|${yearMonth(date)}`;
+}
+
+async function fetchFromMusicBrainz(
+  artistMbid: string
+): Promise<AggregatedRelease[]> {
+  try {
+    const groups = await fetchReleaseGroupsForArtist(artistMbid);
+    return groups.map((rg) => ({
+      release_key: buildKey(rg.title, rg["first-release-date"]),
+      source: "musicbrainz" as const,
+      album_title: rg.title,
+      release_date: rg["first-release-date"] || null,
+      external_id: rg.id,
+    }));
+  } catch (error) {
+    log.error(`MB fetch failed for ${artistMbid}`, error);
+    return [];
+  }
+}
+
+async function fetchFromDeezer(
+  artistName: string
+): Promise<AggregatedRelease[]> {
+  const albums = await getDeezerAlbums(artistName);
+  return albums.map((a) => ({
+    release_key: buildKey(a.title, a.release_date),
+    source: "deezer" as const,
+    album_title: a.title,
+    release_date: a.release_date ?? null,
+    external_id: String(a.id),
+  }));
+}
+
+async function fetchFromApple(
+  artistName: string
+): Promise<AggregatedRelease[]> {
+  const albums = await getAppleAlbums(artistName);
+  return albums.map((a) => ({
+    release_key: buildKey(a.collectionName, a.releaseDate),
+    source: "apple" as const,
+    album_title: a.collectionName,
+    release_date: a.releaseDate ? a.releaseDate.slice(0, 10) : null,
+    external_id: String(a.collectionId),
+  }));
+}
+
+/**
+ * Aggregate the artist's releases across MB, Deezer, Apple.
+ * Dedupes by (normalized title + release year-month). MB is preferred when
+ * the same key surfaces from multiple sources.
+ */
+export async function aggregateArtistReleases(
+  artistMbid: string,
+  artistName: string
+): Promise<AggregatedRelease[]> {
+  const [mb, deezer, apple] = await Promise.all([
+    fetchFromMusicBrainz(artistMbid),
+    fetchFromDeezer(artistName),
+    fetchFromApple(artistName),
+  ]);
+
+  const sourceOrder: ReleaseSource[] = ["musicbrainz", "deezer", "apple"];
+  const combined = [...mb, ...deezer, ...apple];
+
+  const byKey = new Map<string, AggregatedRelease>();
+  for (const rel of combined) {
+    if (!rel.release_key || rel.release_key === "|0000-00") continue;
+    const existing = byKey.get(rel.release_key);
+    if (!existing) {
+      byKey.set(rel.release_key, rel);
+      continue;
+    }
+    const existingRank = sourceOrder.indexOf(existing.source);
+    const newRank = sourceOrder.indexOf(rel.source);
+    if (newRank < existingRank) {
+      byKey.set(rel.release_key, rel);
+    }
+  }
+
+  return Array.from(byKey.values());
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
               <Route path="purchases" element={null} />
               <Route path="wanted" element={null} />
               <Route path="requests" element={null} />
+              <Route path="following" element={null} />
             </Route>
             <Route path="/settings" element={<SettingsLayout />}>
               <Route

--- a/src/components/FollowArtistButton.tsx
+++ b/src/components/FollowArtistButton.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { BellIcon, BellSlashIcon } from "./icons";
+import useFollowedArtists from "@/hooks/useFollowedArtists";
+
+type FollowArtistButtonProps = {
+  artistMbid: string;
+  artistName: string;
+  size?: "sm" | "md";
+  showLabel?: boolean;
+  className?: string;
+};
+
+const SIZE_STYLES = {
+  sm: "h-8 px-2 text-xs",
+  md: "h-9 px-3 text-sm",
+};
+
+export default function FollowArtistButton({
+  artistMbid,
+  artistName,
+  size = "md",
+  showLabel = true,
+  className = "",
+}: FollowArtistButtonProps) {
+  const { isFollowing, follow, unfollow } = useFollowedArtists();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!artistMbid) return null;
+
+  const following = isFollowing(artistMbid);
+
+  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (following) {
+        await unfollow(artistMbid);
+      } else {
+        await follow(artistMbid, artistName);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const label = following ? "Following" : "Follow";
+  const Icon = following ? BellIcon : BellSlashIcon;
+  const colorClasses = following
+    ? "bg-pink-400 text-black"
+    : "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      aria-pressed={following}
+      aria-label={following ? `Unfollow ${artistName}` : `Follow ${artistName}`}
+      title={error ?? label}
+      className={`inline-flex items-center gap-1 rounded-full border-2 border-black font-bold ${SIZE_STYLES[size]} ${colorClasses} disabled:opacity-50 ${className}`}
+    >
+      <Icon className="h-4 w-4" aria-hidden />
+      {showLabel ? label : null}
+    </button>
+  );
+}

--- a/src/components/NotificationBadge.tsx
+++ b/src/components/NotificationBadge.tsx
@@ -1,0 +1,21 @@
+type NotificationBadgeProps = {
+  count: number;
+  className?: string;
+};
+
+export default function NotificationBadge({
+  count,
+  className = "",
+}: NotificationBadgeProps) {
+  if (count <= 0) return null;
+  const label = count > 99 ? "99+" : String(count);
+  return (
+    <span
+      data-testid="notification-badge"
+      aria-label={`${count} new`}
+      className={`inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold rounded-full border-2 border-black bg-rose-400 text-black shadow-cartoon-sm ${className}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/ReleaseGroupCard.tsx
+++ b/src/components/ReleaseGroupCard.tsx
@@ -5,6 +5,7 @@ import TrackList from "./TrackList";
 import PurchaseLinksModal from "./PurchaseLinksModal";
 import PurchasePriceModal from "./PurchasePriceModal";
 import Spinner from "./Spinner";
+import FollowArtistButton from "./FollowArtistButton";
 import { CheckIcon, PlusIcon } from "@/components/icons";
 import ImageWithShimmer from "./ImageWithShimmer";
 import OptionSelect from "./OptionSelect";
@@ -54,8 +55,9 @@ export default function ReleaseGroupCard({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isPurchaseModalOpen, setIsPurchaseModalOpen] = useState(false);
 
-  const artistName =
-    releaseGroup["artist-credit"]?.[0]?.artist?.name || "Unknown Artist";
+  const artistCredit = releaseGroup["artist-credit"]?.[0]?.artist;
+  const artistName = artistCredit?.name || "Unknown Artist";
+  const artistMbid = artistCredit?.id;
   const albumTitle = releaseGroup.title || "";
   const albumMbid = releaseGroup.id;
   const pastelBg = useMemo(() => pastelColorFromId(albumMbid), [albumMbid]);
@@ -326,13 +328,25 @@ export default function ReleaseGroupCard({
               />
             </div>
 
-            <div className="flex-shrink-0 mt-2 flex items-center justify-end gap-1.5">
-              <OptionSelect options={cardOptions} title={albumTitle} />
-              <MonitorButton
-                state={effectiveState}
-                onClick={handleMonitorClick}
-                errorMsg={errorMsg ?? undefined}
-              />
+            <div className="flex-shrink-0 mt-2 flex items-center justify-between gap-1.5">
+              {artistMbid ? (
+                <FollowArtistButton
+                  artistMbid={artistMbid}
+                  artistName={artistName}
+                  size="sm"
+                  showLabel={false}
+                />
+              ) : (
+                <span />
+              )}
+              <div className="flex items-center gap-1.5">
+                <OptionSelect options={cardOptions} title={albumTitle} />
+                <MonitorButton
+                  state={effectiveState}
+                  onClick={handleMonitorClick}
+                  errorMsg={errorMsg ?? undefined}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ import {
   UserCircleIcon,
 } from "@/components/icons";
 import UserAvatar from "@/components/UserAvatar";
+import NotificationBadge from "@/components/NotificationBadge";
+import useUnseenReleaseCount from "@/hooks/useUnseenReleaseCount";
 import { useAuth } from "@/context/useAuth";
 
 type NavItem = {
@@ -46,6 +48,7 @@ function makeSearchClickHandler(
 function MobileNav() {
   const { user } = useAuth();
   const { pathname } = useLocation();
+  const { count: unseenCount } = useUnseenReleaseCount();
   const navRef = useRef<HTMLUListElement>(null);
   const pillRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
@@ -117,15 +120,23 @@ function MobileNav() {
                   }`
                 }
               >
-                {link.to === "/settings" && user?.thumb ? (
-                  <UserAvatar
-                    thumb={user.thumb}
-                    username={user.username}
-                    className="w-6 h-6"
-                  />
-                ) : (
-                  <link.icon className="w-6 h-6" />
-                )}
+                <div className="relative">
+                  {link.to === "/settings" && user?.thumb ? (
+                    <UserAvatar
+                      thumb={user.thumb}
+                      username={user.username}
+                      className="w-6 h-6"
+                    />
+                  ) : (
+                    <link.icon className="w-6 h-6" />
+                  )}
+                  {link.to === "/library" && (
+                    <NotificationBadge
+                      count={unseenCount}
+                      className="absolute -top-1.5 -right-2"
+                    />
+                  )}
+                </div>
                 <span>{link.label}</span>
               </NavLink>
             </li>
@@ -138,6 +149,7 @@ function MobileNav() {
 
 function DesktopNavLink({ link }: { link: NavItem }) {
   const { pathname } = useLocation();
+  const { count: unseenCount } = useUnseenReleaseCount();
   const base = link.to.split("/").slice(0, 2).join("/");
   const isActive =
     link.to === "/" ? pathname === "/" : pathname.startsWith(base);
@@ -153,7 +165,8 @@ function DesktopNavLink({ link }: { link: NavItem }) {
       }`}
     >
       <link.icon className="w-5 h-5" />
-      <span>{link.label}</span>
+      <span className="flex-1">{link.label}</span>
+      {link.to === "/library" && <NotificationBadge count={unseenCount} />}
     </NavLink>
   );
 }

--- a/src/components/__tests__/FollowArtistButton.test.tsx
+++ b/src/components/__tests__/FollowArtistButton.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import FollowArtistButton from "../FollowArtistButton";
+import { __resetFollowedArtistsForTests } from "@/hooks/useFollowedArtists";
+
+beforeEach(() => {
+  __resetFollowedArtistsForTests();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("FollowArtistButton", () => {
+  it("renders nothing when artistMbid is empty", () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse([]));
+    const { container } = render(
+      <FollowArtistButton artistMbid="" artistName="X" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows 'Follow' when artist is not followed", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse([]));
+    render(<FollowArtistButton artistMbid="mbid-1" artistName="X" />);
+    expect(await screen.findByText("Follow")).toBeInTheDocument();
+  });
+
+  it("shows 'Following' when artist is already followed", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse([
+        {
+          id: 1,
+          artistMbid: "mbid-1",
+          artistName: "X",
+          lastCheckedAt: null,
+          createdAt: "2025-01-01",
+        },
+      ])
+    );
+    render(<FollowArtistButton artistMbid="mbid-1" artistName="X" />);
+    expect(await screen.findByText("Following")).toBeInTheDocument();
+  });
+
+  it("clicking triggers POST when not followed", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ status: "added", id: 1 }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            artistMbid: "mbid-1",
+            artistName: "X",
+            lastCheckedAt: null,
+            createdAt: "2025-01-01",
+          },
+        ])
+      );
+
+    render(<FollowArtistButton artistMbid="mbid-1" artistName="X" />);
+    const btn = await screen.findByRole("button", { name: /Follow X/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/followed",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  it("clicking triggers DELETE when already followed", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            artistMbid: "mbid-1",
+            artistName: "X",
+            lastCheckedAt: null,
+            createdAt: "2025-01-01",
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ status: "removed" }));
+
+    render(<FollowArtistButton artistMbid="mbid-1" artistName="X" />);
+    const btn = await screen.findByRole("button", { name: /Unfollow X/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      const deleteCall = fetchMock.mock.calls.find(
+        (c) => (c[1] as RequestInit | undefined)?.method === "DELETE"
+      );
+      expect(deleteCall?.[0]).toBe("/api/followed/mbid-1");
+    });
+  });
+});

--- a/src/components/__tests__/NotificationBadge.test.tsx
+++ b/src/components/__tests__/NotificationBadge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import NotificationBadge from "../NotificationBadge";
+
+describe("NotificationBadge", () => {
+  it("renders nothing when count is 0", () => {
+    const { container } = render(<NotificationBadge count={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for negative values", () => {
+    const { container } = render(<NotificationBadge count={-5} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the count when positive", () => {
+    render(<NotificationBadge count={3} />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByLabelText("3 new")).toBeInTheDocument();
+  });
+
+  it("renders 99+ when count exceeds 99", () => {
+    render(<NotificationBadge count={150} />);
+    expect(screen.getByText("99+")).toBeInTheDocument();
+  });
+});

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -25,4 +25,6 @@ export {
   DocumentIcon,
   InformationCircleIcon,
   HeartIcon,
+  BellIcon,
+  BellSlashIcon,
 } from "@heroicons/react/20/solid";

--- a/src/hooks/__tests__/useFollowedArtists.test.ts
+++ b/src/hooks/__tests__/useFollowedArtists.test.ts
@@ -1,0 +1,146 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import useFollowedArtists, {
+  __resetFollowedArtistsForTests,
+} from "../useFollowedArtists";
+
+beforeEach(() => {
+  __resetFollowedArtistsForTests();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockSequence(...responses: Response[]) {
+  const fn = vi.mocked(fetch);
+  for (const r of responses) {
+    fn.mockResolvedValueOnce(r);
+  }
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("useFollowedArtists", () => {
+  it("loads followed artists on mount", async () => {
+    mockSequence(
+      jsonResponse([
+        {
+          id: 1,
+          artistMbid: "mbid-1",
+          artistName: "Radiohead",
+          lastCheckedAt: null,
+          createdAt: "2025-01-01",
+        },
+      ])
+    );
+
+    const { result } = renderHook(() => useFollowedArtists());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.isFollowing("mbid-1")).toBe(true);
+    expect(result.current.isFollowing("mbid-other")).toBe(false);
+  });
+
+  it("sets error on fetch failure", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response("", { status: 500 }));
+    const { result } = renderHook(() => useFollowedArtists());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("Failed to load followed artists");
+  });
+
+  it("follow() POSTs and refreshes the list", async () => {
+    mockSequence(
+      jsonResponse([]),
+      jsonResponse({ status: "added", id: 7 }),
+      jsonResponse([
+        {
+          id: 7,
+          artistMbid: "mbid-1",
+          artistName: "X",
+          lastCheckedAt: null,
+          createdAt: "2025-05-01",
+        },
+      ])
+    );
+
+    const { result } = renderHook(() => useFollowedArtists());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.follow("mbid-1", "X");
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    const postCall = vi.mocked(fetch).mock.calls[1];
+    expect(postCall[0]).toBe("/api/followed");
+    expect((postCall[1] as RequestInit).method).toBe("POST");
+  });
+
+  it("unfollow() removes the item locally on 200", async () => {
+    mockSequence(
+      jsonResponse([
+        {
+          id: 1,
+          artistMbid: "mbid-1",
+          artistName: "X",
+          lastCheckedAt: null,
+          createdAt: "2025-01-01",
+        },
+      ]),
+      jsonResponse({ status: "removed" })
+    );
+
+    const { result } = renderHook(() => useFollowedArtists());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.unfollow("mbid-1");
+    });
+
+    expect(result.current.items).toHaveLength(0);
+    const deleteCall = vi.mocked(fetch).mock.calls[1];
+    expect((deleteCall[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("unfollow() also removes locally on 404", async () => {
+    mockSequence(
+      jsonResponse([
+        {
+          id: 1,
+          artistMbid: "mbid-1",
+          artistName: "X",
+          lastCheckedAt: null,
+          createdAt: "2025-01-01",
+        },
+      ]),
+      jsonResponse({ error: "not found" }, 404)
+    );
+
+    const { result } = renderHook(() => useFollowedArtists());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.unfollow("mbid-1");
+    });
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("follow() throws when API returns an error", async () => {
+    mockSequence(jsonResponse([]), jsonResponse({ error: "boom" }, 500));
+
+    const { result } = renderHook(() => useFollowedArtists());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(
+      act(async () => {
+        await result.current.follow("mbid-1", "X");
+      })
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/hooks/__tests__/useUnseenReleaseCount.test.ts
+++ b/src/hooks/__tests__/useUnseenReleaseCount.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import useUnseenReleaseCount, {
+  __resetUnseenReleaseCountForTests,
+} from "../useUnseenReleaseCount";
+
+beforeEach(() => {
+  __resetUnseenReleaseCountForTests();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("useUnseenReleaseCount", () => {
+  it("loads count on mount", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ count: 5 }));
+    const { result } = renderHook(() => useUnseenReleaseCount());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.count).toBe(5);
+  });
+
+  it("falls back to 0 on fetch error", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("", { status: 500 }));
+    const { result } = renderHook(() => useUnseenReleaseCount());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.count).toBe(0);
+  });
+
+  it("markViewed POSTs and zeros count immediately", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ count: 3 }))
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+
+    const { result } = renderHook(() => useUnseenReleaseCount());
+    await waitFor(() => expect(result.current.count).toBe(3));
+
+    await act(async () => {
+      await result.current.markViewed();
+    });
+
+    expect(result.current.count).toBe(0);
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === "POST"
+    );
+    expect(postCall?.[0]).toBe("/api/followed/mark-viewed");
+  });
+
+  it("refresh re-fetches", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ count: 1 }))
+      .mockResolvedValueOnce(jsonResponse({ count: 7 }));
+
+    const { result } = renderHook(() => useUnseenReleaseCount());
+    await waitFor(() => expect(result.current.count).toBe(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.count).toBe(7);
+  });
+});

--- a/src/hooks/useFollowedArtists.ts
+++ b/src/hooks/useFollowedArtists.ts
@@ -1,0 +1,109 @@
+import { useState, useEffect, useCallback } from "react";
+import type { FollowedArtistItem } from "@/types";
+
+type Subscriber = (state: SharedState) => void;
+type SharedState = {
+  items: FollowedArtistItem[];
+  loading: boolean;
+  error: string | null;
+};
+
+let sharedState: SharedState = { items: [], loading: true, error: null };
+let inflight: Promise<void> | null = null;
+let initialized = false;
+const subscribers = new Set<Subscriber>();
+
+function publish(next: Partial<SharedState>): void {
+  sharedState = { ...sharedState, ...next };
+  for (const subscriber of subscribers) {
+    subscriber(sharedState);
+  }
+}
+
+async function refreshShared(): Promise<void> {
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const res = await fetch("/api/followed");
+      if (!res.ok) throw new Error("Failed to load followed artists");
+      const data: FollowedArtistItem[] = await res.json();
+      publish({ items: data, loading: false, error: null });
+    } catch (err) {
+      publish({
+        loading: false,
+        error:
+          err instanceof Error
+            ? err.message
+            : "Failed to load followed artists",
+      });
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/** Test-only helper to reset module state between tests */
+export function __resetFollowedArtistsForTests(): void {
+  sharedState = { items: [], loading: true, error: null };
+  inflight = null;
+  initialized = false;
+  subscribers.clear();
+}
+
+export default function useFollowedArtists() {
+  const [state, setState] = useState<SharedState>(sharedState);
+
+  useEffect(() => {
+    subscribers.add(setState);
+    if (!initialized) {
+      initialized = true;
+      void refreshShared();
+    }
+    return () => {
+      subscribers.delete(setState);
+    };
+  }, []);
+
+  const follow = useCallback(async (artistMbid: string, artistName: string) => {
+    const res = await fetch("/api/followed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ artistMbid, artistName }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to follow artist");
+    }
+    await refreshShared();
+  }, []);
+
+  const unfollow = useCallback(async (artistMbid: string) => {
+    const res = await fetch(`/api/followed/${encodeURIComponent(artistMbid)}`, {
+      method: "DELETE",
+    });
+    if (!res.ok && res.status !== 404) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to unfollow artist");
+    }
+    publish({
+      items: sharedState.items.filter((item) => item.artistMbid !== artistMbid),
+    });
+  }, []);
+
+  const isFollowing = useCallback(
+    (artistMbid: string) =>
+      state.items.some((item) => item.artistMbid === artistMbid),
+    [state.items]
+  );
+
+  return {
+    items: state.items,
+    loading: state.loading,
+    error: state.error,
+    isFollowing,
+    follow,
+    unfollow,
+    refresh: refreshShared,
+  };
+}

--- a/src/hooks/useUnseenReleaseCount.ts
+++ b/src/hooks/useUnseenReleaseCount.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState, useCallback } from "react";
+
+type Subscriber = (state: SharedState) => void;
+type SharedState = { count: number; loading: boolean };
+
+let sharedState: SharedState = { count: 0, loading: true };
+let inflight: Promise<void> | null = null;
+let initialized = false;
+const subscribers = new Set<Subscriber>();
+
+function publish(next: Partial<SharedState>): void {
+  sharedState = { ...sharedState, ...next };
+  for (const subscriber of subscribers) {
+    subscriber(sharedState);
+  }
+}
+
+async function refreshShared(): Promise<void> {
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const res = await fetch("/api/followed/unseen-count");
+      if (!res.ok) {
+        publish({ loading: false });
+        return;
+      }
+      const data = (await res.json()) as { count: number };
+      publish({ count: data.count ?? 0, loading: false });
+    } catch {
+      publish({ loading: false });
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+async function markViewedShared(): Promise<void> {
+  publish({ count: 0 });
+  try {
+    await fetch("/api/followed/mark-viewed", { method: "POST" });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Test-only helper to reset module state between tests */
+export function __resetUnseenReleaseCountForTests(): void {
+  sharedState = { count: 0, loading: true };
+  inflight = null;
+  initialized = false;
+  subscribers.clear();
+}
+
+export default function useUnseenReleaseCount() {
+  const [state, setState] = useState<SharedState>(sharedState);
+
+  useEffect(() => {
+    subscribers.add(setState);
+    if (!initialized) {
+      initialized = true;
+      void refreshShared();
+    }
+    return () => {
+      subscribers.delete(setState);
+    };
+  }, []);
+
+  const refresh = useCallback(() => refreshShared(), []);
+  const markViewed = useCallback(() => markViewedShared(), []);
+
+  return {
+    count: state.count,
+    loading: state.loading,
+    refresh,
+    markViewed,
+  };
+}

--- a/src/pages/DiscoverPage/components/ArtistCard.tsx
+++ b/src/pages/DiscoverPage/components/ArtistCard.tsx
@@ -5,6 +5,7 @@ import ReleaseGroupCard from "@/components/ReleaseGroupCard";
 import { ChevronDownIcon, MusicalNoteIcon } from "@/components/icons";
 import ImageWithShimmer from "@/components/ImageWithShimmer";
 import Skeleton from "@/components/Skeleton";
+import FollowArtistButton from "@/components/FollowArtistButton";
 import type { ReleaseGroup } from "@/types";
 
 const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
@@ -32,6 +33,7 @@ function splitAlbumsByCredit(
 
 interface ArtistCardProps {
   name: string;
+  mbid?: string;
   imageUrl?: string;
   /** 0-1 similarity score, shown as percentage */
   match?: number;
@@ -41,6 +43,7 @@ interface ArtistCardProps {
 
 export default function ArtistCard({
   name,
+  mbid,
   imageUrl,
   match,
   inLibrary,
@@ -137,6 +140,15 @@ export default function ArtistCard({
               </p>
             )}
           </div>
+          {mbid && (
+            <FollowArtistButton
+              artistMbid={mbid}
+              artistName={name}
+              size="sm"
+              showLabel={false}
+              className="flex-shrink-0"
+            />
+          )}
           <ChevronDownIcon
             className={`w-5 h-5 text-gray-400 transition-transform flex-shrink-0 ${expanded ? "rotate-180" : ""}`}
           />

--- a/src/pages/DiscoverPage/components/ArtistResultsList.tsx
+++ b/src/pages/DiscoverPage/components/ArtistResultsList.tsx
@@ -57,6 +57,7 @@ export default function ArtistResultsList({
                 <ArtistCard
                   key={`${artist.name}-${artist.rank}`}
                   name={artist.name}
+                  mbid={artist.mbid}
                   imageUrl={artist.imageUrl}
                   match={artist.match}
                   inLibrary={isInLibrary(artist.name, artist.mbid)}
@@ -78,6 +79,7 @@ export default function ArtistResultsList({
         <ArtistCard
           key={`${artist.name}-${artist.match ?? artist.rank}`}
           name={artist.name}
+          mbid={artist.mbid}
           imageUrl={artist.imageUrl}
           match={artist.match}
           inLibrary={isInLibrary(artist.name, artist.mbid)}

--- a/src/pages/LibraryPage/LibraryPage.tsx
+++ b/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/useAuth";
 import { hasPermission } from "@shared/permissions";
@@ -10,30 +10,46 @@ import useIsMobile from "@/hooks/useIsMobile";
 import { useSettings } from "@/context/useSettings";
 import { DEFAULT_SPENDING } from "@/context/spendingDefaults";
 import SettingsTabs, { type SettingsRoute } from "@/components/SettingsTabs";
+import NotificationBadge from "@/components/NotificationBadge";
+import useUnseenReleaseCount from "@/hooks/useUnseenReleaseCount";
 import RequestFilter from "./components/RequestFilter";
 import RequestList from "./components/RequestList";
 import WantedList from "./components/WantedList";
 import PurchaseList from "./components/PurchaseList";
 import SpendingSummary from "./components/SpendingSummary";
+import FollowingList from "./components/FollowingList";
 import Skeleton from "@/components/Skeleton";
 
-const libraryTabs: SettingsRoute[] = [
-  {
-    text: "Purchases",
-    route: "/library/purchases",
-    regex: /^\/library\/purchases/,
-  },
-  {
-    text: "Wanted",
-    route: "/library/wanted",
-    regex: /^\/library\/wanted/,
-  },
-  {
-    text: "Requests",
-    route: "/library/requests",
-    regex: /^\/library\/requests/,
-  },
-];
+function buildLibraryTabs(unseenCount: number): SettingsRoute[] {
+  return [
+    {
+      text: "Purchases",
+      route: "/library/purchases",
+      regex: /^\/library\/purchases/,
+    },
+    {
+      text: "Wanted",
+      route: "/library/wanted",
+      regex: /^\/library\/wanted/,
+    },
+    {
+      text: "Following",
+      content: (
+        <span className="flex items-center gap-2">
+          Following
+          <NotificationBadge count={unseenCount} />
+        </span>
+      ),
+      route: "/library/following",
+      regex: /^\/library\/following/,
+    },
+    {
+      text: "Requests",
+      route: "/library/requests",
+      regex: /^\/library\/requests/,
+    },
+  ];
+}
 
 export default function LibraryPage() {
   const { user } = useAuth();
@@ -41,6 +57,7 @@ export default function LibraryPage() {
   const isMobile = useIsMobile();
   const { settings } = useSettings();
   const spending = settings.spending ?? DEFAULT_SPENDING;
+  const { count: unseenCount, markViewed } = useUnseenReleaseCount();
   const [filters, setFilters] = useState<Record<string, string[]>>({
     requester: [],
     status: [],
@@ -49,7 +66,20 @@ export default function LibraryPage() {
   const isRequestsTab = /^\/library\/requests/.test(location.pathname);
   const isPurchasesTab = /^\/library\/purchases/.test(location.pathname);
   const isWantedTab = /^\/library\/wanted/.test(location.pathname);
-  const isSubTab = isRequestsTab || isWantedTab || isPurchasesTab;
+  const isFollowingTab = /^\/library\/following/.test(location.pathname);
+  const isSubTab =
+    isRequestsTab || isWantedTab || isPurchasesTab || isFollowingTab;
+
+  useEffect(() => {
+    if (isFollowingTab && unseenCount > 0) {
+      void markViewed();
+    }
+  }, [isFollowingTab, unseenCount, markViewed]);
+
+  const libraryTabs = useMemo(
+    () => buildLibraryTabs(unseenCount),
+    [unseenCount]
+  );
 
   const canViewAll =
     user !== null &&
@@ -147,6 +177,8 @@ export default function LibraryPage() {
               />
             )}
 
+            {isFollowingTab && <FollowingList />}
+
             {isRequestsTab && (
               <div className="flex flex-col gap-6">
                 <RequestFilter values={filters} onChange={handleFilterChange} />
@@ -222,6 +254,8 @@ export default function LibraryPage() {
               onRemove={removeWantedItem}
             />
           )}
+
+          {isFollowingTab && <FollowingList />}
 
           {isRequestsTab && (
             <div className="flex flex-col gap-6">

--- a/src/pages/LibraryPage/components/FollowingList.tsx
+++ b/src/pages/LibraryPage/components/FollowingList.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import useFollowedArtists from "@/hooks/useFollowedArtists";
+import FollowArtistButton from "@/components/FollowArtistButton";
+import Skeleton from "@/components/Skeleton";
+import type { SeenReleaseItem } from "@/types";
+
+function formatChecked(iso: string | null): string {
+  if (!iso) return "Never checked";
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return "Never checked";
+  return `Last checked ${parsed.toLocaleDateString()}`;
+}
+
+function ReleaseFeed() {
+  const [items, setItems] = useState<SeenReleaseItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/followed/releases?limit=30")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load recent releases");
+        return res.json();
+      })
+      .then((data: SeenReleaseItem[]) => {
+        if (active) {
+          setItems(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : "Failed to load");
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(3)].map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-rose-500 text-sm">{error}</p>;
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="text-gray-400 dark:text-gray-500 text-sm">
+        No releases yet. New releases will appear here as your followed artists
+        publish them.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {items.map((release) => (
+        <li
+          key={release.id}
+          className="flex items-center gap-3 rounded-xl border-2 border-black bg-white dark:bg-gray-800 shadow-cartoon-sm px-3 py-2"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-sm text-gray-900 dark:text-gray-100 truncate">
+              {release.albumTitle}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {release.artistName}
+              {release.releaseDate ? ` · ${release.releaseDate}` : ""}
+            </p>
+          </div>
+          <span className="text-[10px] uppercase tracking-wide font-bold rounded-full bg-amber-200 text-black border-2 border-black px-2 py-0.5">
+            {release.source}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DevPollButton() {
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const handleClick = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/followed/poll-now", { method: "POST" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setMsg("Poll triggered — reload to see updates");
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={busy}
+        className="px-3 py-1 text-xs font-bold rounded-lg border-2 border-black bg-amber-300 text-black shadow-cartoon-sm disabled:opacity-50"
+      >
+        {busy ? "Polling…" : "Dev: run poller now"}
+      </button>
+      {msg && (
+        <span className="text-xs text-gray-500 dark:text-gray-400">{msg}</span>
+      )}
+    </div>
+  );
+}
+
+export default function FollowingList() {
+  const { items, loading, error } = useFollowedArtists();
+
+  return (
+    <div className="space-y-8">
+      {import.meta.env.DEV && <DevPollButton />}
+      <section>
+        <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3">
+          Followed artists
+        </h3>
+        {loading && (
+          <div className="space-y-2">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-14 w-full rounded-xl" />
+            ))}
+          </div>
+        )}
+        {error && <p className="text-rose-500 text-sm">{error}</p>}
+        {!loading && !error && items.length === 0 && (
+          <p className="text-gray-400 dark:text-gray-500 text-sm">
+            You aren&apos;t following any artists yet. Tap the bell on any
+            artist tile to start.
+          </p>
+        )}
+        {!loading && !error && items.length > 0 && (
+          <ul className="space-y-2">
+            {items.map((follow) => (
+              <li
+                key={follow.id}
+                className="flex items-center gap-3 rounded-xl border-2 border-black bg-white dark:bg-gray-800 shadow-cartoon-sm px-3 py-2"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-sm text-gray-900 dark:text-gray-100 truncate">
+                    {follow.artistName}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {formatChecked(follow.lastCheckedAt)}
+                  </p>
+                </div>
+                <FollowArtistButton
+                  artistMbid={follow.artistMbid}
+                  artistName={follow.artistName}
+                  size="sm"
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3">
+          Recent releases
+        </h3>
+        <ReleaseFeed />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/LibraryPage/components/FollowingList.tsx
+++ b/src/pages/LibraryPage/components/FollowingList.tsx
@@ -1,8 +1,16 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import useFollowedArtists from "@/hooks/useFollowedArtists";
 import FollowArtistButton from "@/components/FollowArtistButton";
 import Skeleton from "@/components/Skeleton";
+import { SearchIcon } from "@/components/icons";
 import type { SeenReleaseItem } from "@/types";
+
+function buildSearchHref(release: SeenReleaseItem): string {
+  const query = `${release.artistName} ${release.albumTitle}`.trim();
+  const params = new URLSearchParams({ q: query, searchType: "album" });
+  return `/search?${params.toString()}`;
+}
 
 function formatChecked(iso: string | null): string {
   if (!iso) return "Never checked";
@@ -78,9 +86,14 @@ function ReleaseFeed() {
               {release.releaseDate ? ` · ${release.releaseDate}` : ""}
             </p>
           </div>
-          <span className="text-[10px] uppercase tracking-wide font-bold rounded-full bg-amber-200 text-black border-2 border-black px-2 py-0.5">
-            {release.source}
-          </span>
+          <Link
+            to={buildSearchHref(release)}
+            aria-label={`Search for ${release.albumTitle}`}
+            title={`Search for ${release.albumTitle}`}
+            className="inline-flex items-center justify-center w-8 h-8 rounded-full border-2 border-black bg-yellow-400 text-black shadow-cartoon-sm"
+          >
+            <SearchIcon className="w-4 h-4" />
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
+++ b/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import FollowingList from "../FollowingList";
+import { __resetFollowedArtistsForTests } from "@/hooks/useFollowedArtists";
+
+beforeEach(() => {
+  __resetFollowedArtistsForTests();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockEndpoints(map: Record<string, unknown>) {
+  vi.mocked(fetch).mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const key = Object.keys(map).find((k) => url.includes(k));
+    if (key) {
+      return Promise.resolve(
+        new Response(JSON.stringify(map[key]), { status: 200 })
+      );
+    }
+    return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+  });
+}
+
+describe("FollowingList", () => {
+  it("renders empty state for followed artists when none", async () => {
+    mockEndpoints({
+      "/api/followed/releases": [],
+      "/api/followed": [],
+    });
+
+    render(<FollowingList />);
+
+    expect(
+      await screen.findByText(/aren't following any artists yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders followed artists with last-checked label", async () => {
+    mockEndpoints({
+      "/api/followed/releases": [],
+      "/api/followed": [
+        {
+          id: 1,
+          artistMbid: "mbid-1",
+          artistName: "Radiohead",
+          lastCheckedAt: "2025-05-01T12:00:00.000Z",
+          createdAt: "2025-04-01",
+        },
+      ],
+    });
+
+    render(<FollowingList />);
+    expect(await screen.findByText("Radiohead")).toBeInTheDocument();
+    expect(screen.getByText(/Last checked/i)).toBeInTheDocument();
+  });
+
+  it("renders the seen-release feed when entries exist", async () => {
+    mockEndpoints({
+      "/api/followed/releases": [
+        {
+          id: 5,
+          followedArtistId: 1,
+          artistMbid: "mbid-1",
+          artistName: "Radiohead",
+          releaseKey: "k",
+          source: "musicbrainz",
+          albumTitle: "New EP",
+          releaseDate: "2025-05-01",
+          externalId: "rg-1",
+          notifiedAt: "2025-05-02",
+        },
+      ],
+      "/api/followed": [],
+    });
+
+    render(<FollowingList />);
+    await waitFor(() => {
+      expect(screen.getByText("New EP")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Radiohead/)).toBeInTheDocument();
+    expect(screen.getByText("musicbrainz")).toBeInTheDocument();
+  });
+
+  it("shows release feed error message on failure", async () => {
+    vi.mocked(fetch).mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/followed/releases")) {
+        return Promise.resolve(new Response("", { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+    });
+
+    render(<FollowingList />);
+    expect(
+      await screen.findByText(/Failed to load recent releases/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
+++ b/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import FollowingList from "../FollowingList";
 import { __resetFollowedArtistsForTests } from "@/hooks/useFollowedArtists";
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 beforeEach(() => {
   __resetFollowedArtistsForTests();
@@ -31,7 +36,7 @@ describe("FollowingList", () => {
       "/api/followed": [],
     });
 
-    render(<FollowingList />);
+    renderWithRouter(<FollowingList />);
 
     expect(
       await screen.findByText(/aren't following any artists yet/i)
@@ -52,7 +57,7 @@ describe("FollowingList", () => {
       ],
     });
 
-    render(<FollowingList />);
+    renderWithRouter(<FollowingList />);
     expect(await screen.findByText("Radiohead")).toBeInTheDocument();
     expect(screen.getByText(/Last checked/i)).toBeInTheDocument();
   });
@@ -76,12 +81,48 @@ describe("FollowingList", () => {
       "/api/followed": [],
     });
 
-    render(<FollowingList />);
+    renderWithRouter(<FollowingList />);
     await waitFor(() => {
       expect(screen.getByText("New EP")).toBeInTheDocument();
     });
     expect(screen.getByText(/Radiohead/)).toBeInTheDocument();
-    expect(screen.getByText("musicbrainz")).toBeInTheDocument();
+  });
+
+  it("renders a search link for each release", async () => {
+    vi.mocked(fetch).mockImplementation((input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/followed/releases")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                id: 5,
+                followedArtistId: 1,
+                artistMbid: "mbid-1",
+                artistName: "Radiohead",
+                releaseKey: "k",
+                source: "musicbrainz",
+                albumTitle: "New EP",
+                releaseDate: "2025-05-01",
+                externalId: "rg-1",
+                notifiedAt: "2025-05-02",
+              },
+            ]),
+            { status: 200 }
+          )
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+    });
+
+    renderWithRouter(<FollowingList />);
+
+    const link = (await screen.findByRole("link", {
+      name: /Search for New EP/i,
+    })) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe(
+      "/search?q=Radiohead+New+EP&searchType=album"
+    );
   });
 
   it("shows release feed error message on failure", async () => {
@@ -93,7 +134,7 @@ describe("FollowingList", () => {
       return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
     });
 
-    render(<FollowingList />);
+    renderWithRouter(<FollowingList />);
     expect(
       await screen.findByText(/Failed to load recent releases/i)
     ).toBeInTheDocument();

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,3 +87,26 @@ export type MonitorState =
   | "success"
   | "already_monitored"
   | "error";
+
+export type ReleaseNotificationSource = "musicbrainz" | "deezer" | "apple";
+
+export interface FollowedArtistItem {
+  id: number;
+  artistMbid: string;
+  artistName: string;
+  lastCheckedAt: string | null;
+  createdAt: string;
+}
+
+export interface SeenReleaseItem {
+  id: number;
+  followedArtistId: number;
+  artistMbid: string;
+  artistName: string;
+  releaseKey: string;
+  source: ReleaseNotificationSource;
+  albumTitle: string;
+  releaseDate: string | null;
+  externalId: string | null;
+  notifiedAt: string;
+}


### PR DESCRIPTION
## Summary
- Follow MusicBrainz artists from Discover tiles and album cards; new `/library/following` tab lists who you follow and recent releases the poller has surfaced
- Background poller (default 6h) aggregates releases across MusicBrainz, Deezer, and Apple; deduped by normalized title + release month, MB preferred
- Red notification badge on the Library nav and the Following tab when there are unseen releases; clears on tab view (server-side `users.followed_last_viewed_at`)
- Each release row links straight to `/search?q=<artist>+<album>&searchType=album`

## Out of scope
- No push/email notifications. Per-user notification preferences would need a separate model — the existing settings > notifications flow is server-level, not per-user.

## Notes
- Bundles one unrelated commit (`0416ea2 chore(seed): seed wanted items and purchases for dev`) that was already on local main when this branch was cut.

Closes #127

## Test plan
- [x] Follow an artist from a DiscoverPage tile (bell icon appears on tiles where `mbid` is known)
- [x] Follow an artist from the back of a SearchPage album card
- [x] Visit `/library/following` — followed artist appears with "Never checked" label
- [x] In dev, click "Dev: run poller now" — releases surface in the feed
- [ ] Library nav + Following tab show a red badge with the unseen count
- [ ] Click into Following — badge clears immediately and stays cleared on reload
- [x] Click the yellow search icon on a release row — lands on `/search` with results pre-loaded
- [x] Unfollow from the followed-artists list — row disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)