### PR TITLE
fix(auth): set session cookie Secure flag from request protocol

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,10 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Honor X-Forwarded-Proto from a reverse proxy so req.secure reflects the
+// client-facing protocol, which decides whether the session cookie is Secure.
+app.set("trust proxy", true);
+
 app.use(express.json());
 
 app.use("/api/auth", authRoutes);

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -72,6 +72,29 @@ describe("POST /auth/setup", () => {
     expect(res.body.error).toBe("Setup already completed");
   });
 
+  it("does not set the Secure flag when the request is plain HTTP", async () => {
+    const res = await request(app)
+      .post("/auth/setup")
+      .send({ username: "admin", password: "password123" });
+
+    expect(res.headers["set-cookie"][0]).not.toContain("Secure");
+  });
+
+  it("sets the Secure flag when forwarded protocol is https", async () => {
+    const httpsApp = express();
+    httpsApp.set("trust proxy", true);
+    httpsApp.use(express.json());
+    httpsApp.use("/auth", authRouter);
+    httpsApp.use(errorHandler);
+
+    const res = await request(httpsApp)
+      .post("/auth/setup")
+      .set("X-Forwarded-Proto", "https")
+      .send({ username: "admin", password: "password123" });
+
+    expect(res.headers["set-cookie"][0]).toContain("Secure");
+  });
+
   it("validates username length", async () => {
     const res = await request(app)
       .post("/auth/setup")

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -27,14 +27,13 @@ const router = express.Router();
 
 const VALID_THEMES = ["light", "dark", "system"] as const;
 
-function setSessionCookie(res: Response, token: string) {
+function setSessionCookie(req: Request, res: Response, token: string) {
   const maxAge = 30 * 24 * 60 * 60 * 1000;
-  const isProduction = process.env.NODE_ENV === "production";
 
   res.cookie(SESSION_COOKIE_NAME, token, {
     httpOnly: true,
     sameSite: "lax",
-    secure: isProduction,
+    secure: req.secure,
     maxAge,
     path: "/",
   });
@@ -99,7 +98,7 @@ router.post(
 
       const user = await createAdminUser(username, password);
       const token = await createSession(user.id);
-      setSessionCookie(res, token);
+      setSessionCookie(req, res, token);
 
       res.status(201).json({ user: userResponse(user) });
     } catch (err) {
@@ -144,7 +143,7 @@ router.post(
       );
 
       const token = await createSession(user.id);
-      setSessionCookie(res, token);
+      setSessionCookie(req, res, token);
 
       res.status(201).json({ user: userResponse(user) });
     } catch (err) {
@@ -177,7 +176,7 @@ router.post(
       }
 
       const token = await createSession(user.id);
-      setSessionCookie(res, token);
+      setSessionCookie(req, res, token);
 
       res.json({ user: userResponse(user) });
     } catch (err) {
@@ -222,7 +221,7 @@ router.post(
       }
 
       const token = await createSession(user.id);
-      setSessionCookie(res, token);
+      setSessionCookie(req, res, token);
 
       res.json({ user: userResponse(user) });
     } catch (err) {


### PR DESCRIPTION
Closes #140

## Problem

Users hit **"Connection failed: Authentication required"** in the setup wizard when testing the Lidarr connection, even with a correct address, port, and API key.

The error doesn't come from Lidarr — it comes from our own `requireAuth` middleware. Root cause is the session cookie's `Secure` flag:

- `setSessionCookie` used `secure: NODE_ENV === "production"`, and the Dockerfile sets `NODE_ENV=production`.
- Most self-hosted users access the app over **plain HTTP** (`http://host:3001` or an HTTP reverse proxy). Browsers will not send a `Secure` cookie over HTTP.
- `/setup` sets the cookie *and* returns the user in the response body. The frontend stores that user in React state and routes to `/onboarding`, so the UI looks logged in — but the cookie was never stored.
- The wizard then calls `POST /api/settings/test` (behind `requireAuth` + `ADMIN`). No cookie → 401 → `Connection failed: Authentication required`.

This also means a post-setup page reload bounces the user back to login, since `/api/auth/me` fails the same way.

## Fix

- Derive the cookie `Secure` flag from `req.secure` instead of `NODE_ENV`.
- `app.set("trust proxy", true)` so `req.secure` honors `X-Forwarded-Proto` behind a reverse proxy.

HTTPS deployments (direct or via proxy) keep `Secure` cookies; plain-HTTP deployments now work. No new env var required.

### Note on existing installs

Anyone who already completed setup over HTTP has a dropped `Secure` cookie and may appear stuck — re-logging in at `/login` issues a working (non-Secure) cookie after upgrade.

## Tests

Added to `server/routes/auth.test.ts`:
- no `Secure` flag over plain HTTP (the regression)
- `Secure` flag set when `X-Forwarded-Proto: https` with trust proxy

Full server suite passes (867 tests); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)