### PR TITLE
Fix wanted state not persisted across searches (#131)

### DIFF
--- a/src/hooks/__tests__/useWanted.test.ts
+++ b/src/hooks/__tests__/useWanted.test.ts
@@ -16,6 +16,53 @@ describe("useWanted", () => {
     expect(result.current.errorMsg).toBeNull();
   });
 
+  it("seeds state from initialWanted", () => {
+    const { result } = renderHook(() => useWanted(true));
+    expect(result.current.state).toBe("wanted");
+  });
+
+  it("reconciles to initialWanted when it resolves after mount", () => {
+    const { result, rerender } = renderHook(({ wanted }) => useWanted(wanted), {
+      initialProps: { wanted: false },
+    });
+    expect(result.current.state).toBe("idle");
+
+    rerender({ wanted: true });
+    expect(result.current.state).toBe("wanted");
+  });
+
+  it("does not clobber a pending transition when initialWanted changes", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.mocked(fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(({ wanted }) => useWanted(wanted), {
+      initialProps: { wanted: false },
+    });
+
+    let addPromise: Promise<void>;
+    act(() => {
+      addPromise = result.current.addToWanted("mbid-1");
+    });
+    expect(result.current.state).toBe("adding");
+
+    rerender({ wanted: false });
+    expect(result.current.state).toBe("adding");
+
+    await act(async () => {
+      resolveFetch(
+        new Response(JSON.stringify({ status: "added", id: 1 }), {
+          status: 200,
+        })
+      );
+      await addPromise;
+    });
+    expect(result.current.state).toBe("wanted");
+  });
+
   it("transitions to wanted on successful add", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ status: "added", id: 1 }), { status: 200 })

--- a/src/hooks/__tests__/useWantedAlbums.test.ts
+++ b/src/hooks/__tests__/useWantedAlbums.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import useWantedAlbums from "../useWantedAlbums";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useWantedAlbums", () => {
+  it("returns false when no wanted items loaded", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const { result } = renderHook(() => useWantedAlbums());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/wanted");
+    });
+
+    expect(result.current.isAlbumWanted("some-mbid")).toBe(false);
+  });
+
+  it("identifies wanted albums by albumMbid", async () => {
+    const items = [
+      {
+        id: 1,
+        albumMbid: "rg-1",
+        artistName: "Radiohead",
+        albumTitle: "OK Computer",
+        createdAt: "2024-01-01",
+      },
+      {
+        id: 2,
+        albumMbid: "rg-2",
+        artistName: "Radiohead",
+        albumTitle: "Kid A",
+        createdAt: "2024-01-02",
+      },
+    ];
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(items), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const { result } = renderHook(() => useWantedAlbums());
+
+    await waitFor(() => {
+      expect(result.current.isAlbumWanted("rg-1")).toBe(true);
+    });
+
+    expect(result.current.isAlbumWanted("rg-2")).toBe(true);
+    expect(result.current.isAlbumWanted("rg-unknown")).toBe(false);
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useWantedAlbums());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+
+    expect(result.current.isAlbumWanted("any-mbid")).toBe(false);
+  });
+
+  it("handles non-ok response gracefully", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 })
+    );
+
+    const { result } = renderHook(() => useWantedAlbums());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+
+    expect(result.current.isAlbumWanted("any-mbid")).toBe(false);
+  });
+});

--- a/src/hooks/useWanted.ts
+++ b/src/hooks/useWanted.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 type WantedState = "idle" | "adding" | "removing" | "wanted" | "error";
 
@@ -7,6 +7,16 @@ export default function useWanted(initialWanted = false) {
     initialWanted ? "wanted" : "idle"
   );
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    setState((prev) =>
+      prev === "idle" || prev === "wanted"
+        ? initialWanted
+          ? "wanted"
+          : "idle"
+        : prev
+    );
+  }, [initialWanted]);
 
   const addToWanted = useCallback(async (albumMbid: string) => {
     setState("adding");

--- a/src/hooks/useWantedAlbums.ts
+++ b/src/hooks/useWantedAlbums.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useMemo } from "react";
+import type { WantedItem } from "@/types";
+
+export default function useWantedAlbums() {
+  const [wantedItems, setWantedItems] = useState<WantedItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/wanted");
+        if (res.ok) {
+          setWantedItems(await res.json());
+        }
+      } catch {
+        // Wanted list may not be available yet
+      }
+    };
+    load();
+  }, []);
+
+  const wantedAlbumMbids = useMemo(
+    () => new Set(wantedItems.map((item) => item.albumMbid)),
+    [wantedItems]
+  );
+
+  const isAlbumWanted = (albumMbid: string) => wantedAlbumMbids.has(albumMbid);
+
+  return { isAlbumWanted };
+}

