### PR TITLE
Filter requests by lifecycle status (#122)

### DIFF
--- a/server/api/lidarr/config.test.ts
+++ b/server/api/lidarr/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
   DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -33,6 +34,7 @@ const baseConfig = {
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
   followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  requestStatusPollIntervalMs: DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/api/plex/config.test.ts
+++ b/server/api/plex/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
   DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -33,6 +34,7 @@ const fullConfig = {
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
   followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  requestStatusPollIntervalMs: DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/api/slskd/config.test.ts
+++ b/server/api/slskd/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PURCHASE_DECISION,
   DEFAULT_SPENDING,
   DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 } from "../../config";
 
 vi.mock("../../config", async (importOriginal) => {
@@ -33,6 +34,7 @@ const fullConfig = {
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
   followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  requestStatusPollIntervalMs: DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 };
 
 beforeEach(() => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -56,6 +56,7 @@ export type IConfig = {
   purchaseDecision: PurchaseDecisionConfig;
   spending: SpendingConfig;
   followedArtistPollIntervalMs: number;
+  requestStatusPollIntervalMs: number;
 };
 
 /** Input type for setConfig — nested objects are optional since defaults are deep-merged */
@@ -79,6 +80,7 @@ export const DEFAULT_SPENDING: SpendingConfig = {
 };
 
 export const DEFAULT_FOLLOWED_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS = 2 * 60 * 1000;
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
@@ -124,6 +126,7 @@ const DEFAULT_CONFIG: IConfig = {
   purchaseDecision: DEFAULT_PURCHASE_DECISION,
   spending: DEFAULT_SPENDING,
   followedArtistPollIntervalMs: DEFAULT_FOLLOWED_POLL_INTERVAL_MS,
+  requestStatusPollIntervalMs: DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS,
 };
 
 type RawStatement = {
@@ -313,6 +316,14 @@ function validateConfig(mergedConfig: IConfig) {
   ) {
     throw new Error(
       "followedArtistPollIntervalMs must be a number >= 60000 (1 minute)"
+    );
+  }
+  if (
+    typeof mergedConfig.requestStatusPollIntervalMs !== "number" ||
+    mergedConfig.requestStatusPollIntervalMs < 60_000
+  ) {
+    throw new Error(
+      "requestStatusPollIntervalMs must be a number >= 60000 (1 minute)"
     );
   }
 }

--- a/server/db/dataSource.ts
+++ b/server/db/dataSource.ts
@@ -15,6 +15,7 @@ import { WantedItems1711000000000 } from "./migration/3_WantedItems";
 import { Purchases1712000000000 } from "./migration/4_Purchases";
 import { FollowedArtists1713000000000 } from "./migration/5_FollowedArtists";
 import { FollowedLastViewedAt1714000000000 } from "./migration/6_FollowedLastViewedAt";
+import { RequestLidarrStatus1715000000000 } from "./migration/7_RequestLidarrStatus";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +49,7 @@ export function createDataSource(dbPath?: string): DataSource {
       Purchases1712000000000,
       FollowedArtists1713000000000,
       FollowedLastViewedAt1714000000000,
+      RequestLidarrStatus1715000000000,
     ],
     synchronize: false,
     migrationsRun: true,

--- a/server/db/entity/Request.ts
+++ b/server/db/entity/Request.ts
@@ -12,6 +12,12 @@ import { User } from "./User";
 
 export type RequestStatus = "pending" | "approved" | "declined";
 
+export type LidarrLifecycleStatus =
+  | "wanted"
+  | "downloading"
+  | "imported"
+  | "failed";
+
 @Entity("requests")
 export class Request {
   @PrimaryGeneratedColumn()
@@ -38,6 +44,10 @@ export class Request {
   @Index("idx_requests_status")
   @Column({ type: "text", default: "pending" })
   status!: RequestStatus;
+
+  @Index("idx_requests_lidarr_status")
+  @Column({ type: "text", nullable: true })
+  lidarr_status!: LidarrLifecycleStatus | null;
 
   @Column({ type: "integer", nullable: true })
   approved_by!: number | null;

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -43,7 +43,7 @@ export async function closeDatabase(): Promise<void> {
 export type { UserType } from "./entity/User";
 export { User } from "./entity/User";
 export { Session } from "./entity/Session";
-export type { RequestStatus } from "./entity/Request";
+export type { RequestStatus, LidarrLifecycleStatus } from "./entity/Request";
 export { Request } from "./entity/Request";
 export { WantedItem } from "./entity/WantedItem";
 export { Purchase } from "./entity/Purchase";

--- a/server/db/migration.test.ts
+++ b/server/db/migration.test.ts
@@ -78,6 +78,31 @@ describe("InitialSchema migration", () => {
   });
 });
 
+describe("RequestLidarrStatus migration", () => {
+  it("adds nullable lidarr_status column to requests", async () => {
+    const db = await initTestDb();
+
+    const columns = (await db.query("PRAGMA table_info(requests)")) as {
+      name: string;
+      notnull: number;
+    }[];
+    const lidarrStatus = columns.find((c) => c.name === "lidarr_status");
+
+    expect(lidarrStatus).toBeDefined();
+    expect(lidarrStatus?.notnull).toBe(0);
+  });
+
+  it("creates the lidarr_status index", async () => {
+    const db = await initTestDb();
+
+    const indexes = (await db.query(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name = 'idx_requests_lidarr_status'"
+    )) as { name: string }[];
+
+    expect(indexes.map((i) => i.name)).toContain("idx_requests_lidarr_status");
+  });
+});
+
 describe("constraint enforcement", () => {
   it("enforces enabled CHECK constraint", async () => {
     const db = await initTestDb();

--- a/server/db/migration/7_RequestLidarrStatus.ts
+++ b/server/db/migration/7_RequestLidarrStatus.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RequestLidarrStatus1715000000000 implements MigrationInterface {
+  name = "RequestLidarrStatus1715000000000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "requests" ADD COLUMN "lidarr_status" TEXT`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_requests_lidarr_status" ON "requests" ("lidarr_status")`
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_requests_lidarr_status"`);
+    await queryRunner.query(
+      `ALTER TABLE "requests" DROP COLUMN "lidarr_status"`
+    );
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import purchasesRoutes from "./routes/purchases";
 import wantedRoutes from "./routes/wanted";
 import followedRoutes from "./routes/followed";
 import { startFollowedArtistPoller } from "./services/followed/poller";
+import { startRequestStatusPoller } from "./services/requests/statusPoller";
 import { getConfig } from "./config";
 
 const log = createLogger("Server");
@@ -73,6 +74,10 @@ initializeConfig();
 const followedPollIntervalMs =
   getConfig().followedArtistPollIntervalMs ?? 6 * 60 * 60 * 1000;
 startFollowedArtistPoller(followedPollIntervalMs);
+
+const requestStatusPollIntervalMs =
+  getConfig().requestStatusPollIntervalMs ?? 2 * 60 * 1000;
+startRequestStatusPoller(requestStatusPollIntervalMs);
 
 app.listen(PORT, () => {
   log.info(`Listening on port ${PORT}`);

--- a/server/routes/requests.test.ts
+++ b/server/routes/requests.test.ts
@@ -118,7 +118,7 @@ describe("GET /", () => {
         album_mbid: "mbid-1",
         artist_name: "Artist",
         album_title: "Album",
-        status: "pending",
+        status: "approved",
         created_at: "2024-01-01",
         updated_at: "2024-01-01",
         approved_at: null,
@@ -149,7 +149,7 @@ describe("GET /", () => {
       albumMbid: "mbid-1",
       artistName: "Artist",
       albumTitle: "Album",
-      status: "pending",
+      status: "approved",
       createdAt: "2024-01-01",
       updatedAt: "2024-01-01",
       approvedAt: null,
@@ -184,6 +184,37 @@ describe("GET /", () => {
 
     const res = await request(app).get("/");
     expect(res.status).toBe(200);
+    expect(res.body[0].lidarr).toBeNull();
+  });
+
+  it("does not attach a lidarr lifecycle to non-approved requests", async () => {
+    mockGetRequests.mockResolvedValue([
+      {
+        id: 1,
+        album_mbid: "mbid-1",
+        artist_name: "Artist",
+        album_title: "Album",
+        status: "declined",
+        created_at: "2024-01-01",
+        updated_at: "2024-01-01",
+        approved_at: null,
+        user: null,
+      },
+    ]);
+    mockEnrichRequestsWithLidarr.mockResolvedValue([
+      {
+        status: "imported",
+        downloadProgress: null,
+        quality: null,
+        sourceIndexer: null,
+        lastEvent: null,
+        lidarrAlbumId: null,
+      },
+    ]);
+
+    const res = await request(app).get("/");
+    expect(res.status).toBe(200);
+    expect(res.body[0].status).toBe("declined");
     expect(res.body[0].lidarr).toBeNull();
   });
 

--- a/server/routes/requests.test.ts
+++ b/server/routes/requests.test.ts
@@ -191,6 +191,18 @@ describe("GET /", () => {
       userId: undefined,
     });
   });
+
+  it("passes lifecycle status params through to the service", async () => {
+    mockGetRequests.mockResolvedValue([]);
+    mockEnrichRequestsWithLidarr.mockResolvedValue([]);
+    await request(app).get(
+      "/?status=downloading&status=imported&status=failed"
+    );
+    expect(mockGetRequests).toHaveBeenCalledWith({
+      status: ["downloading", "imported", "failed"],
+      userId: undefined,
+    });
+  });
 });
 
 describe("POST /:id/approve", () => {
@@ -206,6 +218,13 @@ describe("POST /:id/approve", () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("approved");
     expect(mockApproveRequest).toHaveBeenCalledWith(1, 1);
+  });
+
+  it("returns 200 with failed status when fulfillment fails", async () => {
+    mockApproveRequest.mockResolvedValue({ status: "failed" });
+    const res = await request(app).post("/1/approve");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
   });
 });
 

--- a/server/routes/requests.test.ts
+++ b/server/routes/requests.test.ts
@@ -5,6 +5,11 @@ const mockApproveRequest = vi.fn();
 const mockDeclineRequest = vi.fn();
 const mockGetRequests = vi.fn();
 const mockEnrichRequestsWithLidarr = vi.fn();
+const mockRunStatusSyncOnce = vi.fn();
+
+vi.mock("../services/requests/statusPoller", () => ({
+  runStatusSyncOnce: (...args: unknown[]) => mockRunStatusSyncOnce(...args),
+}));
 
 vi.mock("../services/requests/requestService", () => ({
   createRequest: (...args: unknown[]) => mockCreateRequest(...args),
@@ -62,6 +67,7 @@ app.use(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockRunStatusSyncOnce.mockResolvedValue(undefined);
 });
 
 describe("POST /", () => {
@@ -81,6 +87,7 @@ describe("POST /", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: "pending", requestId: 10 });
     expect(mockCreateRequest).toHaveBeenCalledWith(1, 9, "mbid-1");
+    expect(mockRunStatusSyncOnce).not.toHaveBeenCalled();
   });
 
   it("returns approved when auto-approved", async () => {
@@ -92,6 +99,14 @@ describe("POST /", () => {
     const res = await request(app).post("/").send({ albumMbid: "mbid-1" });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("approved");
+  });
+
+  it("triggers a status sync after an auto-approved request", async () => {
+    mockCreateRequest.mockResolvedValue({ status: "approved", requestId: 10 });
+
+    await request(app).post("/").send({ albumMbid: "mbid-1" });
+
+    expect(mockRunStatusSyncOnce).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -212,12 +227,13 @@ describe("POST /:id/approve", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns approved on success", async () => {
+  it("returns approved on success and triggers a status sync", async () => {
     mockApproveRequest.mockResolvedValue({ status: "approved" });
     const res = await request(app).post("/1/approve");
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("approved");
     expect(mockApproveRequest).toHaveBeenCalledWith(1, 1);
+    expect(mockRunStatusSyncOnce).toHaveBeenCalledTimes(1);
   });
 
   it("returns 200 with failed status when fulfillment fails", async () => {
@@ -225,6 +241,13 @@ describe("POST /:id/approve", () => {
     const res = await request(app).post("/1/approve");
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("failed");
+    expect(mockRunStatusSyncOnce).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger a status sync when the request is not found", async () => {
+    mockApproveRequest.mockResolvedValue({ status: "not_found" });
+    await request(app).post("/1/approve");
+    expect(mockRunStatusSyncOnce).not.toHaveBeenCalled();
   });
 });
 

--- a/server/routes/requests.ts
+++ b/server/routes/requests.ts
@@ -9,8 +9,16 @@ import {
   getRequests,
 } from "../services/requests/requestService";
 import { enrichRequestsWithLidarr } from "../services/requests/lidarrEnrichment";
+import { runStatusSyncOnce } from "../services/requests/statusPoller";
 
 const router = express.Router();
+
+const FULFILLED_STATUSES = new Set(["approved", "already_monitored"]);
+
+/** Refreshes persisted lifecycle statuses out-of-band after a fulfillment. */
+function triggerStatusSync(): void {
+  void runStatusSyncOnce().catch(() => {});
+}
 
 router.use(requireAuth);
 
@@ -29,6 +37,8 @@ router.post(
       req.user!.permissions,
       albumMbid
     );
+
+    if (FULFILLED_STATUSES.has(result.status)) triggerStatusSync();
 
     res.json(result);
   }
@@ -84,6 +94,8 @@ router.post(
     if (result.status === "not_found") {
       return res.status(404).json({ error: "Request not found" });
     }
+
+    if (FULFILLED_STATUSES.has(result.status)) triggerStatusSync();
 
     res.json(result);
   }

--- a/server/routes/requests.ts
+++ b/server/routes/requests.ts
@@ -78,7 +78,7 @@ router.get("/", async (req: Request, res: Response) => {
           thumb: r.user.plex_thumb,
         }
       : null,
-    lidarr: lifecycles[i] ?? null,
+    lidarr: r.status === "approved" ? (lifecycles[i] ?? null) : null,
   }));
 
   res.json(sanitized);

--- a/server/services/requests/lidarrEnrichment.ts
+++ b/server/services/requests/lidarrEnrichment.ts
@@ -139,7 +139,7 @@ export function classifyRequest(
   };
 }
 
-async function fetchLidarrData() {
+export async function fetchLidarrData() {
   const historyBaseQuery = {
     pageSize: 200,
     sortKey: "date",

--- a/server/services/requests/requestService.test.ts
+++ b/server/services/requests/requestService.test.ts
@@ -1,22 +1,51 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { In } from "typeorm";
+import { Brackets } from "typeorm";
 import { Permission } from "../../../shared/permissions";
 
 const mockFulfillRequest = vi.fn();
 const mockGetAlbumByMbid = vi.fn();
 
-const mockFind = vi.fn();
 const mockFindOne = vi.fn();
 const mockCreate = vi.fn();
 const mockSave = vi.fn();
+const mockGetMany = vi.fn();
+
+/** Records calls made on the query builder so tests can assert filter SQL. */
+const qbCalls = {
+  andWhere: [] as { sql: unknown; params?: unknown }[],
+  orWhere: [] as { sql: unknown; params?: unknown }[],
+};
+
+const subBuilder = {
+  orWhere: (sql: unknown, params?: unknown) => {
+    qbCalls.orWhere.push({ sql, params });
+    return subBuilder;
+  },
+};
+
+const queryBuilder = {
+  leftJoinAndSelect: () => queryBuilder,
+  orderBy: () => queryBuilder,
+  andWhere: (sql: unknown, params?: unknown) => {
+    if (sql instanceof Brackets) {
+      (sql as unknown as { whereFactory: (b: unknown) => void }).whereFactory(
+        subBuilder
+      );
+    } else {
+      qbCalls.andWhere.push({ sql, params });
+    }
+    return queryBuilder;
+  },
+  getMany: (...args: unknown[]) => mockGetMany(...args),
+};
 
 vi.mock("../../db/index", () => ({
   getDataSource: () => ({
     getRepository: () => ({
-      find: (...args: unknown[]) => mockFind(...args),
       findOne: (...args: unknown[]) => mockFindOne(...args),
       create: (...args: unknown[]) => mockCreate(...args),
       save: (...args: unknown[]) => mockSave(...args),
+      createQueryBuilder: () => queryBuilder,
     }),
   }),
   Request: "Request",
@@ -47,6 +76,8 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  qbCalls.andWhere = [];
+  qbCalls.orWhere = [];
   mockGetAlbumByMbid.mockResolvedValue({
     title: "Test Album",
     artist: { artistName: "Test Artist" },
@@ -166,6 +197,25 @@ describe("createRequest", () => {
     const result = await createRequest(1, Permission.ADMIN, "mbid-1");
     expect(result).toEqual({ status: "already_monitored", requestId: 10 });
   });
+
+  it("marks lidarr_status failed when auto-approve fulfillment throws", async () => {
+    mockFindOne.mockResolvedValue(null);
+    const savedRequest = {
+      id: 10,
+      user_id: 1,
+      album_mbid: "mbid-1",
+      status: "pending",
+    } as Record<string, unknown>;
+    mockCreate.mockReturnValue(savedRequest);
+    mockSave.mockResolvedValue(savedRequest);
+    mockFulfillRequest.mockRejectedValue(new Error("lidarr boom"));
+
+    const result = await createRequest(1, Permission.ADMIN, "mbid-1");
+
+    expect(result).toEqual({ status: "failed", requestId: 10 });
+    expect(savedRequest.status).toBe("approved");
+    expect(savedRequest.lidarr_status).toBe("failed");
+  });
 });
 
 describe("approveRequest", () => {
@@ -196,6 +246,23 @@ describe("approveRequest", () => {
     expect(req.status).toBe("approved");
     expect(mockFulfillRequest).toHaveBeenCalledWith("mbid-1");
   });
+
+  it("marks lidarr_status failed when fulfillment throws", async () => {
+    const req = {
+      id: 1,
+      status: "pending",
+      album_mbid: "mbid-1",
+    } as Record<string, unknown>;
+    mockFindOne.mockResolvedValue(req);
+    mockSave.mockResolvedValue(req);
+    mockFulfillRequest.mockRejectedValue(new Error("lidarr boom"));
+
+    const result = await approveRequest(1, 2);
+
+    expect(result).toEqual({ status: "failed" });
+    expect(req.status).toBe("approved");
+    expect(req.lidarr_status).toBe("failed");
+  });
 });
 
 describe("declineRequest", () => {
@@ -223,48 +290,65 @@ describe("declineRequest", () => {
 });
 
 describe("getRequests", () => {
-  it("returns requests with user info", async () => {
-    mockFind.mockResolvedValue([]);
+  it("returns requests with no filters applied", async () => {
+    mockGetMany.mockResolvedValue([]);
     const result = await getRequests();
     expect(result).toEqual([]);
-    expect(mockFind).toHaveBeenCalledWith({
-      where: {},
-      order: { created_at: "DESC" },
-      relations: ["user"],
-    });
+    expect(qbCalls.andWhere).toHaveLength(0);
+    expect(qbCalls.orWhere).toHaveLength(0);
   });
 
-  it("filters by single status", async () => {
-    mockFind.mockResolvedValue([]);
-    await getRequests({ status: ["pending"] });
-    expect(mockFind).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { status: "pending" } })
-    );
-  });
-
-  it("filters by multiple statuses using In()", async () => {
-    mockFind.mockResolvedValue([]);
+  it("filters approval statuses on the status column", async () => {
+    mockGetMany.mockResolvedValue([]);
     await getRequests({ status: ["pending", "approved"] });
-    expect(mockFind).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { status: In(["pending", "approved"]) },
-      })
-    );
+
+    expect(qbCalls.orWhere).toEqual([
+      {
+        sql: "request.status IN (:...approvals)",
+        params: { approvals: ["pending", "approved"] },
+      },
+    ]);
   });
 
-  it("does not filter status when array is empty", async () => {
-    mockFind.mockResolvedValue([]);
+  it("filters lifecycle statuses on the lidarr_status column", async () => {
+    mockGetMany.mockResolvedValue([]);
+    await getRequests({ status: ["downloading", "imported"] });
+
+    expect(qbCalls.orWhere).toEqual([
+      {
+        sql: "request.lidarr_status IN (:...lifecycles)",
+        params: { lifecycles: ["downloading", "imported"] },
+      },
+    ]);
+  });
+
+  it("ORs approval and lifecycle statuses across both columns", async () => {
+    mockGetMany.mockResolvedValue([]);
+    await getRequests({ status: ["approved", "failed", "wanted"] });
+
+    expect(qbCalls.orWhere).toEqual([
+      {
+        sql: "request.status IN (:...approvals)",
+        params: { approvals: ["approved"] },
+      },
+      {
+        sql: "request.lidarr_status IN (:...lifecycles)",
+        params: { lifecycles: ["failed", "wanted"] },
+      },
+    ]);
+  });
+
+  it("does not add a status filter when the array is empty", async () => {
+    mockGetMany.mockResolvedValue([]);
     await getRequests({ status: [] });
-    expect(mockFind).toHaveBeenCalledWith(
-      expect.objectContaining({ where: {} })
-    );
+    expect(qbCalls.orWhere).toHaveLength(0);
   });
 
   it("filters by userId", async () => {
-    mockFind.mockResolvedValue([]);
+    mockGetMany.mockResolvedValue([]);
     await getRequests({ userId: 5 });
-    expect(mockFind).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { user_id: 5 } })
-    );
+    expect(qbCalls.andWhere).toEqual([
+      { sql: "request.user_id = :userId", params: { userId: 5 } },
+    ]);
   });
 });

--- a/server/services/requests/requestService.ts
+++ b/server/services/requests/requestService.ts
@@ -1,4 +1,4 @@
-import { In } from "typeorm";
+import { Brackets } from "typeorm";
 import { getDataSource, Request } from "../../db/index";
 import { hasPermission, Permission } from "../../../shared/permissions";
 import { getAlbumByMbid } from "../lidarr/helpers";
@@ -9,13 +9,17 @@ type CreateRequestResult =
   | { status: "approved"; requestId: number }
   | { status: "pending"; requestId: number }
   | { status: "already_monitored"; requestId: number }
-  | { status: "duplicate_pending"; requestId: number };
+  | { status: "duplicate_pending"; requestId: number }
+  | { status: "failed"; requestId: number };
 
 type ApproveRequestResult =
   | { status: "approved" }
   | { status: "already_monitored" }
   | { status: "not_found" }
-  | { status: "already_resolved" };
+  | { status: "already_resolved" }
+  | { status: "failed" };
+
+const APPROVAL_STATUSES = new Set(["pending", "approved", "declined"]);
 
 type DeclineRequestResult =
   | { status: "declined" }
@@ -87,12 +91,12 @@ async function processApproval(
 ): Promise<CreateRequestResult> {
   const repo = getRequestRepo();
 
+  request.status = "approved";
+  request.approved_by = approvedBy;
+  request.approved_at = new Date().toISOString();
+
   try {
     const result = await fulfillRequest(request.album_mbid);
-
-    request.status = "approved";
-    request.approved_by = approvedBy;
-    request.approved_at = new Date().toISOString();
     await repo.save(request);
 
     log.info(`Request #${request.id} auto-approved and fulfilled`);
@@ -103,8 +107,10 @@ async function processApproval(
 
     return { status: "approved", requestId: request.id };
   } catch (err) {
+    request.lidarr_status = "failed";
+    await repo.save(request);
     log.error(`Failed to fulfill request #${request.id}: ${err}`);
-    throw err;
+    return { status: "failed", requestId: request.id };
   }
 }
 
@@ -124,20 +130,27 @@ export async function approveRequest(
     return { status: "already_resolved" };
   }
 
-  const result = await fulfillRequest(request.album_mbid);
-
   request.status = "approved";
   request.approved_by = approvedBy;
   request.approved_at = new Date().toISOString();
-  await repo.save(request);
 
-  log.info(`Request #${requestId} approved by user ${approvedBy}`);
+  try {
+    const result = await fulfillRequest(request.album_mbid);
+    await repo.save(request);
 
-  if (result.status === "already_monitored") {
-    return { status: "already_monitored" };
+    log.info(`Request #${requestId} approved by user ${approvedBy}`);
+
+    if (result.status === "already_monitored") {
+      return { status: "already_monitored" };
+    }
+
+    return { status: "approved" };
+  } catch (err) {
+    request.lidarr_status = "failed";
+    await repo.save(request);
+    log.error(`Failed to fulfill request #${requestId}: ${err}`);
+    return { status: "failed" };
   }
-
-  return { status: "approved" };
 }
 
 export async function declineRequest(
@@ -169,16 +182,33 @@ export async function getRequests(filters?: {
 }) {
   const repo = getRequestRepo();
 
-  const where: Record<string, unknown> = {};
-  if (filters?.status && filters.status.length > 0) {
-    where.status =
-      filters.status.length === 1 ? filters.status[0] : In(filters.status);
-  }
-  if (filters?.userId) where.user_id = filters.userId;
+  const qb = repo
+    .createQueryBuilder("request")
+    .leftJoinAndSelect("request.user", "user")
+    .orderBy("request.created_at", "DESC");
 
-  return repo.find({
-    where,
-    order: { created_at: "DESC" },
-    relations: ["user"],
-  });
+  if (filters?.userId) {
+    qb.andWhere("request.user_id = :userId", { userId: filters.userId });
+  }
+
+  const statuses = filters?.status ?? [];
+  if (statuses.length > 0) {
+    const approvals = statuses.filter((s) => APPROVAL_STATUSES.has(s));
+    const lifecycles = statuses.filter((s) => !APPROVAL_STATUSES.has(s));
+
+    qb.andWhere(
+      new Brackets((b) => {
+        if (approvals.length > 0) {
+          b.orWhere("request.status IN (:...approvals)", { approvals });
+        }
+        if (lifecycles.length > 0) {
+          b.orWhere("request.lidarr_status IN (:...lifecycles)", {
+            lifecycles,
+          });
+        }
+      })
+    );
+  }
+
+  return qb.getMany();
 }

--- a/server/services/requests/statusPoller.test.ts
+++ b/server/services/requests/statusPoller.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockSync = vi.fn();
+
+vi.mock("./statusSync", () => ({
+  syncRequestStatuses: (...args: unknown[]) => mockSync(...args),
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import {
+  runStatusSyncOnce,
+  startRequestStatusPoller,
+  stopRequestStatusPoller,
+} from "./statusPoller";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  stopRequestStatusPoller();
+  vi.useRealTimers();
+});
+
+describe("runStatusSyncOnce", () => {
+  it("runs the sync", async () => {
+    mockSync.mockResolvedValue(undefined);
+    await runStatusSyncOnce();
+    expect(mockSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a concurrent run while one is in flight", async () => {
+    let resolveSync: () => void = () => {};
+    mockSync.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSync = resolve;
+        })
+    );
+
+    const first = runStatusSyncOnce();
+    await runStatusSyncOnce();
+    expect(mockSync).toHaveBeenCalledTimes(1);
+
+    resolveSync();
+    await first;
+
+    mockSync.mockResolvedValue(undefined);
+    await runStatusSyncOnce();
+    expect(mockSync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("startRequestStatusPoller", () => {
+  it("runs the sync after the first-run delay", async () => {
+    mockSync.mockResolvedValue(undefined);
+
+    startRequestStatusPoller(60_000);
+    expect(mockSync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("reschedules on the configured interval", async () => {
+    mockSync.mockResolvedValue(undefined);
+
+    startRequestStatusPoller(60_000);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockSync).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("is idempotent — a second start does not double-schedule", async () => {
+    mockSync.mockResolvedValue(undefined);
+
+    startRequestStatusPoller(60_000);
+    startRequestStatusPoller(60_000);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/requests/statusPoller.ts
+++ b/server/services/requests/statusPoller.ts
@@ -1,0 +1,49 @@
+import { syncRequestStatuses } from "./statusSync";
+import { createLogger } from "../../logger";
+
+const log = createLogger("request-status-poller");
+
+const DEFAULT_INTERVAL_MS = 2 * 60 * 1000;
+const FIRST_RUN_DELAY_MS = 15 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+export async function runStatusSyncOnce(): Promise<void> {
+  if (running) {
+    log.warn("Status sync already running, skipping this tick");
+    return;
+  }
+  running = true;
+  try {
+    await syncRequestStatuses();
+  } finally {
+    running = false;
+  }
+}
+
+export function startRequestStatusPoller(
+  intervalMs: number = DEFAULT_INTERVAL_MS
+): void {
+  if (timer) return;
+
+  const tick = async () => {
+    try {
+      await runStatusSyncOnce();
+    } catch (error) {
+      log.error("Status sync tick failed", error);
+    } finally {
+      timer = setTimeout(tick, intervalMs);
+    }
+  };
+
+  timer = setTimeout(tick, FIRST_RUN_DELAY_MS);
+  log.info(`Request status poller scheduled (interval: ${intervalMs / 1000}s)`);
+}
+
+export function stopRequestStatusPoller(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/server/services/requests/statusSync.test.ts
+++ b/server/services/requests/statusSync.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFind = vi.fn();
+const mockSave = vi.fn();
+const mockFetchLidarrData = vi.fn();
+const mockMockEnrich = vi.fn();
+
+vi.mock("../../db/index", () => ({
+  getDataSource: () => ({
+    getRepository: () => ({
+      find: (...args: unknown[]) => mockFind(...args),
+      save: (...args: unknown[]) => mockSave(...args),
+    }),
+  }),
+  Request: "Request",
+}));
+
+vi.mock("./lidarrEnrichment", async () => {
+  const actual =
+    await vi.importActual<typeof import("./lidarrEnrichment")>(
+      "./lidarrEnrichment"
+    );
+  return {
+    ...actual,
+    fetchLidarrData: (...args: unknown[]) => mockFetchLidarrData(...args),
+  };
+});
+
+vi.mock("../../dev/mockLidarrEnrichment", () => ({
+  mockEnrichRequestsWithLidarr: (...args: unknown[]) => mockMockEnrich(...args),
+}));
+
+vi.mock("../../logger", () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import { syncRequestStatuses } from "./statusSync";
+
+function emptyMaps() {
+  return { queueMap: new Map(), importedMap: new Map(), wantedMap: new Map() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.MOCK_LIDARR;
+});
+
+describe("syncRequestStatuses", () => {
+  it("persists newly classified statuses for approved requests", async () => {
+    mockFind.mockResolvedValue([
+      { id: 1, album_mbid: "mbid-down", lidarr_status: null },
+      { id: 2, album_mbid: "mbid-wanted", lidarr_status: null },
+    ]);
+    mockFetchLidarrData.mockResolvedValue({
+      queueMap: new Map([
+        ["mbid-down", { downloadProgress: 40, quality: "FLAC" }],
+      ]),
+      importedMap: new Map(),
+      wantedMap: new Map([
+        ["mbid-wanted", { lastEvent: null, lidarrAlbumId: 7 }],
+      ]),
+    });
+
+    await syncRequestStatuses();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    const saved = mockSave.mock.calls[0][0] as {
+      id: number;
+      lidarr_status: string;
+    }[];
+    expect(saved).toEqual([
+      expect.objectContaining({ id: 1, lidarr_status: "downloading" }),
+      expect.objectContaining({ id: 2, lidarr_status: "wanted" }),
+    ]);
+  });
+
+  it("does not save when no status changed", async () => {
+    mockFind.mockResolvedValue([
+      { id: 1, album_mbid: "mbid-down", lidarr_status: "downloading" },
+    ]);
+    mockFetchLidarrData.mockResolvedValue({
+      queueMap: new Map([
+        ["mbid-down", { downloadProgress: 40, quality: "FLAC" }],
+      ]),
+      importedMap: new Map(),
+      wantedMap: new Map(),
+    });
+
+    await syncRequestStatuses();
+
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("aborts without writing when the Lidarr fetch fails", async () => {
+    mockFind.mockResolvedValue([
+      { id: 1, album_mbid: "mbid-1", lidarr_status: "downloading" },
+    ]);
+    mockFetchLidarrData.mockRejectedValue(new Error("lidarr down"));
+
+    await syncRequestStatuses();
+
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("clears the status when Lidarr no longer knows the album", async () => {
+    mockFind.mockResolvedValue([
+      { id: 1, album_mbid: "mbid-gone", lidarr_status: "downloading" },
+    ]);
+    mockFetchLidarrData.mockResolvedValue(emptyMaps());
+
+    await syncRequestStatuses();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    const saved = mockSave.mock.calls[0][0] as { lidarr_status: null }[];
+    expect(saved[0].lidarr_status).toBeNull();
+  });
+
+  it("excludes terminal statuses from the candidate query", async () => {
+    mockFind.mockResolvedValue([]);
+
+    await syncRequestStatuses();
+
+    const whereArg = mockFind.mock.calls[0][0] as { where: unknown };
+    expect(whereArg.where).toBeDefined();
+    expect(mockFetchLidarrData).not.toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("uses the mock enrichment source in MOCK_LIDARR mode", async () => {
+    process.env.MOCK_LIDARR = "true";
+    mockFind.mockResolvedValue([
+      { id: 1, album_mbid: "mbid-1", lidarr_status: null },
+    ]);
+    mockMockEnrich.mockResolvedValue([{ status: "imported" }]);
+
+    await syncRequestStatuses();
+
+    expect(mockFetchLidarrData).not.toHaveBeenCalled();
+    const saved = mockSave.mock.calls[0][0] as { lidarr_status: string }[];
+    expect(saved[0].lidarr_status).toBe("imported");
+  });
+});

--- a/server/services/requests/statusSync.ts
+++ b/server/services/requests/statusSync.ts
@@ -1,0 +1,69 @@
+import { In, IsNull, Not } from "typeorm";
+import { getDataSource, Request } from "../../db/index";
+import type { LidarrLifecycleStatus } from "../../db/index";
+import { fetchLidarrData, classifyRequest } from "./lidarrEnrichment";
+import { mockEnrichRequestsWithLidarr } from "../../dev/mockLidarrEnrichment";
+import { createLogger } from "../../logger";
+
+const log = createLogger("request-status-sync");
+
+const TERMINAL_STATUSES: LidarrLifecycleStatus[] = ["failed", "imported"];
+
+function getRequestRepo() {
+  return getDataSource().getRepository(Request);
+}
+
+async function resolveStatuses(
+  albumMbids: string[]
+): Promise<(LidarrLifecycleStatus | null)[]> {
+  if (process.env.MOCK_LIDARR === "true") {
+    const mocks = await mockEnrichRequestsWithLidarr(albumMbids);
+    return mocks.map((m) => m?.status ?? null);
+  }
+
+  const { queueMap, importedMap, wantedMap } = await fetchLidarrData();
+  return albumMbids.map(
+    (mbid) => classifyRequest(mbid, queueMap, importedMap, wantedMap).status
+  );
+}
+
+/**
+ * Polls Lidarr once and persists the discrete lifecycle status onto approved
+ * requests. `failed` and `imported` are treated as terminal and never
+ * overwritten. A Lidarr fetch failure aborts the sync without writing, so
+ * transient outages don't wipe existing statuses.
+ */
+export async function syncRequestStatuses(): Promise<void> {
+  const repo = getRequestRepo();
+
+  const candidates = await repo.find({
+    where: [
+      { status: "approved", lidarr_status: IsNull() },
+      { status: "approved", lidarr_status: Not(In(TERMINAL_STATUSES)) },
+    ],
+  });
+
+  if (candidates.length === 0) return;
+
+  let statuses: (LidarrLifecycleStatus | null)[];
+  try {
+    statuses = await resolveStatuses(candidates.map((c) => c.album_mbid));
+  } catch (err) {
+    log.warn(`Skipping status sync; Lidarr fetch failed: ${err}`);
+    return;
+  }
+
+  const changed: Request[] = [];
+  candidates.forEach((request, i) => {
+    const next = statuses[i] ?? null;
+    if (request.lidarr_status !== next) {
+      request.lidarr_status = next;
+      changed.push(request);
+    }
+  });
+
+  if (changed.length > 0) {
+    await repo.save(changed);
+    log.info(`Updated lidarr_status for ${changed.length} request(s)`);
+  }
+}

--- a/src/components/__tests__/StatusBadge.test.tsx
+++ b/src/components/__tests__/StatusBadge.test.tsx
@@ -27,6 +27,17 @@ describe("StatusBadge", () => {
     );
   });
 
+  it("applies a distinct color class for failed rather than the default", () => {
+    const { rerender } = render(<StatusBadge status="failed" />);
+    const failedClass = screen.getByTestId("status-badge").className;
+    expect(failedClass).toContain("bg-rose-400");
+
+    rerender(<StatusBadge status="something-unknown" />);
+    expect(screen.getByTestId("status-badge").className).not.toContain(
+      "bg-rose-400"
+    );
+  });
+
   it("sets data-status for unknown status", () => {
     render(<StatusBadge status="something-unknown" />);
     expect(screen.getByTestId("status-badge")).toHaveAttribute(

--- a/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
+++ b/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
@@ -164,6 +164,14 @@ describe("LibraryPage", () => {
     expect(
       screen.getByRole("option", { name: "Declined" })
     ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Wanted" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Downloading" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Imported" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Failed" })).toBeInTheDocument();
   });
 
   it("defaults to showing all requests with no filters active", async () => {
@@ -217,6 +225,19 @@ describe("LibraryPage", () => {
     await waitFor(() => {
       expect(vi.mocked(fetch)).toHaveBeenCalledWith(
         "/api/requests?status=pending"
+      );
+    });
+  });
+
+  it("fetches filtered requests when selecting a lifecycle status", async () => {
+    renderWithAuth(Permission.ADMIN);
+    const user = userEvent.setup();
+
+    await toggleFilterChip(user, "Status", "Downloading");
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        "/api/requests?status=downloading"
       );
     });
   });

--- a/src/pages/LibraryPage/components/RequestFilter.tsx
+++ b/src/pages/LibraryPage/components/RequestFilter.tsx
@@ -20,6 +20,10 @@ const REQUEST_FILTERS = [
       { value: "pending", label: "Pending" },
       { value: "approved", label: "Approved" },
       { value: "declined", label: "Declined" },
+      { value: "wanted", label: "Wanted" },
+      { value: "downloading", label: "Downloading" },
+      { value: "imported", label: "Imported" },
+      { value: "failed", label: "Failed" },
     ],
   },
 ];

--- a/src/pages/LibraryPage/components/__tests__/RequestFilter.test.tsx
+++ b/src/pages/LibraryPage/components/__tests__/RequestFilter.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import RequestFilter from "../RequestFilter";
+
+const emptyValues = { requester: [], status: [] };
+
+describe("RequestFilter", () => {
+  it("renders all approval and lifecycle status options", async () => {
+    const user = userEvent.setup();
+    render(<RequestFilter values={emptyValues} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /Status/ }));
+
+    for (const label of [
+      "Pending",
+      "Approved",
+      "Declined",
+      "Wanted",
+      "Downloading",
+      "Imported",
+      "Failed",
+    ]) {
+      expect(screen.getByRole("option", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("invokes onChange with the toggled lifecycle value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RequestFilter values={emptyValues} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /Status/ }));
+    await user.click(screen.getByRole("option", { name: "Imported" }));
+
+    expect(onChange).toHaveBeenCalledWith("status", ["imported"]);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,11 @@ export interface RequestUser {
   thumb: string | null;
 }
 
-export type LidarrLifecycleStatus = "downloading" | "wanted" | "imported";
+export type LidarrLifecycleStatus =
+  | "downloading"
+  | "wanted"
+  | "imported"
+  | "failed";
 
 export interface LidarrLifecycle {
   status: LidarrLifecycleStatus | null;


### PR DESCRIPTION
Closes #122.

Adds status filtering on the Requests page for the full lifecycle (wanted / downloading / imported / failed) in addition to the existing approval statuses (pending / approved / declined).

## Approach

Mirrors Overseerr's model: persist the **discrete** lifecycle state to the DB so it's filterable, while keeping live download progress ephemeral. Overseerr sets request status reactively (a poll/scan flips `media.status`, which cascades requests to COMPLETED; a failed Radarr/Sonarr handoff marks FAILED) rather than watching downloads to completion — this PR does the equivalent for Lidarr.

## Backend

- **`requests.lidarr_status` column** (`wanted | downloading | imported | failed | null`) + index + migration `7_RequestLidarrStatus`.
- **`statusSync`** — polls Lidarr once, reuses the existing `classifyRequest` logic, writes only changed rows. `failed` and `imported` are terminal; a Lidarr fetch failure aborts without wiping existing statuses; status is cleared when Lidarr no longer knows the album.
- **`statusPoller`** — self-rescheduling background poller (clone of the followed-artist poller), wired into server startup. New `requestStatusPollIntervalMs` config (default 2m, min 1m).
- **Failed-on-approve** — when the Lidarr handoff (`fulfillRequest`) throws during approve/auto-approve, the request stays approved with `lidarr_status="failed"` instead of bubbling a 500.
- **`getRequests` filtering** — QueryBuilder splits requested statuses across the `status` and `lidarr_status` columns (OR-combined) for real server-side filtering.
- **Sync-on-fulfillment** — the create/approve routes fire a fire-and-forget sync so a freshly approved request becomes filterable within seconds rather than waiting for the next poll tick.

## Frontend

- Requests page Status filter expanded to all 7 values; `failed` added to the `LidarrLifecycleStatus` type. `StatusBadge` and `useRequests` already supported the rest.

## Tests

Full coverage added/updated across both suites (migration, statusSync, statusPoller, requestService filter + failed-on-approve, route, RequestFilter, LibraryPage, StatusBadge). Client 756 + server 887 passing; typecheck and lint clean.

## Notes

- The schema change applies automatically on next server start (`migrationsRun: true`).
- Possible follow-ups (out of scope): surface `requestStatusPollIntervalMs` in the settings UI; Lidarr inbound webhooks for reactive updates instead of polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)