### PR TITLE
feat(discover): track recent listening + anti-repeat for promoted album

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { getDataSource } from "./db/index";
 import { createLogger } from "./logger";
+import type { TopArtistsRange } from "./api/plex/types";
 
 const log = createLogger("Config");
 
@@ -26,6 +27,7 @@ export type SpendingConfig = {
 
 export type PromotedAlbumConfig = {
   cacheDurationMinutes: number;
+  topArtistsRange: TopArtistsRange;
   topArtistsCount: number;
   pickedArtistsCount: number;
   tagsPerArtist: number;
@@ -77,6 +79,7 @@ export const DEFAULT_FOLLOWED_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
+  topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 3,
   tagsPerArtist: 5,
@@ -175,6 +178,13 @@ const VALID_LIBRARY_PREFERENCES: LibraryPreference[] = [
   "no_preference",
 ];
 
+const VALID_TOP_ARTISTS_RANGES: TopArtistsRange[] = [
+  "all",
+  "4weeks",
+  "6months",
+  "12months",
+];
+
 function validatePositiveInt(value: unknown, name: string) {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
     throw new Error(`${name} must be a positive integer`);
@@ -187,6 +197,11 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
     config.cacheDurationMinutes < 0
   ) {
     throw new Error("cacheDurationMinutes must be a non-negative number");
+  }
+  if (!VALID_TOP_ARTISTS_RANGES.includes(config.topArtistsRange)) {
+    throw new Error(
+      `topArtistsRange must be one of: ${VALID_TOP_ARTISTS_RANGES.join(", ")}`
+    );
   }
   validatePositiveInt(config.topArtistsCount, "topArtistsCount");
   validatePositiveInt(config.pickedArtistsCount, "pickedArtistsCount");

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -37,6 +37,7 @@ import { getPromotedAlbum, clearPromotedAlbumCache } from "./getPromotedAlbum";
 
 const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
+  topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 3,
   tagsPerArtist: 5,
@@ -121,7 +122,11 @@ describe("getPromotedAlbum", () => {
     });
     expect(result!.tag).toBe("alternative");
     expect(result!.inLibrary).toBe(false);
-    expect(mockGetTopArtists).toHaveBeenCalledWith("test-plex-token", 10);
+    expect(mockGetTopArtists).toHaveBeenCalledWith(
+      "test-plex-token",
+      10,
+      "6months"
+    );
   });
 
   it("fetches both page 1 and a deep page of tag albums", async () => {
@@ -246,7 +251,11 @@ describe("getPromotedAlbum", () => {
     mockGetTopArtists.mockClear();
 
     await getPromotedAlbum("user-b-token");
-    expect(mockGetTopArtists).toHaveBeenCalledWith("user-b-token", 10);
+    expect(mockGetTopArtists).toHaveBeenCalledWith(
+      "user-b-token",
+      10,
+      "6months"
+    );
   });
 
   it("busts cache when forceRefresh is true", async () => {
@@ -355,6 +364,38 @@ describe("getPromotedAlbum", () => {
 
     const result = await getPromotedAlbum("test-plex-token");
     expect(result).toBeNull();
+  });
+
+  describe("anti-repeat", () => {
+    it("avoids re-showing the most recent album on refresh", async () => {
+      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockGetArtistTopTags.mockResolvedValue(tags);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+      mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+      const first = await getPromotedAlbum("test-plex-token");
+      const second = await getPromotedAlbum("test-plex-token", true);
+
+      expect(first).not.toBeNull();
+      expect(second).not.toBeNull();
+      expect(second!.album.mbid).not.toBe(first!.album.mbid);
+    });
+
+    it("falls back to the full pool when every album was recently shown", async () => {
+      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockGetArtistTopTags.mockResolvedValue(tags);
+      mockGetTopAlbumsByTag.mockResolvedValue({
+        albums: [albumsPage.albums[0]],
+        pagination: { page: 1, totalPages: 1 },
+      });
+      mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+      const first = await getPromotedAlbum("test-plex-token");
+      const second = await getPromotedAlbum("test-plex-token", true);
+
+      expect(first).not.toBeNull();
+      expect(second!.album.mbid).toBe(first!.album.mbid);
+    });
   });
 
   describe("trace", () => {
@@ -484,7 +525,29 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       await getPromotedAlbum("test-plex-token");
-      expect(mockGetTopArtists).toHaveBeenCalledWith("test-plex-token", 5);
+      expect(mockGetTopArtists).toHaveBeenCalledWith(
+        "test-plex-token",
+        5,
+        "6months"
+      );
+    });
+
+    it("uses topArtistsRange from config", async () => {
+      mockGetConfigValue.mockReturnValue({
+        ...defaultPromotedAlbumConfig,
+        topArtistsRange: "4weeks",
+      });
+      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockGetArtistTopTags.mockResolvedValue(tags);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+      mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+      await getPromotedAlbum("test-plex-token");
+      expect(mockGetTopArtists).toHaveBeenCalledWith(
+        "test-plex-token",
+        10,
+        "4weeks"
+      );
     });
 
     it("uses custom genericTags from config", async () => {

--- a/server/promotedAlbum/getPromotedAlbum.ts
+++ b/server/promotedAlbum/getPromotedAlbum.ts
@@ -32,8 +32,21 @@ type CacheEntry = { result: PromotedAlbumResult; cachedAt: number };
 
 const userCache = new Map<string, CacheEntry>();
 
+const RECENT_SHOWN_LIMIT = 10;
+const recentlyShownByUser = new Map<string, string[]>();
+
 export function clearPromotedAlbumCache() {
   userCache.clear();
+  recentlyShownByUser.clear();
+}
+
+function rememberShown(plexToken: string, mbid: string) {
+  const previous = recentlyShownByUser.get(plexToken) ?? [];
+  const next = [mbid, ...previous.filter((m) => m !== mbid)].slice(
+    0,
+    RECENT_SHOWN_LIMIT
+  );
+  recentlyShownByUser.set(plexToken, next);
 }
 
 function mergeTagsFromResults(
@@ -309,7 +322,11 @@ export async function getPromotedAlbum(
     libraryArtistMbids.has(artistMbid);
   const albumInLibrary = (rgMbid: string) => libraryAlbumMbids.has(rgMbid);
 
-  const plexArtists = await getTopArtists(plexToken, config.topArtistsCount);
+  const plexArtists = await getTopArtists(
+    plexToken,
+    config.topArtistsCount,
+    config.topArtistsRange
+  );
   if (plexArtists.length === 0) return null;
 
   const pickedArtists = weightedRandomPick(
@@ -360,7 +377,11 @@ export async function getPromotedAlbum(
 
   if (allAlbums.length === 0) return null;
 
-  const shuffled = shuffle(allAlbums);
+  const recentlyShown = new Set(recentlyShownByUser.get(plexToken) ?? []);
+  const freshAlbums = allAlbums.filter((a) => !recentlyShown.has(a.mbid));
+  const candidatePool = freshAlbums.length > 0 ? freshAlbums : allAlbums;
+
+  const shuffled = shuffle(candidatePool);
 
   const picked = await selectAlbum(
     shuffled,
@@ -369,6 +390,8 @@ export async function getPromotedAlbum(
     getReleaseGroupIdFromRelease
   );
   if (!picked) return null;
+
+  rememberShown(plexToken, picked.album.mbid);
 
   const albumPoolInfo: TraceAlbumPoolInfo = {
     page1Count: page1.albums.length,

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -2,6 +2,7 @@ import type { PromotedAlbumSettings } from "./settingsContextDef";
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
   cacheDurationMinutes: 30,
+  topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 3,
   tagsPerArtist: 5,

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -5,8 +5,11 @@ export type LibraryPreference =
   | "prefer_library"
   | "no_preference";
 
+export type TopArtistsRange = "all" | "4weeks" | "6months" | "12months";
+
 export interface PromotedAlbumSettings {
   cacheDurationMinutes: number;
+  topArtistsRange: TopArtistsRange;
   topArtistsCount: number;
   pickedArtistsCount: number;
   tagsPerArtist: number;

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -1,6 +1,7 @@
 import type {
   PromotedAlbumSettings,
   LibraryPreference,
+  TopArtistsRange,
 } from "@/context/settingsContextDef";
 import { DEFAULT_PROMOTED_ALBUM } from "@/context/promotedAlbumDefaults";
 import TagListEditor from "./TagListEditor";
@@ -27,6 +28,16 @@ const LIBRARY_PREFERENCE_OPTIONS: {
   { value: "prefer_new", label: "Prefer New" },
   { value: "prefer_library", label: "Prefer Library" },
   { value: "no_preference", label: "No Preference" },
+];
+
+const TOP_ARTISTS_RANGE_OPTIONS: {
+  value: TopArtistsRange;
+  label: string;
+}[] = [
+  { value: "4weeks", label: "4 Weeks" },
+  { value: "6months", label: "6 Months" },
+  { value: "12months", label: "12 Months" },
+  { value: "all", label: "All Time" },
 ];
 
 function NumberField({
@@ -104,6 +115,33 @@ export default function RecommendationsSection({
         step={5}
         description="How long to cache a promoted album before picking a new one. Set to 0 to disable caching."
       />
+
+      <div>
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
+          Listening Window
+        </label>
+        <div className="flex rounded-lg border-2 border-black overflow-hidden shadow-cartoon-sm">
+          {TOP_ARTISTS_RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => update("topArtistsRange", opt.value)}
+              className={`flex-1 px-3 py-2 text-sm font-bold transition-colors ${
+                config.topArtistsRange === opt.value
+                  ? "bg-amber-300 text-black"
+                  : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-amber-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          How far back to look at your Plex listening when seeding
+          recommendations. Shorter windows track your current taste; longer
+          windows draw from a wider pool.
+        </p>
+      </div>
 
       <NumberField
         label="Top Artists Count"


### PR DESCRIPTION
## What & why

Two quick fixes to the promoted album feature, aimed at making Discover better for exploration.

### Range mismatch (the lag bug)
`getPromotedAlbum` called the Plex top-artists query with **no range arg**, so it always used all-time top artists — the hero recommendation never tracked recent listening shifts (meanwhile the Discover page itself defaults to a 4-week window).

Now it reads a configurable **listening window** (`topArtistsRange`), defaulting to **6 months** — recent enough to track taste shifts, wide enough to keep the seed/tag pool diverse. Exposed as a "Listening Window" segmented control in Settings → Recommendations.

### Anti-repeat
The feature had no memory of what it had shown, so hitting Shuffle could hand back the same album. Now a bounded per-user list (last 10 album mbids) is excluded from the candidate pool on refresh, with a fallback to the full pool when every candidate was recently shown.

## Changes
- `server/config.ts` — `topArtistsRange` field + default + validation (mirrors `libraryPreference`)
- `server/promotedAlbum/getPromotedAlbum.ts` — pass the range through; recently-shown tracking + filter
- `src/context/settingsContextDef.ts`, `promotedAlbumDefaults.ts`, `RecommendationsSection.tsx` — frontend type, default, and UI control kept in sync

## Testing
- `getPromotedAlbum` tests: 33 pass (added range + anti-repeat coverage)
- Server suite: 832 pass · Client suite: 771 pass
- Both typechecks clean · lint clean · formatted

## Not in this PR
The deeper "taste echo chamber" problem (the tag pick is weighted by listening, so it favors your dominant genre every time) is being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)