--- a/src/pages/ArtistPage/ArtistPage.tsx
+++ b/src/pages/ArtistPage/ArtistPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useParams } from "react-router-dom";
 import useArtistDetails from "@/hooks/useArtistDetails";
 import useLibraryAlbums from "@/hooks/useLibraryAlbums";
+import useWantedAlbums from "@/hooks/useWantedAlbums";
 import { groupArtistReleases } from "@/utils/groupArtistReleases";
 import ArtistHeader from "./components/ArtistHeader";
 import ReleaseSectionGrid from "./components/ReleaseSectionGrid";
@@ -11,6 +12,7 @@ export default function ArtistPage() {
   const { mbid } = useParams<{ mbid: string }>();
   const { artist, releaseGroups, loading, error } = useArtistDetails(mbid);
   const { isAlbumInLibrary } = useLibraryAlbums();
+  const { isAlbumWanted } = useWantedAlbums();
 
   const sections = useMemo(
     () => (mbid ? groupArtistReleases(releaseGroups, mbid) : []),
@@ -52,6 +54,7 @@ export default function ArtistPage() {
             title={section.title}
             items={section.items}
             isAlbumInLibrary={isAlbumInLibrary}
+            isAlbumWanted={isAlbumWanted}
           />
         ))
       )}

--- a/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
+++ b/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
@@ -20,15 +20,27 @@ vi.mock("@/hooks/useLibraryAlbums", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useWantedAlbums", () => ({
+  default: () => ({
+    isAlbumWanted: (id: string) => id === "wanted",
+  }),
+}));
+
 vi.mock("@/components/ReleaseGroupCard", () => ({
   default: ({
     releaseGroup,
     inLibrary,
+    initialWanted,
   }: {
     releaseGroup: ReleaseGroup;
     inLibrary?: boolean;
+    initialWanted?: boolean;
   }) => (
-    <div data-testid={`rg-${releaseGroup.id}`} data-in-library={inLibrary}>
+    <div
+      data-testid={`rg-${releaseGroup.id}`}
+      data-in-library={inLibrary}
+      data-wanted={initialWanted}
+    >
       {releaseGroup.title}
     </div>
   ),
@@ -116,6 +128,24 @@ describe("ArtistPage", () => {
       "false"
     );
     expect(screen.getByText("In Library")).toBeInTheDocument();
+  });
+
+  it("passes wanted status through to release cards", () => {
+    mockState.artist = { mbid: "a1", name: "Radiohead" };
+    mockState.releaseGroups = [
+      makeRg({ id: "wanted", title: "On Wanted" }),
+      makeRg({ id: "not-wanted", title: "Not Wanted" }),
+    ];
+    renderPage();
+
+    expect(screen.getByTestId("rg-wanted")).toHaveAttribute(
+      "data-wanted",
+      "true"
+    );
+    expect(screen.getByTestId("rg-not-wanted")).toHaveAttribute(
+      "data-wanted",
+      "false"
+    );
   });
 
   it("shows an empty message when the artist has no releases", () => {

--- a/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
+++ b/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
@@ -7,12 +7,14 @@ interface ReleaseSectionGridProps {
   title: string;
   items: ReleaseGroup[];
   isAlbumInLibrary: (albumMbid: string) => boolean;
+  isAlbumWanted: (albumMbid: string) => boolean;
 }
 
 export default function ReleaseSectionGrid({
   title,
   items,
   isAlbumInLibrary,
+  isAlbumWanted,
 }: ReleaseSectionGridProps) {
   return (
     <section className="mb-8">
@@ -34,6 +36,7 @@ export default function ReleaseSectionGrid({
             <ReleaseGroupCard
               releaseGroup={rg}
               inLibrary={isAlbumInLibrary(rg.id)}
+              initialWanted={isAlbumWanted(rg.id)}
             />
           </div>
         ))}

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -6,6 +6,7 @@ import ArtistCard from "@/pages/DiscoverPage/components/ArtistCard";
 import Skeleton from "@/components/Skeleton";
 import useSearch from "@/hooks/useSearch";
 import useLibraryAlbums from "@/hooks/useLibraryAlbums";
+import useWantedAlbums from "@/hooks/useWantedAlbums";
 
 const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
 
@@ -13,6 +14,7 @@ export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { albums, artists, kind, loading, error, search } = useSearch();
   const { isAlbumInLibrary } = useLibraryAlbums();
+  const { isAlbumWanted } = useWantedAlbums();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const query = searchParams.get("q") ?? "";
@@ -127,6 +129,7 @@ export default function SearchPage() {
               <ReleaseGroupCard
                 releaseGroup={rg}
                 inLibrary={isAlbumInLibrary(rg.id)}
+                initialWanted={isAlbumWanted(rg.id)}
               />
             </div>
           ))}

--- a/src/pages/SearchPage/__tests__/SearchPage.test.tsx
+++ b/src/pages/SearchPage/__tests__/SearchPage.test.tsx
@@ -22,13 +22,27 @@ vi.mock("@/hooks/useLibraryAlbums", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useWantedAlbums", () => ({
+  default: () => ({
+    isAlbumWanted: (id: string) => id === "rg-wanted",
+  }),
+}));
+
 vi.mock("@/hooks/useNavigateToArtist", () => ({
   default: () => ({ go: vi.fn(), resolving: false }),
 }));
 
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({ releaseGroup }: { releaseGroup: { title: string } }) => (
-    <div data-testid="release-card">{releaseGroup.title}</div>
+  default: ({
+    releaseGroup,
+    initialWanted,
+  }: {
+    releaseGroup: { title: string };
+    initialWanted?: boolean;
+  }) => (
+    <div data-testid="release-card" data-wanted={initialWanted}>
+      {releaseGroup.title}
+    </div>
   ),
 }));
 
