### PR TITLE
feat(discover): explore mode — similar vibe, different genre

### DIFF
--- a/server/api/listenbrainz/config.ts
+++ b/server/api/listenbrainz/config.ts
@@ -1,0 +1,9 @@
+export const LISTENBRAINZ_LABS_BASE = "https://labs.api.listenbrainz.org";
+
+/**
+ * Session-based collaborative similarity: artists frequently played in the same
+ * listening sessions. Crosses genres while preserving "vibe", unlike tag-based
+ * similarity.
+ */
+export const DEFAULT_SIMILAR_ARTISTS_ALGORITHM =
+  "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30";

--- a/server/api/listenbrainz/similarArtists.test.ts
+++ b/server/api/listenbrainz/similarArtists.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockResilientFetch = vi.fn();
+
+vi.mock("../resilientFetch", () => ({
+  resilientFetch: (...args: unknown[]) => mockResilientFetch(...args),
+}));
+
+import { getSimilarArtists } from "./similarArtists";
+
+const sampleResponse = [
+  {
+    artist_mbid: "mbid-nirvana",
+    name: "Nirvana",
+    comment: "grunge band",
+    type: "Group",
+    gender: null,
+    score: 9000,
+    reference_mbid: "mbid-seed",
+  },
+  {
+    artist_mbid: "mbid-muse",
+    name: "Muse",
+    comment: "",
+    type: "Group",
+    gender: null,
+    score: 11000,
+    reference_mbid: "mbid-seed",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSimilarArtists", () => {
+  it("returns artists sorted by descending score", async () => {
+    mockResilientFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleResponse),
+    });
+
+    const result = await getSimilarArtists("mbid-seed");
+    expect(result.map((a) => a.name)).toEqual(["Muse", "Nirvana"]);
+  });
+
+  it("passes the artist mbid and algorithm in the query", async () => {
+    mockResilientFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    await getSimilarArtists("mbid-seed", "custom_algo");
+    const url = mockResilientFetch.mock.calls[0][0] as string;
+    expect(url).toContain("artist_mbids=mbid-seed");
+    expect(url).toContain("algorithm=custom_algo");
+  });
+
+  it("filters out the seed artist and unnamed entries", async () => {
+    mockResilientFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { ...sampleResponse[0], artist_mbid: "mbid-seed" },
+          { ...sampleResponse[1], name: "" },
+          sampleResponse[0],
+        ]),
+    });
+
+    const result = await getSimilarArtists("mbid-seed");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Nirvana");
+  });
+
+  it("returns [] on a non-ok response", async () => {
+    mockResilientFetch.mockResolvedValue({ ok: false, json: () => {} });
+    expect(await getSimilarArtists("mbid-seed")).toEqual([]);
+  });
+
+  it("returns [] when the response is not an array", async () => {
+    mockResilientFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ error: "nope" }),
+    });
+    expect(await getSimilarArtists("mbid-seed")).toEqual([]);
+  });
+
+  it("returns [] when the fetch throws", async () => {
+    mockResilientFetch.mockRejectedValue(new Error("network"));
+    expect(await getSimilarArtists("mbid-seed")).toEqual([]);
+  });
+});

--- a/server/api/listenbrainz/similarArtists.ts
+++ b/server/api/listenbrainz/similarArtists.ts
@@ -1,0 +1,34 @@
+import { resilientFetch } from "../resilientFetch";
+import {
+  LISTENBRAINZ_LABS_BASE,
+  DEFAULT_SIMILAR_ARTISTS_ALGORITHM,
+} from "./config";
+import type { ListenBrainzSimilarArtist } from "./types";
+
+/**
+ * Fetch session-based similar artists for a MusicBrainz artist MBID, sorted by
+ * descending similarity score. Returns an empty array on any failure — callers
+ * treat this as a best-effort signal.
+ */
+export async function getSimilarArtists(
+  artistMbid: string,
+  algorithm: string = DEFAULT_SIMILAR_ARTISTS_ALGORITHM
+): Promise<ListenBrainzSimilarArtist[]> {
+  const url = `${LISTENBRAINZ_LABS_BASE}/similar-artists/json?artist_mbids=${encodeURIComponent(
+    artistMbid
+  )}&algorithm=${encodeURIComponent(algorithm)}`;
+
+  try {
+    const response = await resilientFetch(url);
+    if (!response.ok) return [];
+
+    const data = (await response.json()) as ListenBrainzSimilarArtist[];
+    if (!Array.isArray(data)) return [];
+
+    return data
+      .filter((a) => a.artist_mbid && a.artist_mbid !== artistMbid && a.name)
+      .sort((a, b) => b.score - a.score);
+  } catch {
+    return [];
+  }
+}

--- a/server/api/listenbrainz/types.ts
+++ b/server/api/listenbrainz/types.ts
@@ -1,0 +1,9 @@
+export type ListenBrainzSimilarArtist = {
+  artist_mbid: string;
+  name: string;
+  comment: string;
+  type: string | null;
+  gender: string | null;
+  score: number;
+  reference_mbid: string;
+};

--- a/server/api/musicbrainz/artists.test.ts
+++ b/server/api/musicbrainz/artists.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRateLimitedMbFetch = vi.fn();
+
+vi.mock("./config", () => ({
+  MB_BASE: "https://musicbrainz.org/ws/2",
+  MB_HEADERS: { "User-Agent": "test" },
+  rateLimitedMbFetch: (...args: unknown[]) => mockRateLimitedMbFetch(...args),
+}));
+
+import { getArtistMbidByName, clearArtistMbidCache } from "./artists";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearArtistMbidCache();
+});
+
+describe("getArtistMbidByName", () => {
+  it("returns the top-matching artist's MBID", async () => {
+    mockRateLimitedMbFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ artists: [{ id: "mbid-1", name: "X" }] }),
+    });
+
+    expect(await getArtistMbidByName("Radiohead")).toBe("mbid-1");
+  });
+
+  it("returns null when there are no matches", async () => {
+    mockRateLimitedMbFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ artists: [] }),
+    });
+
+    expect(await getArtistMbidByName("Nonexistent Band")).toBeNull();
+  });
+
+  it("caches results across calls (including misses)", async () => {
+    mockRateLimitedMbFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ artists: [{ id: "mbid-1", name: "X" }] }),
+    });
+
+    await getArtistMbidByName("Radiohead");
+    await getArtistMbidByName("radiohead");
+    expect(mockRateLimitedMbFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache transient failures", async () => {
+    mockRateLimitedMbFetch.mockResolvedValueOnce({ ok: false, json: () => {} });
+    expect(await getArtistMbidByName("Radiohead")).toBeNull();
+
+    mockRateLimitedMbFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ artists: [{ id: "mbid-1", name: "X" }] }),
+    });
+    expect(await getArtistMbidByName("Radiohead")).toBe("mbid-1");
+    expect(mockRateLimitedMbFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when the fetch throws", async () => {
+    mockRateLimitedMbFetch.mockRejectedValue(new Error("network"));
+    expect(await getArtistMbidByName("Radiohead")).toBeNull();
+  });
+});

--- a/server/api/musicbrainz/artists.ts
+++ b/server/api/musicbrainz/artists.ts
@@ -1,0 +1,34 @@
+import { MB_BASE, MB_HEADERS, rateLimitedMbFetch } from "./config";
+import type { MusicBrainzArtistSearchResponse } from "./types";
+
+const mbidCache = new Map<string, string | null>();
+
+export function clearArtistMbidCache() {
+  mbidCache.clear();
+}
+
+/**
+ * Resolve an artist name to its top-matching MusicBrainz artist MBID. Results
+ * are cached for the process lifetime (including misses). Returns null when no
+ * match is found; transient fetch failures are not cached.
+ */
+export async function getArtistMbidByName(
+  name: string
+): Promise<string | null> {
+  const key = name.toLowerCase();
+  const cached = mbidCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const url = `${MB_BASE}/artist/?query=${encodeURIComponent(name)}&limit=1&fmt=json`;
+  try {
+    const response = await rateLimitedMbFetch(url, { headers: MB_HEADERS });
+    if (!response.ok) return null;
+
+    const data: MusicBrainzArtistSearchResponse = await response.json();
+    const mbid = data.artists?.[0]?.id ?? null;
+    mbidCache.set(key, mbid);
+    return mbid;
+  } catch {
+    return null;
+  }
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -35,6 +35,9 @@ export type PromotedAlbumConfig = {
   deepPageMax: number;
   genericTags: string[];
   libraryPreference: LibraryPreference;
+  explorationRate: number;
+  exploreCandidateCount: number;
+  genreOverlapThreshold: number;
 };
 
 export type IConfig = {
@@ -100,6 +103,9 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
     "all",
   ],
   libraryPreference: "prefer_new",
+  explorationRate: 0.5,
+  exploreCandidateCount: 12,
+  genreOverlapThreshold: 0.15,
 };
 
 const DEFAULT_CONFIG: IConfig = {
@@ -191,6 +197,12 @@ function validatePositiveInt(value: unknown, name: string) {
   }
 }
 