@@ -96,6 +110,40 @@ describe("SearchPage", () => {
     ];
     renderSearchPage("OK", "album");
     expect(screen.getByText("OK Computer")).toBeInTheDocument();
+  });
+
+  it("seeds initialWanted from the wanted list for matching albums", () => {
+    mockSearchState.albums = [
+      {
+        id: "rg-wanted",
+        title: "In Rainbows",
+        score: 100,
+        "primary-type": "Album",
+        "first-release-date": "2007-10-10",
+        "artist-credit": [
+          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
+        ],
+      },
+      {
+        id: "rg-other",
+        title: "Amnesiac",
+        score: 90,
+        "primary-type": "Album",
+        "first-release-date": "2001-06-05",
+        "artist-credit": [
+          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
+        ],
+      },
+    ];
+    renderSearchPage("Radiohead", "album");
+    expect(screen.getByText("In Rainbows")).toHaveAttribute(
+      "data-wanted",
+      "true"
+    );
+    expect(screen.getByText("Amnesiac")).toHaveAttribute(
+      "data-wanted",
+      "false"
+    );
   });
 
   it("renders artist cards in artist mode", () => {


### PR DESCRIPTION
Closes #131.

## Problem
On the search page, albums already on the wanted list showed "Add to wanted" instead of "Remove from wanted". Clicking it flipped the state correctly, but on refresh or navigating away and back it reverted to "Add to wanted".

`ReleaseGroupCard` derives the label from `useWanted(initialWanted)`, but `SearchPage` never passed `initialWanted` — so cards always mounted as not-wanted. `ArtistPage` had the same latent bug.

## Fix
- New `useWantedAlbums` hook exposing `isAlbumWanted(mbid)`, mirroring `useLibraryAlbums`.
- Wired into `SearchPage` and `ArtistPage` (via `ReleaseSectionGrid`).
- `useWanted` now reconciles to `initialWanted` when it resolves after mount, guarded so an in-flight `adding`/`removing`/`error` is never clobbered. This closes the race where a card mounts before the wanted list finishes loading.

## Tests
- New `useWantedAlbums.test.ts`.
- `useWanted.test.ts`: seeds from `initialWanted`, reconciles on late resolve, doesn't clobber a pending transition.
- `SearchPage` and `ArtistPage` tests assert wanted status propagates to cards.

Lint, typecheck, and full frontend suite (761 tests) pass. No server-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)