+function validateRatio(value: unknown, name: string) {
+  if (typeof value !== "number" || value < 0 || value > 1) {
+    throw new Error(`${name} must be a number between 0 and 1`);
+  }
+}
+
 function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
   if (
     typeof config.cacheDurationMinutes !== "number" ||
@@ -214,6 +226,9 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
   if (!Array.isArray(config.genericTags)) {
     throw new Error("genericTags must be an array");
   }
+  validateRatio(config.explorationRate, "explorationRate");
+  validatePositiveInt(config.exploreCandidateCount, "exploreCandidateCount");
+  validateRatio(config.genreOverlapThreshold, "genreOverlapThreshold");
   if (
     !VALID_LIBRARY_PREFERENCES.includes(
       config.libraryPreference as LibraryPreference

--- a/server/promotedAlbum/explore.ts
+++ b/server/promotedAlbum/explore.ts
@@ -1,0 +1,236 @@
+import { getSimilarArtists } from "../api/listenbrainz/similarArtists";
+import { getArtistMbidByName } from "../api/musicbrainz/artists";
+import { fetchReleaseGroupsForArtist } from "../api/musicbrainz/releaseGroups";
+import { getArtistTopTags } from "../api/lastfm/artists";
+import type { MusicBrainzReleaseGroup } from "../api/musicbrainz/types";
+import type { ListenBrainzSimilarArtist } from "../api/listenbrainz/types";
+import type { PromotedAlbumConfig } from "../config";
+import { weightedRandomPick, shuffle } from "../utils/random";
+import type {
+  BuiltAlbum,
+  ExploreResult,
+  ExploreTrace,
+  TraceSelectionReason,
+  TraceSimilarArtist,
+} from "./types";
+
+type SeedArtist = { name: string; viewCount: number };
+
+type ExploreContext = {
+  plexArtists: SeedArtist[];
+  config: PromotedAlbumConfig;
+  recentlyShown: Set<string>;
+  artistInLibrary: (artistMbid: string) => boolean;
+  albumInLibrary: (rgMbid: string) => boolean;
+};
+
+type EvaluatedCandidate = {
+  candidate: ListenBrainzSimilarArtist;
+  genres: Set<string>;
+  overlap: number;
+  isDifferentGenre: boolean;
+};
+
+const SEED_GENRE_LIMIT = 8;
+
+async function safeTopTags(
+  name: string
+): Promise<{ name: string; count: number }[]> {
+  try {
+    return await getArtistTopTags(name);
+  } catch {
+    return [];
+  }
+}
+
+function buildGenreSet(
+  tags: { name: string; count: number }[],
+  genericTags: Set<string>,
+  limit: number
+): Set<string> {
+  const set = new Set<string>();
+  for (const t of tags) {
+    const name = t.name.toLowerCase();
+    if (genericTags.has(name)) continue;
+    set.add(name);
+    if (set.size >= limit) break;
+  }
+  return set;
+}
+
+/** Jaccard similarity of two genre sets (0 = disjoint, 1 = identical). */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const x of a) if (b.has(x)) intersection += 1;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function evaluateCandidates(
+  candidates: ListenBrainzSimilarArtist[],
+  tagSets: { name: string; count: number }[][],
+  seedGenres: Set<string>,
+  genericTags: Set<string>,
+  threshold: number
+): EvaluatedCandidate[] {
+  return candidates.map((candidate, i) => {
+    const genres = buildGenreSet(tagSets[i], genericTags, SEED_GENRE_LIMIT);
+    const overlap = jaccard(seedGenres, genres);
+    return {
+      candidate,
+      genres,
+      overlap,
+      isDifferentGenre: genres.size > 0 && overlap <= threshold,
+    };
+  });
+}
+
+async function pickAlbumFromArtist(
+  artistMbid: string,
+  recentlyShown: Set<string>
+): Promise<MusicBrainzReleaseGroup | null> {
+  const releaseGroups = await fetchReleaseGroupsForArtist(artistMbid);
+  const albums = releaseGroups.filter(
+    (rg) => rg["primary-type"] === "Album" && rg["first-release-date"] && rg.id
+  );
+  if (albums.length === 0) return null;
+
+  const shuffled = shuffle(albums);
+  const fresh = shuffled.filter((rg) => !recentlyShown.has(rg.id));
+  const pool = fresh.length > 0 ? fresh : shuffled;
+  return pool[0] ?? null;
+}
+
+function buildExploreTrace(
+  seedArtist: string,
+  seedGenres: Set<string>,
+  evaluated: EvaluatedCandidate[],
+  chosen: EvaluatedCandidate,
+  newGenres: string[],
+  selectionReason: TraceSelectionReason
+): ExploreTrace {
+  const candidates: TraceSimilarArtist[] = evaluated.map((e) => ({
+    name: e.candidate.name,
+    score: e.candidate.score,
+    genres: [...e.genres],
+    genreOverlap: e.overlap,
+    isDifferentGenre: e.isDifferentGenre,
+    chosen: e.candidate.artist_mbid === chosen.candidate.artist_mbid,
+  }));
+
+  return {
+    kind: "explore",
+    seedArtist,
+    seedGenres: [...seedGenres],
+    candidates,
+    chosenArtist: chosen.candidate.name,
+    chosenGenres: [...chosen.genres],
+    newGenres,
+    selectionReason,
+  };
+}
+
+function assembleResult(
+  ctx: ExploreContext,
+  seedArtist: string,
+  seedGenres: Set<string>,
+  evaluated: EvaluatedCandidate[],
+  chosen: EvaluatedCandidate,
+  album: MusicBrainzReleaseGroup
+): BuiltAlbum {
+  const newGenres = [...chosen.genres].filter((g) => !seedGenres.has(g));
+  const selectionReason: TraceSelectionReason = ctx.artistInLibrary(
+    chosen.candidate.artist_mbid
+  )
+    ? "fallback_in_library"
+    : "preferred_non_library";
+
+  const result: ExploreResult = {
+    mode: "explore",
+    album: {
+      name: album.title,
+      mbid: album.id,
+      artistName: chosen.candidate.name,
+      artistMbid: chosen.candidate.artist_mbid,
+      coverUrl: `https://coverartarchive.org/release-group/${album.id}/front-500`,
+      year: (album["first-release-date"] || "").slice(0, 4),
+    },
+    seedArtist,
+    newGenres,
+    inLibrary: ctx.albumInLibrary(album.id),
+    trace: buildExploreTrace(
+      seedArtist,
+      seedGenres,
+      evaluated,
+      chosen,
+      newGenres,
+      selectionReason
+    ),
+  };
+
+  return { result, rememberKey: album.id };
+}
+
+/**
+ * "Similar vibe, different genre": seed from a top Plex artist, find artists
+ * people play alongside them (ListenBrainz), keep only those in a genre the
+ * seed doesn't share, and surface an album by one of them. Returns null when no
+ * genre-distant candidate yields an album — the caller falls back to
+ * within-taste.
+ */
+export async function buildExploreResult(
+  ctx: ExploreContext
+): Promise<BuiltAlbum | null> {
+  const { plexArtists, config, recentlyShown } = ctx;
+  const genericTags = new Set(config.genericTags.map((t) => t.toLowerCase()));
+
+  const [seed] = weightedRandomPick(plexArtists, (a) => a.viewCount, 1);
+  if (!seed) return null;
+
+  const seedMbid = await getArtistMbidByName(seed.name);
+  if (!seedMbid) return null;
+
+  const similar = await getSimilarArtists(seedMbid);
+  if (similar.length === 0) return null;
+
+  const seedGenres = buildGenreSet(
+    await safeTopTags(seed.name),
+    genericTags,
+    SEED_GENRE_LIMIT
+  );
+  if (seedGenres.size === 0) return null;
+
+  const candidates = similar.slice(0, config.exploreCandidateCount);
+  const tagSets = await Promise.all(candidates.map((c) => safeTopTags(c.name)));
+  const evaluated = evaluateCandidates(
+    candidates,
+    tagSets,
+    seedGenres,
+    genericTags,
+    config.genreOverlapThreshold
+  );
+
+  const ranked = evaluated
+    .filter((e) => e.isDifferentGenre)
+    .sort((a, b) => b.candidate.score - a.candidate.score);
+
+  for (const chosen of ranked) {
+    const album = await pickAlbumFromArtist(
+      chosen.candidate.artist_mbid,
+      recentlyShown
+    );
+    if (album) {
+      return assembleResult(
+        ctx,
+        seed.name,
+        seedGenres,
+        evaluated,
+        chosen,
+        album
+      );
+    }
+  }
+
+  return null;
+}

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -6,7 +6,10 @@ const mockGetArtistTopTags = vi.fn();
 const mockGetTopAlbumsByTag = vi.fn();
 const mockLidarrGet = vi.fn();
 const mockGetReleaseGroupIdFromRelease = vi.fn();
+const mockFetchReleaseGroupsForArtist = vi.fn();
 const mockGetConfigValue = vi.fn();
+const mockGetSimilarArtists = vi.fn();
+const mockGetArtistMbidByName = vi.fn();
 
 vi.mock("../api/plex/topArtists", () => ({
   getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
@@ -27,6 +30,16 @@ vi.mock("../api/lidarr/get", () => ({
 vi.mock("../api/musicbrainz/releaseGroups", () => ({
   getReleaseGroupIdFromRelease: (...args: unknown[]) =>
     mockGetReleaseGroupIdFromRelease(...args),
+  fetchReleaseGroupsForArtist: (...args: unknown[]) =>
+    mockFetchReleaseGroupsForArtist(...args),
+}));
+
+vi.mock("../api/listenbrainz/similarArtists", () => ({
+  getSimilarArtists: (...args: unknown[]) => mockGetSimilarArtists(...args),
+}));
+
+vi.mock("../api/musicbrainz/artists", () => ({
+  getArtistMbidByName: (...args: unknown[]) => mockGetArtistMbidByName(...args),
 }));
 
 vi.mock("../config", () => ({
@@ -34,11 +47,34 @@ vi.mock("../config", () => ({
 }));
 
 import { getPromotedAlbum, clearPromotedAlbumCache } from "./getPromotedAlbum";
+import type { WithinTasteResult, ExploreResult } from "./types";
+
+/** Narrows a result to within-taste; the suite forces this via explorationRate: 0. */
+function wt(
+  result: Awaited<ReturnType<typeof getPromotedAlbum>>
+): WithinTasteResult {
+  if (!result || result.mode !== "within_taste") {
+    throw new Error("expected a within_taste result");
+  }
+  return result;
+}
+
+function ex(
+  result: Awaited<ReturnType<typeof getPromotedAlbum>>
+): ExploreResult {
+  if (!result || result.mode !== "explore") {
+    throw new Error("expected an explore result");
+  }
+  return result;
+}
 
 const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
   topArtistsRange: "6months",
   topArtistsCount: 10,
+  explorationRate: 0,
+  exploreCandidateCount: 12,
+  genreOverlapThreshold: 0.15,
   pickedArtistsCount: 3,
   tagsPerArtist: 5,
   deepPageMin: 2,
@@ -120,7 +156,7 @@ describe("getPromotedAlbum", () => {
       ),
       year: "1997",
     });
-    expect(result!.tag).toBe("alternative");
+    expect(wt(result).tag).toBe("alternative");
     expect(result!.inLibrary).toBe(false);
     expect(mockGetTopArtists).toHaveBeenCalledWith(
       "test-plex-token",
@@ -406,8 +442,8 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      expect(result!.trace.plexArtists).toHaveLength(2);
-      expect(result!.trace.plexArtists.map((a) => a.name)).toEqual([
+      expect(wt(result).trace.plexArtists).toHaveLength(2);
+      expect(wt(result).trace.plexArtists.map((a) => a.name)).toEqual([
         "Radiohead",
         "Bjork",
       ]);
@@ -420,7 +456,7 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      const picked = result!.trace.plexArtists.filter((a) => a.picked);
+      const picked = wt(result).trace.plexArtists.filter((a) => a.picked);
       expect(picked).toHaveLength(2);
     });
 
@@ -431,7 +467,7 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      expect(result!.trace.chosenTag.name).toBe(result!.tag);
+      expect(wt(result).trace.chosenTag.name).toBe(wt(result).tag);
     });
 
     it("albumPool counts are accurate", async () => {
@@ -441,11 +477,12 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      expect(result!.trace.albumPool.page1Count).toBe(2);
-      expect(result!.trace.albumPool.deepPageCount).toBe(2);
-      expect(result!.trace.albumPool.totalAfterDedup).toBe(2);
-      expect(result!.trace.albumPool.deepPage).toBeGreaterThanOrEqual(2);
-      expect(result!.trace.albumPool.deepPage).toBeLessThanOrEqual(10);
+      const { albumPool } = wt(result).trace;
+      expect(albumPool.page1Count).toBe(2);
+      expect(albumPool.deepPageCount).toBe(2);
+      expect(albumPool.totalAfterDedup).toBe(2);
+      expect(albumPool.deepPage).toBeGreaterThanOrEqual(2);
+      expect(albumPool.deepPage).toBeLessThanOrEqual(10);
     });
 
     it("selectionReason is preferred_non_library when artist not in library", async () => {
@@ -489,7 +526,7 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      const altTag = result!.trace.weightedTags.find(
+      const altTag = wt(result).trace.weightedTags.find(
         (t) => t.name === "alternative"
       );
       expect(altTag).toBeDefined();
@@ -505,7 +542,7 @@ describe("getPromotedAlbum", () => {
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       const result = await getPromotedAlbum("test-plex-token");
-      const radiohead = result!.trace.plexArtists.find(
+      const radiohead = wt(result).trace.plexArtists.find(
         (a) => a.name === "Radiohead"
       );
       expect(radiohead!.tagContributions).toHaveLength(2);
@@ -562,7 +599,7 @@ describe("getPromotedAlbum", () => {
 
       const result = await getPromotedAlbum("test-plex-token");
       if (result) {
-        expect(result.tag).toBe("rock");
+        expect(wt(result).tag).toBe("rock");
       }
     });
 
@@ -638,6 +675,152 @@ describe("getPromotedAlbum", () => {
       await getPromotedAlbum("test-plex-token");
       const calls = mockGetTopAlbumsByTag.mock.calls;
       expect(calls[1][1]).toBe("5");
+    });
+  });
+
+  describe("explore mode", () => {
+    const exploreConfig = { ...defaultPromotedAlbumConfig, explorationRate: 1 };
+
+    const similarArtists = [
+      {
+        artist_mbid: "mbid-rock",
+        name: "Rock Clone",
+        comment: "",
+        type: "Group",
+        gender: null,
+        score: 9000,
+        reference_mbid: "mbid-seed",
+      },
+      {
+        artist_mbid: "mbid-jazz",
+        name: "Jazz Cat",
+        comment: "",
+        type: "Group",
+        gender: null,
+        score: 5000,
+        reference_mbid: "mbid-seed",
+      },
+    ];
+
+    const genreByArtist: Record<string, { name: string; count: number }[]> = {
+      Radiohead: [
+        { name: "alternative", count: 100 },
+        { name: "rock", count: 80 },
+      ],
+      "Rock Clone": [
+        { name: "alternative", count: 100 },
+        { name: "rock", count: 80 },
+      ],
+      "Jazz Cat": [
+        { name: "jazz", count: 100 },
+        { name: "bebop", count: 50 },
+      ],
+    };
+
+    const jazzReleaseGroups = [
+      {
+        id: "rg-jazz-1",
+        score: 1,
+        title: "Blue Album",
+        "primary-type": "Album",
+        "first-release-date": "1965-03-01",
+        "artist-credit": [
+          { name: "Jazz Cat", artist: { id: "mbid-jazz", name: "Jazz Cat" } },
+        ],
+      },
+    ];
+
+    function setupExplore() {
+      mockGetConfigValue.mockReturnValue(exploreConfig);
+      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockGetArtistMbidByName.mockResolvedValue("mbid-seed");
+      mockGetSimilarArtists.mockResolvedValue(similarArtists);
+      mockGetArtistTopTags.mockImplementation((name: string) =>
+        Promise.resolve(genreByArtist[name] ?? [])
+      );
+      mockFetchReleaseGroupsForArtist.mockImplementation((mbid: string) =>
+        Promise.resolve(mbid === "mbid-jazz" ? jazzReleaseGroups : [])
+      );
+      mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+    }
+
+    it("surfaces a genre-distant album from a similar artist", async () => {
+      setupExplore();
+
+      const result = await getPromotedAlbum("test-plex-token");
+      expect(ex(result).mode).toBe("explore");
+      expect(ex(result).seedArtist).toBe("Radiohead");
+      expect(ex(result).album.name).toBe("Blue Album");
+      expect(ex(result).album.artistName).toBe("Jazz Cat");
+      expect(ex(result).album.mbid).toBe("rg-jazz-1");
+      expect(ex(result).album.year).toBe("1965");
+    });
+
+    it("reports the new genres the seed does not share", async () => {
+      setupExplore();
+
+      const result = await getPromotedAlbum("test-plex-token");
+      expect(ex(result).newGenres).toEqual(["jazz", "bebop"]);
+    });
+
+    it("chooses the genre-distant candidate, not the same-genre one", async () => {
+      setupExplore();
+
+      const result = await getPromotedAlbum("test-plex-token");
+      const { candidates, chosenArtist } = ex(result).trace;
+      expect(chosenArtist).toBe("Jazz Cat");
+
+      const jazz = candidates.find((c) => c.name === "Jazz Cat");
+      const rock = candidates.find((c) => c.name === "Rock Clone");
+      expect(jazz!.isDifferentGenre).toBe(true);
+      expect(jazz!.chosen).toBe(true);
+      expect(rock!.isDifferentGenre).toBe(false);
+      expect(rock!.chosen).toBe(false);
+    });
+
+    it("falls back to within-taste when the seed has no MBID", async () => {
+      setupExplore();
+      mockGetArtistMbidByName.mockResolvedValue(null);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+
+      const result = await getPromotedAlbum("test-plex-token");
+      expect(result!.mode).toBe("within_taste");
+    });
+
+    it("falls back to within-taste when ListenBrainz returns no similar artists", async () => {
+      setupExplore();
+      mockGetSimilarArtists.mockResolvedValue([]);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+
+      const result = await getPromotedAlbum("test-plex-token");
+      expect(result!.mode).toBe("within_taste");
+    });
+
+    it("falls back to within-taste when no candidate is a different genre", async () => {
+      setupExplore();
+      mockGetArtistTopTags.mockResolvedValue(genreByArtist["Radiohead"]);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+
+      const result = await getPromotedAlbum("test-plex-token");
+      expect(result!.mode).toBe("within_taste");
+    });
+
+    it("does not repeat the most recent album across refreshes", async () => {
+      setupExplore();
+      mockFetchReleaseGroupsForArtist.mockImplementation((mbid: string) =>
+        Promise.resolve(
+          mbid === "mbid-jazz"
+            ? [
+                jazzReleaseGroups[0],
+                { ...jazzReleaseGroups[0], id: "rg-jazz-2", title: "Green" },
+              ]
+            : []
+        )
+      );
+
+      const first = await getPromotedAlbum("test-plex-token");
+      const second = await getPromotedAlbum("test-plex-token", true);
+      expect(ex(first).album.mbid).not.toBe(ex(second).album.mbid);
     });
   });
 });

--- a/server/promotedAlbum/getPromotedAlbum.ts
+++ b/server/promotedAlbum/getPromotedAlbum.ts
@@ -6,11 +6,14 @@ import type { LidarrAlbum, LidarrArtist } from "../api/lidarr/types";
 import { getReleaseGroupIdFromRelease } from "../api/musicbrainz/releaseGroups";
 import type { ReleaseGroupInfo } from "../api/musicbrainz/types";
 import { getConfigValue } from "../config";
-import type { LibraryPreference } from "../config";
+import type { LibraryPreference, PromotedAlbumConfig } from "../config";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { buildExploreResult } from "./explore";
 import type {
+  BuiltAlbum,
   PromotedAlbumResult,
-  RecommendationTrace,
+  WithinTasteResult,
+  WithinTasteTrace,
   TraceArtistEntry,
   TraceAlbumPoolInfo,
   TraceSelectionReason,
@@ -18,6 +21,14 @@ import type {
 } from "./types";
 
 export type { PromotedAlbumResult } from "./types";
+
+type BuildContext = {
+  plexArtists: { name: string; viewCount: number }[];
+  config: PromotedAlbumConfig;
+  recentlyShown: Set<string>;
+  artistInLibrary: (artistMbid: string) => boolean;
+  albumInLibrary: (rgMbid: string) => boolean;
+};
 
 type WeightedTag = { name: string; weight: number };
 
@@ -104,7 +115,7 @@ function buildTrace(
   selectionReason: TraceSelectionReason,
   genericTags: Set<string>,
   tagsPerArtist: number
-): RecommendationTrace {
+): WithinTasteTrace {
   const traceArtists: TraceArtistEntry[] = plexArtists.map((a) => {
     const picked = pickedArtistNames.has(a.name);
     const result = tagResults.find((r) => r.artist.name === a.name);
@@ -137,6 +148,7 @@ function buildTrace(
   });
 
   return {
+    kind: "within_taste",
     plexArtists: traceArtists,
     weightedTags: traceWeightedTags,
     chosenTag: { name: chosenTag.name, weight: chosenTag.weight },
@@ -279,55 +291,17 @@ function selectAlbum(
   }
 }
 
-export async function getPromotedAlbum(
-  plexToken: string,
-  forceRefresh = false
-): Promise<PromotedAlbumResult> {
-  const config = getConfigValue("promotedAlbum");
-  const cacheDurationMs = config.cacheDurationMinutes * 60 * 1000;
-
-  const cached = userCache.get(plexToken);
-  if (
-    !forceRefresh &&
-    cached &&
-    Date.now() - cached.cachedAt < cacheDurationMs
-  ) {
-    return cached.result;
-  }
-
+async function buildWithinTasteResult(
+  ctx: BuildContext
+): Promise<BuiltAlbum | null> {
+  const {
+    plexArtists,
+    config,
+    recentlyShown,
+    artistInLibrary,
+    albumInLibrary,
+  } = ctx;
   const genericTags = new Set(config.genericTags.map((t) => t.toLowerCase()));
-
-  let libraryArtistMbids = new Set<string>();
-  let libraryAlbumMbids = new Set<string>();
-  try {
-    const [artistResult, albumResult] = await Promise.all([
-      lidarrGet<LidarrArtist[]>("/artist"),
-      lidarrGet<LidarrAlbum[]>("/album"),
-    ]);
-    if (artistResult.ok) {
-      libraryArtistMbids = new Set(
-        artistResult.data.map((a) => a.foreignArtistId)
-      );
-    }
-    if (albumResult.ok) {
-      libraryAlbumMbids = new Set(
-        albumResult.data.map((a) => a.foreignAlbumId)
-      );
-    }
-  } catch {
-    // Lidarr unavailable — treat all as not in library
-  }
-
-  const artistInLibrary = (artistMbid: string) =>
-    libraryArtistMbids.has(artistMbid);
-  const albumInLibrary = (rgMbid: string) => libraryAlbumMbids.has(rgMbid);
-
-  const plexArtists = await getTopArtists(
-    plexToken,
-    config.topArtistsCount,
-    config.topArtistsRange
-  );
-  if (plexArtists.length === 0) return null;
 
   const pickedArtists = weightedRandomPick(
     plexArtists,
@@ -352,7 +326,6 @@ export async function getPromotedAlbum(
     genericTags,
     config.tagsPerArtist
   );
-
   if (weightedTags.length === 0) return null;
 
   const [chosenTag] = weightedRandomPick(weightedTags, (t) => t.weight, 1);
@@ -374,13 +347,10 @@ export async function getPromotedAlbum(
     seen.add(a.mbid);
     return true;
   });
-
   if (allAlbums.length === 0) return null;
 
-  const recentlyShown = new Set(recentlyShownByUser.get(plexToken) ?? []);
   const freshAlbums = allAlbums.filter((a) => !recentlyShown.has(a.mbid));
   const candidatePool = freshAlbums.length > 0 ? freshAlbums : allAlbums;
-
   const shuffled = shuffle(candidatePool);
 
   const picked = await selectAlbum(
@@ -390,8 +360,6 @@ export async function getPromotedAlbum(
     getReleaseGroupIdFromRelease
   );
   if (!picked) return null;
-
-  rememberShown(plexToken, picked.album.mbid);
 
   const albumPoolInfo: TraceAlbumPoolInfo = {
     page1Count: page1.albums.length,
@@ -412,7 +380,8 @@ export async function getPromotedAlbum(
     config.tagsPerArtist
   );
 
-  const result: PromotedAlbumResult = {
+  const result: WithinTasteResult = {
+    mode: "within_taste",
     album: {
       name: picked.album.name,
       mbid: picked.rgMbid,
@@ -426,7 +395,84 @@ export async function getPromotedAlbum(
     trace,
   };
 
-  userCache.set(plexToken, { result, cachedAt: Date.now() });
+  return { result, rememberKey: picked.album.mbid };
+}
 
-  return result;
+async function loadLibraryMbids(): Promise<{
+  artistInLibrary: (mbid: string) => boolean;
+  albumInLibrary: (mbid: string) => boolean;
+}> {
+  let libraryArtistMbids = new Set<string>();
+  let libraryAlbumMbids = new Set<string>();
+  try {
+    const [artistResult, albumResult] = await Promise.all([
+      lidarrGet<LidarrArtist[]>("/artist"),
+      lidarrGet<LidarrAlbum[]>("/album"),
+    ]);
+    if (artistResult.ok) {
+      libraryArtistMbids = new Set(
+        artistResult.data.map((a) => a.foreignArtistId)
+      );
+    }
+    if (albumResult.ok) {
+      libraryAlbumMbids = new Set(
+        albumResult.data.map((a) => a.foreignAlbumId)
+      );
+    }
+  } catch {
+    // Lidarr unavailable — treat all as not in library
+  }
+
+  return {
+    artistInLibrary: (mbid) => libraryArtistMbids.has(mbid),
+    albumInLibrary: (mbid) => libraryAlbumMbids.has(mbid),
+  };
+}
+
+export async function getPromotedAlbum(
+  plexToken: string,
+  forceRefresh = false
+): Promise<PromotedAlbumResult> {
+  const config = getConfigValue("promotedAlbum");
+  const cacheDurationMs = config.cacheDurationMinutes * 60 * 1000;
+
+  const cached = userCache.get(plexToken);
+  if (
+    !forceRefresh &&
+    cached &&
+    Date.now() - cached.cachedAt < cacheDurationMs
+  ) {
+    return cached.result;
+  }
+
+  const { artistInLibrary, albumInLibrary } = await loadLibraryMbids();
+
+  const plexArtists = await getTopArtists(
+    plexToken,
+    config.topArtistsCount,
+    config.topArtistsRange
+  );
+  if (plexArtists.length === 0) return null;
+
+  const ctx: BuildContext = {
+    plexArtists,
+    config,
+    recentlyShown: new Set(recentlyShownByUser.get(plexToken) ?? []),
+    artistInLibrary,
+    albumInLibrary,
+  };
+
+  let built: BuiltAlbum | null = null;
+  if (Math.random() < config.explorationRate) {
+    built = await buildExploreResult(ctx);
+  }
+  if (!built) {
+    built = await buildWithinTasteResult(ctx);
+  }
+  if (!built) return null;
+
+  rememberShown(plexToken, built.rememberKey);
+  userCache.set(plexToken, { result: built.result, cachedAt: Date.now() });
+
+  return built.result;
 }

--- a/server/promotedAlbum/types.ts
+++ b/server/promotedAlbum/types.ts
@@ -31,7 +31,8 @@ export type TraceSelectionReason =
   | "fallback_non_library"
   | "no_preference";
 
-export type RecommendationTrace = {
+export type WithinTasteTrace = {
+  kind: "within_taste";
   plexArtists: TraceArtistEntry[];
   weightedTags: TraceWeightedTag[];
   chosenTag: { name: string; weight: number };
@@ -39,16 +40,58 @@ export type RecommendationTrace = {
   selectionReason: TraceSelectionReason;
 };
 
-export type PromotedAlbumResult = {
-  album: {
-    name: string;
-    mbid: string;
-    artistName: string;
-    artistMbid: string;
-    coverUrl: string;
-    year: string;
-  };
+export type TraceSimilarArtist = {
+  name: string;
+  score: number;
+  genres: string[];
+  genreOverlap: number;
+  isDifferentGenre: boolean;
+  chosen: boolean;
+};
+
+export type ExploreTrace = {
+  kind: "explore";
+  seedArtist: string;
+  seedGenres: string[];
+  candidates: TraceSimilarArtist[];
+  chosenArtist: string;
+  chosenGenres: string[];
+  newGenres: string[];
+  selectionReason: TraceSelectionReason;
+};
+
+export type RecommendationTrace = WithinTasteTrace | ExploreTrace;
+
+export type PromotedAlbumInfo = {
+  name: string;
+  mbid: string;
+  artistName: string;
+  artistMbid: string;
+  coverUrl: string;
+  year: string;
+};
+
+export type WithinTasteResult = {
+  mode: "within_taste";
+  album: PromotedAlbumInfo;
   tag: string;
   inLibrary: boolean;
-  trace: RecommendationTrace;
-} | null;
+  trace: WithinTasteTrace;
+};
+
+export type ExploreResult = {
+  mode: "explore";
+  album: PromotedAlbumInfo;
+  seedArtist: string;
+  newGenres: string[];
+  inLibrary: boolean;
+  trace: ExploreTrace;
+};
+
+/** A built recommendation plus the key used for cross-shuffle anti-repeat. */
+export type BuiltAlbum = {
+  result: WithinTasteResult | ExploreResult;
+  rememberKey: string;
+};
+
+export type PromotedAlbumResult = WithinTasteResult | ExploreResult | null;

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -23,4 +23,7 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
     "all",
   ],
   libraryPreference: "prefer_new",
+  explorationRate: 0.5,
+  exploreCandidateCount: 12,
+  genreOverlapThreshold: 0.15,
 };

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -17,6 +17,9 @@ export interface PromotedAlbumSettings {
   deepPageMax: number;
   genericTags: string[];
   libraryPreference: LibraryPreference;
+  explorationRate: number;
+  exploreCandidateCount: number;
+  genreOverlapThreshold: number;
 }
 
 export interface PurchaseDecisionSettings {

--- a/src/hooks/usePromotedAlbum.ts
+++ b/src/hooks/usePromotedAlbum.ts
@@ -28,9 +28,13 @@ export type TraceAlbumPoolInfo = {
 
 export type TraceSelectionReason =
   | "preferred_non_library"
-  | "fallback_in_library";
+  | "preferred_library"
+  | "fallback_in_library"
+  | "fallback_non_library"
+  | "no_preference";
 
-export type RecommendationTrace = {
+export type WithinTasteTrace = {
+  kind: "within_taste";
   plexArtists: TraceArtistEntry[];
   weightedTags: TraceWeightedTag[];
   chosenTag: { name: string; weight: number };
@@ -38,19 +42,49 @@ export type RecommendationTrace = {
   selectionReason: TraceSelectionReason;
 };
 
-export type PromotedAlbumData = {
-  album: {
-    name: string;
-    mbid: string;
-    artistName: string;
-    artistMbid: string;
-    coverUrl: string;
-    year: string;
-  };
-  tag: string;
-  inLibrary: boolean;
-  trace: RecommendationTrace;
+export type TraceSimilarArtist = {
+  name: string;
+  score: number;
+  genres: string[];
+  genreOverlap: number;
+  isDifferentGenre: boolean;
+  chosen: boolean;
 };
+
+export type ExploreTrace = {
+  kind: "explore";
+  seedArtist: string;
+  seedGenres: string[];
+  candidates: TraceSimilarArtist[];
+  chosenArtist: string;
+  chosenGenres: string[];
+  newGenres: string[];
+  selectionReason: TraceSelectionReason;
+};
+
+export type RecommendationTrace = WithinTasteTrace | ExploreTrace;
+
+export type PromotedAlbumInfo = {
+  name: string;
+  mbid: string;
+  artistName: string;
+  artistMbid: string;
+  coverUrl: string;
+  year: string;
+};
+
+export type PromotedAlbumData = {
+  album: PromotedAlbumInfo;
+  inLibrary: boolean;
+} & (
+  | { mode: "within_taste"; tag: string; trace: WithinTasteTrace }
+  | {
+      mode: "explore";
+      seedArtist: string;
+      newGenres: string[];
+      trace: ExploreTrace;
+    }
+);
 
 export default function usePromotedAlbum() {
   const [promotedAlbum, setPromotedAlbum] = useState<PromotedAlbumData | null>(

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -60,7 +60,6 @@ export default function PromotedAlbum({
   const { toggle, stop, isTrackPlaying } = useAudioPreview();
 
   const album = data?.album;
-  const tag = data?.tag;
   const inLibrary = data?.inLibrary ?? false;
   const pastelBg = album ? pastelColorFromId(album.mbid) : "hsl(200, 70%, 85%)";
 
@@ -202,13 +201,23 @@ export default function PromotedAlbum({
                         <span className="ml-1.5">· {album.year}</span>
                       )}
                     </p>
-                    {tag && (
-                      <button
-                        onClick={() => setIsTraceOpen(true)}
-                        className="inline-block mt-2 px-2 py-0.5 bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 text-xs font-medium rounded-full border border-violet-200 dark:border-violet-700 hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors cursor-pointer"
-                      >
-                        Because you listen to {tag}
-                      </button>
+                    {data && (
+                      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                        <button
+                          onClick={() => setIsTraceOpen(true)}
+                          className="inline-block px-2 py-0.5 bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 text-xs font-medium rounded-full border border-violet-200 dark:border-violet-700 hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors cursor-pointer"
+                        >
+                          {data.mode === "within_taste"
+                            ? `Because you listen to ${data.tag}`
+                            : `Fans of ${data.seedArtist} also love this`}
+                        </button>
+                        {data.mode === "explore" &&
+                          data.newGenres.length > 0 && (
+                            <span className="inline-block px-2 py-0.5 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 text-xs font-medium rounded-full border border-emerald-200 dark:border-emerald-700">
+                              New genre: {data.newGenres[0]}
+                            </span>
+                          )}
+                      </div>
                     )}
                   </div>
 

--- a/src/pages/DiscoverPage/components/RecommendationTraceModal.tsx
+++ b/src/pages/DiscoverPage/components/RecommendationTraceModal.tsx
@@ -1,4 +1,10 @@
-import type { RecommendationTrace } from "@/hooks/usePromotedAlbum";
+import type {
+  RecommendationTrace,
+  WithinTasteTrace,
+  ExploreTrace,
+  TraceSelectionReason,
+  TraceSimilarArtist,
+} from "@/hooks/usePromotedAlbum";
 import Modal from "@/components/Modal";
 
 interface RecommendationTraceModalProps {
@@ -40,10 +46,40 @@ function StageCard({
   );
 }
 
+function GenreChips({
+  genres,
+  highlight,
+}: {
+  genres: string[];
+  highlight?: Set<string>;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {genres.map((g) => (
+        <span
+          key={g}
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs border ${
+            highlight?.has(g)
+              ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border-emerald-300 dark:border-emerald-700 font-bold"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-600"
+          }`}
+        >
+          {g}
+        </span>
+      ))}
+      {genres.length === 0 && (
+        <span className="text-[11px] text-gray-400 dark:text-gray-500 italic">
+          No genres
+        </span>
+      )}
+    </div>
+  );
+}
+
 function PlexArtistsStage({
   artists,
 }: {
-  artists: RecommendationTrace["plexArtists"];
+  artists: WithinTasteTrace["plexArtists"];
 }) {
   return (
     <StageCard title="Plex Listening History">
@@ -70,7 +106,7 @@ function PlexArtistsStage({
 function TagContributionsStage({
   artists,
 }: {
-  artists: RecommendationTrace["plexArtists"];
+  artists: WithinTasteTrace["plexArtists"];
 }) {
   const picked = artists.filter((a) => a.picked);
 
@@ -109,7 +145,7 @@ function TagPoolStage({
   tags,
   chosenTagName,
 }: {
-  tags: RecommendationTrace["weightedTags"];
+  tags: WithinTasteTrace["weightedTags"];
   chosenTagName: string;
 }) {
   return (
@@ -136,7 +172,7 @@ function TagPoolStage({
   );
 }
 
-function AlbumPoolStage({ pool }: { pool: RecommendationTrace["albumPool"] }) {
+function AlbumPoolStage({ pool }: { pool: WithinTasteTrace["albumPool"] }) {
   return (
     <StageCard title="Album Pool">
       <div className="grid grid-cols-2 gap-2 text-xs">
@@ -174,6 +210,68 @@ function AlbumPoolStage({ pool }: { pool: RecommendationTrace["albumPool"] }) {
   );
 }
 
+function SeedStage({ trace }: { trace: ExploreTrace }) {
+  return (
+    <StageCard title="Seed From Your Listening">
+      <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+        {trace.seedArtist}
+      </p>
+      <GenreChips genres={trace.seedGenres} />
+    </StageCard>
+  );
+}
+
+function SimilarArtistsStage({
+  candidates,
+}: {
+  candidates: TraceSimilarArtist[];
+}) {
+  return (
+    <StageCard title="Listeners Also Play (ListenBrainz)">
+      <div className="space-y-1.5">
+        {candidates.map((c) => (
+          <div
+            key={c.name}
+            data-testid={c.chosen ? "chosen-candidate" : "candidate"}
+            className={`flex items-center justify-between gap-2 px-2 py-1 rounded-lg border ${
+              c.chosen
+                ? "bg-violet-100 dark:bg-violet-900/30 border-violet-300 dark:border-violet-700"
+                : "bg-gray-50 dark:bg-gray-700/50 border-gray-200 dark:border-gray-600"
+            }`}
+          >
+            <span className="text-xs font-medium text-gray-800 dark:text-gray-200 truncate">
+              {c.name}
+            </span>
+            <span className="flex items-center gap-1.5 shrink-0">
+              <span
+                className={`px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${
+                  c.isDifferentGenre
+                    ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700"
+                    : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-600"
+                }`}
+              >
+                {c.isDifferentGenre ? "different genre" : "same genre"}
+              </span>
+              <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                {Math.round(c.genreOverlap * 100)}% overlap
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </StageCard>
+  );
+}
+
+function GenreShiftStage({ trace }: { trace: ExploreTrace }) {
+  const newGenres = new Set(trace.newGenres);
+  return (
+    <StageCard title={`Genre Shift → ${trace.chosenArtist}`}>
+      <GenreChips genres={trace.chosenGenres} highlight={newGenres} />
+    </StageCard>
+  );
+}
+
 function ResultStage({
   albumName,
   artistName,
@@ -181,16 +279,15 @@ function ResultStage({
 }: {
   albumName: string;
   artistName: string;
-  selectionReason: RecommendationTrace["selectionReason"];
+  selectionReason: TraceSelectionReason;
 }) {
-  const reasonLabel =
-    selectionReason === "preferred_non_library"
-      ? "New discovery"
-      : "Already in library";
-  const reasonColor =
-    selectionReason === "preferred_non_library"
-      ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700"
-      : "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700";
+  const inLibrary =
+    selectionReason === "preferred_library" ||
+    selectionReason === "fallback_in_library";
+  const reasonLabel = inLibrary ? "Already in library" : "New discovery";
+  const reasonColor = inLibrary
+    ? "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700"
+    : "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700";
 
   return (
     <StageCard title="Result">
@@ -214,6 +311,63 @@ function ResultStage({
   );
 }
 
+function WithinTasteFlow({
+  trace,
+  albumName,
+  artistName,
+}: {
+  trace: WithinTasteTrace;
+  albumName: string;
+  artistName: string;
+}) {
+  return (
+    <div className="flex flex-col">
+      <PlexArtistsStage artists={trace.plexArtists} />
+      <FlowConnector />
+      <TagContributionsStage artists={trace.plexArtists} />
+      <FlowConnector />
+      <TagPoolStage
+        tags={trace.weightedTags}
+        chosenTagName={trace.chosenTag.name}
+      />
+      <FlowConnector />
+      <AlbumPoolStage pool={trace.albumPool} />
+      <FlowConnector />
+      <ResultStage
+        albumName={albumName}
+        artistName={artistName}
+        selectionReason={trace.selectionReason}
+      />
+    </div>
+  );
+}
+
+function ExploreFlow({
+  trace,
+  albumName,
+  artistName,
+}: {
+  trace: ExploreTrace;
+  albumName: string;
+  artistName: string;
+}) {
+  return (
+    <div className="flex flex-col">
+      <SeedStage trace={trace} />
+      <FlowConnector />
+      <SimilarArtistsStage candidates={trace.candidates} />
+      <FlowConnector />
+      <GenreShiftStage trace={trace} />
+      <FlowConnector />
+      <ResultStage
+        albumName={albumName}
+        artistName={artistName}
+        selectionReason={trace.selectionReason}
+      />
+    </div>
+  );
+}
+
 export default function RecommendationTraceModal({
   isOpen,
   onClose,
@@ -228,24 +382,19 @@ export default function RecommendationTraceModal({
           How this was recommended
         </h3>
 
-        <div className="flex flex-col">
-          <PlexArtistsStage artists={trace.plexArtists} />
-          <FlowConnector />
-          <TagContributionsStage artists={trace.plexArtists} />
-          <FlowConnector />
-          <TagPoolStage
-            tags={trace.weightedTags}
-            chosenTagName={trace.chosenTag.name}
-          />
-          <FlowConnector />
-          <AlbumPoolStage pool={trace.albumPool} />
-          <FlowConnector />
-          <ResultStage
+        {trace.kind === "within_taste" ? (
+          <WithinTasteFlow
+            trace={trace}
             albumName={albumName}
             artistName={artistName}
-            selectionReason={trace.selectionReason}
           />
-        </div>
+        ) : (
+          <ExploreFlow
+            trace={trace}
+            albumName={albumName}
+            artistName={artistName}
+          />
+        )}
 
         <button
           onClick={onClose}

--- a/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
@@ -125,6 +125,7 @@ vi.mock("@/components/TrackList", () => ({
 }));
 
 const albumData: PromotedAlbumData = {
+  mode: "within_taste",
   album: {
     name: "OK Computer",
     mbid: "alb-1",
@@ -136,6 +137,7 @@ const albumData: PromotedAlbumData = {
   tag: "alternative",
   inLibrary: false,
   trace: {
+    kind: "within_taste",
     plexArtists: [
       {
         name: "Radiohead",
@@ -163,6 +165,48 @@ const albumData: PromotedAlbumData = {
       deepPageCount: 50,
       totalAfterDedup: 95,
     },
+    selectionReason: "preferred_non_library",
+  },
+};
+
+const exploreData: PromotedAlbumData = {
+  mode: "explore",
+  album: {
+    name: "Blue Album",
+    mbid: "rg-jazz-1",
+    artistName: "Jazz Cat",
+    artistMbid: "mbid-jazz",
+    coverUrl: "https://coverartarchive.org/release-group/rg-jazz-1/front-500",
+    year: "1965",
+  },
+  seedArtist: "Radiohead",
+  newGenres: ["jazz", "bebop"],
+  inLibrary: false,
+  trace: {
+    kind: "explore",
+    seedArtist: "Radiohead",
+    seedGenres: ["alternative", "rock"],
+    candidates: [
+      {
+        name: "Jazz Cat",
+        score: 5000,
+        genres: ["jazz", "bebop"],
+        genreOverlap: 0,
+        isDifferentGenre: true,
+        chosen: true,
+      },
+      {
+        name: "Rock Clone",
+        score: 9000,
+        genres: ["alternative", "rock"],
+        genreOverlap: 1,
+        isDifferentGenre: false,
+        chosen: false,
+      },
+    ],
+    chosenArtist: "Jazz Cat",
+    chosenGenres: ["jazz", "bebop"],
+    newGenres: ["jazz", "bebop"],
     selectionReason: "preferred_non_library",
   },
 };
@@ -408,6 +452,47 @@ describe("PromotedAlbum", () => {
     expect(screen.getByTestId("trace-modal")).toBeInTheDocument();
     fireEvent.click(screen.getByText("Close Trace"));
     expect(screen.queryByTestId("trace-modal")).not.toBeInTheDocument();
+  });
+
+  describe("explore mode", () => {
+    it("shows the 'fans also love' chip instead of the tag chip", () => {
+      renderWithRouter(
+        <PromotedAlbum
+          data={exploreData}
+          loading={false}
+          onRefresh={mockRefresh}
+        />
+      );
+      expect(
+        screen.getByText("Fans of Radiohead also love this")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Because you listen to/)
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the new-genre badge", () => {
+      renderWithRouter(
+        <PromotedAlbum
+          data={exploreData}
+          loading={false}
+          onRefresh={mockRefresh}
+        />
+      );
+      expect(screen.getByText("New genre: jazz")).toBeInTheDocument();
+    });
+
+    it("clicking the explore chip opens the trace modal", () => {
+      renderWithRouter(
+        <PromotedAlbum
+          data={exploreData}
+          loading={false}
+          onRefresh={mockRefresh}
+        />
+      );
+      fireEvent.click(screen.getByText("Fans of Radiohead also love this"));
+      expect(screen.getByTestId("trace-modal")).toBeInTheDocument();
+    });
   });
 
   describe("wanted", () => {

--- a/src/pages/DiscoverPage/components/__tests__/RecommendationTraceModal.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/RecommendationTraceModal.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import RecommendationTraceModal from "../RecommendationTraceModal";
-import type { RecommendationTrace } from "@/hooks/usePromotedAlbum";
+import type { WithinTasteTrace, ExploreTrace } from "@/hooks/usePromotedAlbum";
 
 vi.mock("@/components/Modal", () => ({
   default: ({
@@ -12,7 +12,8 @@ vi.mock("@/components/Modal", () => ({
   }) => (isOpen ? <div data-testid="modal">{children}</div> : null),
 }));
 
-const trace: RecommendationTrace = {
+const trace: WithinTasteTrace = {
+  kind: "within_taste",
   plexArtists: [
     {
       name: "Radiohead",
@@ -51,7 +52,35 @@ const trace: RecommendationTrace = {
   selectionReason: "preferred_non_library",
 };
 
-function renderModal(overrides?: Partial<RecommendationTrace>) {
+const exploreTrace: ExploreTrace = {
+  kind: "explore",
+  seedArtist: "Radiohead",
+  seedGenres: ["alternative", "rock"],
+  candidates: [
+    {
+      name: "Jazz Cat",
+      score: 5000,
+      genres: ["jazz", "bebop"],
+      genreOverlap: 0,
+      isDifferentGenre: true,
+      chosen: true,
+    },
+    {
+      name: "Rock Clone",
+      score: 9000,
+      genres: ["alternative", "rock"],
+      genreOverlap: 1,
+      isDifferentGenre: false,
+      chosen: false,
+    },
+  ],
+  chosenArtist: "Jazz Cat",
+  chosenGenres: ["jazz", "bebop"],
+  newGenres: ["jazz", "bebop"],
+  selectionReason: "preferred_non_library",
+};
+
+function renderModal(overrides?: Partial<WithinTasteTrace>) {
   return render(
     <RecommendationTraceModal
       isOpen={true}
@@ -59,6 +88,18 @@ function renderModal(overrides?: Partial<RecommendationTrace>) {
       trace={{ ...trace, ...overrides }}
       albumName="OK Computer"
       artistName="Radiohead"
+    />
+  );
+}
+
+function renderExploreModal(overrides?: Partial<ExploreTrace>) {
+  return render(
+    <RecommendationTraceModal
+      isOpen={true}
+      onClose={vi.fn()}
+      trace={{ ...exploreTrace, ...overrides }}
+      albumName="Blue Album"
+      artistName="Jazz Cat"
     />
   );
 }
@@ -132,5 +173,41 @@ describe("RecommendationTraceModal", () => {
       />
     );
     expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
+  describe("explore trace", () => {
+    it("renders the explore flow stage cards", () => {
+      renderExploreModal();
+      const stageCards = screen.getAllByTestId("stage-card");
+      expect(stageCards).toHaveLength(4);
+    });
+
+    it("does not render within-taste stages", () => {
+      renderExploreModal();
+      expect(screen.queryByTestId("chosen-tag")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("page1-count")).not.toBeInTheDocument();
+    });
+
+    it("marks the chosen candidate", () => {
+      renderExploreModal();
+      const chosen = screen.getByTestId("chosen-candidate");
+      expect(chosen).toHaveTextContent("Jazz Cat");
+      expect(screen.getAllByTestId("candidate")).toHaveLength(1);
+    });
+
+    it("labels candidates as different vs same genre", () => {
+      renderExploreModal();
+      expect(screen.getByText("different genre")).toBeInTheDocument();
+      expect(screen.getByText("same genre")).toBeInTheDocument();
+    });
+
+    it("shows the seed artist and result", () => {
+      renderExploreModal();
+      expect(screen.getAllByText("Radiohead").length).toBeGreaterThan(0);
+      expect(screen.getByText("Blue Album")).toBeInTheDocument();
+      expect(screen.getByTestId("selection-reason")).toHaveTextContent(
+        "New discovery"
+      );
+    });
   });
 });

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -21,6 +21,13 @@ interface NumberFieldProps {
   description?: string;
 }
 
+interface PercentFieldProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  description?: string;
+}
+
 const LIBRARY_PREFERENCE_OPTIONS: {
   value: LibraryPreference;
   label: string;
@@ -66,6 +73,40 @@ function NumberField({
         max={max}
         step={step}
         className="w-full sm:w-xs px-3 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 focus:outline-none focus:border-amber-400 shadow-cartoon-md text-[16px]"
+      />
+      {description && (
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PercentField({
+  label,
+  value,
+  onChange,
+  description,
+}: PercentFieldProps) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-400">
+          {label}
+        </label>
+        <span className="text-sm font-bold text-gray-900 dark:text-gray-100">
+          {Math.round(value * 100)}%
+        </span>
+      </div>
+      <input
+        type="range"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        min={0}
+        max={1}
+        step={0.05}
+        className="w-full accent-amber-400"
       />
       {description && (
         <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
@@ -222,6 +263,35 @@ export default function RecommendationsSection({
           Whether to prefer albums from new artists, artists already in your
           library, or no preference.
         </p>
+      </div>
+
+      <div className="pt-2 border-t-2 border-dashed border-gray-200 dark:border-gray-700 space-y-4">
+        <h3 className="text-sm font-bold text-gray-700 dark:text-gray-300">
+          Exploration
+        </h3>
+
+        <PercentField
+          label="Exploration mix"
+          value={config.explorationRate}
+          onChange={(v) => update("explorationRate", v)}
+          description="How often a recommendation breaks out of your usual genres (similar vibe, different genre) instead of staying within your taste. 0% never explores; 100% always tries."
+        />
+
+        <PercentField
+          label="Genre difference threshold"
+          value={config.genreOverlapThreshold}
+          onChange={(v) => update("genreOverlapThreshold", v)}
+          description="Maximum genre overlap a similar artist may share with the seed to still count as 'different genre'. Lower means stricter — more distant genres only."
+        />
+
+        <NumberField
+          label="Candidates considered"
+          value={config.exploreCandidateCount}
+          onChange={(v) => update("exploreCandidateCount", v)}
+          min={1}
+          max={50}
+          description="How many similar artists to evaluate per exploration before picking the most genre-distant one."
+        />
       </div>
 
       <div>


### PR DESCRIPTION
## What & why

Phase 2 of breaking the promoted-album "taste echo chamber". The within-taste pipeline always seeds from your top genre and pulls top albums of that same genre, so recommendations never leave your existing taste. This adds a second pipeline, **mixed in** alongside within-taste, that surfaces music in a *different* genre that listeners of your taste actually play.

### How explore mode works
1. Weighted-pick one seed artist from your Plex top artists.
2. Resolve its MusicBrainz MBID (cached).
3. Fetch **ListenBrainz** session-based similar artists — collaborative "played in the same sessions" similarity, which naturally crosses genres while keeping the vibe.
4. Pull Last.fm genre tags (in parallel) for the seed + top candidates.
5. Keep only candidates whose genre **barely overlaps** the seed (Jaccard ≤ threshold), pick the highest-scoring genre-distant one, and surface one of their albums.

### The mix
A weighted coin (`explorationRate`, default **0.5**) decides per recommendation whether to explore or stay within taste — a deliberate blend of comfortable picks and genuine discovery, not all-or-nothing. When explore can't find a genre-distant album (obscure seed, no MBID, empty similar list), it silently **falls back to within-taste**, so a recommendation always appears.

### Data sources (verified, no new auth)
- ListenBrainz labs `similar-artists` — free, unauthenticated, MBID-keyed. (Spotify audio-features are dead for new apps since Nov 2024; this is the maintained alternative.)
- MusicBrainz artist search (name→MBID) and release-groups, throttled at 1/sec; genre distance comes from Last.fm tags (parallelizable) to avoid the MB rate limit.

## Surface area
- New `server/api/listenbrainz/` service + `getArtistMbidByName` MB helper.
- `getPromotedAlbum` refactored into an orchestrator (mode roll) + `buildWithinTasteResult` + `buildExploreResult` (new `explore.ts`).
- Discriminated `mode: within_taste | explore` result/trace types, shared anti-repeat key across modes.
- Config: `explorationRate`, `exploreCandidateCount`, `genreOverlapThreshold` (+ validation), surfaced as an "Exploration" section in Settings → Recommendations.
- Mode-aware chip ("Fans of <seed> also love this" + "New genre" badge) and a dedicated explore flow in the trace modal.

## Testing
- New: `listenbrainz/similarArtists`, `musicbrainz/artists`, explore-mode branch in `getPromotedAlbum` (mode selection, genre filtering, every fallback path, anti-repeat), explore UI in `PromotedAlbum` + `RecommendationTraceModal`.
- Server: 850 pass · Client: 784 pass · both typechecks clean · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)