### PR TITLE
feat(slskd): add test connection button in settings

### DIFF
--- a/server/api/slskd/testConnection.test.ts
+++ b/server/api/slskd/testConnection.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { testSlskdConnection } from "./testConnection";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("testSlskdConnection", () => {
+  it("returns success with version and soulseek state from isLoggedIn", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: { full: "0.21.0" },
+        server: { isConnected: true, isLoggedIn: true },
+      }),
+    });
+
+    const result = await testSlskdConnection("http://slskd:5030/", "key");
+
+    expect(result).toEqual({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: true,
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://slskd:5030/api/v0/application",
+      expect.objectContaining({ headers: { "X-API-Key": "key" } })
+    );
+  });
+
+  it("reports not connected when slskd is not logged into Soulseek", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: { full: "0.21.0" },
+        server: { isConnected: false, isLoggedIn: false },
+      }),
+    });
+
+    const result = await testSlskdConnection("http://slskd:5030", "key");
+
+    expect(result).toEqual({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: false,
+    });
+  });
+
+  it("derives soulseek state from server.state string when isLoggedIn missing", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: "0.20.0",
+        server: { state: "Connected, LoggedIn" },
+      }),
+    });
+
+    const result = await testSlskdConnection("http://slskd:5030", "key");
+
+    expect(result).toEqual({
+      success: true,
+      version: "0.20.0",
+      soulseekConnected: true,
+    });
+  });
+
+  it("returns null version when version is absent", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ server: { isLoggedIn: true } }),
+    });
+
+    const result = await testSlskdConnection("http://slskd:5030", "key");
+
+    expect(result).toEqual({
+      success: true,
+      version: null,
+      soulseekConnected: true,
+    });
+  });
+
+  it("returns error with status on non-ok response", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+
+    const result = await testSlskdConnection("http://slskd:5030", "badkey");
+
+    expect(result).toEqual({ error: "slskd returned 401", status: 401 });
+  });
+
+  it("returns 502 error when slskd is unreachable", async () => {
+    mockFetch.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const result = await testSlskdConnection("http://slskd:5030", "key");
+
+    expect(result).toEqual({ error: "connect ECONNREFUSED", status: 502 });
+  });
+});

--- a/server/api/slskd/testConnection.ts
+++ b/server/api/slskd/testConnection.ts
@@ -1,0 +1,78 @@
+import type { SlskdApplicationState } from "./types";
+import { resilientFetch } from "../resilientFetch";
+import { createLogger } from "../../logger";
+
+const log = createLogger("slskd-test-connection");
+
+export type SlskdTestSuccess = {
+  success: true;
+  version: string | null;
+  soulseekConnected: boolean;
+};
+
+export type SlskdTestError = {
+  error: string;
+  status: number;
+};
+
+/**
+ * @param {SlskdApplicationState["version"]} version
+ * @returns {string | null}
+ */
+function parseVersion(
+  version: SlskdApplicationState["version"]
+): string | null {
+  if (typeof version === "string") return version || null;
+  return version?.full ?? version?.current ?? null;
+}
+
+/**
+ * @param {SlskdApplicationState["server"]} server
+ * @returns {boolean}
+ */
+function parseSoulseekConnected(
+  server: SlskdApplicationState["server"]
+): boolean {
+  if (typeof server?.isLoggedIn === "boolean") return server.isLoggedIn;
+  if (typeof server?.state === "string")
+    return server.state.includes("LoggedIn");
+  return false;
+}
+
+export async function testSlskdConnection(
+  slskdUrl: string,
+  slskdApiKey: string
+): Promise<SlskdTestSuccess | SlskdTestError> {
+  const url = slskdUrl.replace(/\/+$/, "");
+  const headers = { "X-API-Key": slskdApiKey };
+
+  let response: Response;
+  try {
+    response = await resilientFetch(
+      `${url}/api/v0/application`,
+      { headers },
+      { retry: false }
+    );
+  } catch (err) {
+    log.warn(`slskd connection failed: ${err}`);
+    return {
+      error: err instanceof Error ? err.message : "Could not reach slskd",
+      status: 502,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      error: `slskd returned ${response.status}`,
+      status: response.status,
+    };
+  }
+
+  const data = (await response.json()) as SlskdApplicationState;
+
+  return {
+    success: true,
+    version: parseVersion(data.version),
+    soulseekConnected: parseSoulseekConnected(data.server),
+  };
+}

--- a/server/api/slskd/types.ts
+++ b/server/api/slskd/types.ts
@@ -56,6 +56,18 @@ export type SlskdTransferGroup = {
   }[];
 };
 
+// --- Application state (GET /api/v0/application) ---
+
+export type SlskdApplicationState = {
+  version?: { full?: string; current?: string } | string;
+  server?: {
+    address?: string;
+    isConnected?: boolean;
+    isLoggedIn?: boolean;
+    state?: string;
+  };
+};
+
 // --- Grouped search result (our internal representation) ---
 
 export type GroupedSearchResult = {

--- a/server/routes/settings.test.ts
+++ b/server/routes/settings.test.ts
@@ -5,6 +5,7 @@ const mockSetConfig = vi.fn();
 const mockExistsSync = vi.fn();
 const mockClearPromotedAlbumCache = vi.fn();
 const mockTestLidarrConnection = vi.fn();
+const mockTestSlskdConnection = vi.fn();
 
 vi.mock("../config", () => ({
   getConfig: (...args: unknown[]) => mockGetConfig(...args),
@@ -24,6 +25,10 @@ vi.mock("../promotedAlbum/getPromotedAlbum", () => ({
 vi.mock("../services/settings", () => ({
   testLidarrConnection: (...args: unknown[]) =>
     mockTestLidarrConnection(...args),
+}));
+
+vi.mock("../api/slskd/testConnection", () => ({
+  testSlskdConnection: (...args: unknown[]) => mockTestSlskdConnection(...args),
 }));
 
 vi.mock("../middleware/requireAuth", () => ({
@@ -188,6 +193,50 @@ describe("POST /settings/test", () => {
     });
     expect(mockTestLidarrConnection).toHaveBeenCalledWith(
       "http://lidarr:8686",
+      "goodkey"
+    );
+  });
+});
+
+describe("POST /settings/test-slskd", () => {
+  it("returns 400 without required fields", async () => {
+    const res = await request(app).post("/settings/test-slskd").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("URL and API key are required");
+  });
+
+  it("returns error on failed slskd connection", async () => {
+    mockTestSlskdConnection.mockResolvedValue({
+      error: "slskd returned 401",
+      status: 401,
+    });
+
+    const res = await request(app)
+      .post("/settings/test-slskd")
+      .send({ slskdUrl: "http://slskd:5030", slskdApiKey: "badkey" });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("slskd returned 401");
+  });
+
+  it("returns success with version and soulseek state", async () => {
+    mockTestSlskdConnection.mockResolvedValue({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: true,
+    });
+
+    const res = await request(app)
+      .post("/settings/test-slskd")
+      .send({ slskdUrl: "http://slskd:5030", slskdApiKey: "goodkey" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: true,
+    });
+    expect(mockTestSlskdConnection).toHaveBeenCalledWith(
+      "http://slskd:5030",
       "goodkey"
     );
   });

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -5,6 +5,7 @@ import { getConfig, setConfig } from "../config";
 import { clearPromotedAlbumCache } from "../promotedAlbum/getPromotedAlbum";
 import { clearPromotedArtistsCache } from "../promotedArtists/getPromotedArtists";
 import { testLidarrConnection } from "../services/settings";
+import { testSlskdConnection } from "../api/slskd/testConnection";
 import { requireAuth } from "../middleware/requireAuth";
 import { requirePermission } from "../middleware/requirePermission";
 import { Permission } from "../../shared/permissions";
@@ -66,6 +67,20 @@ router.post("/test", async (req: Request, res: Response) => {
   }
 
   const result = await testLidarrConnection(lidarrUrl, lidarrApiKey);
+  if ("error" in result) {
+    return res.status(result.status).json({ error: result.error });
+  }
+
+  res.json(result);
+});
+
+router.post("/test-slskd", async (req: Request, res: Response) => {
+  const { slskdUrl, slskdApiKey } = req.body;
+  if (!slskdUrl || !slskdApiKey) {
+    return res.status(400).json({ error: "URL and API key are required" });
+  }
+
+  const result = await testSlskdConnection(slskdUrl, slskdApiKey);
   if ("error" in result) {
     return res.status(result.status).json({ error: result.error });
   }

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -28,6 +28,7 @@ const connectedContext: SettingsContextValue = {
   saveSettings: vi.fn(),
   savePartialSettings: vi.fn(),
   testConnection: vi.fn(),
+  testSlskdConnection: vi.fn(),
   loadLidarrOptionValues: vi.fn(),
 };
 

--- a/src/components/__tests__/RequireOnboarding.test.tsx
+++ b/src/components/__tests__/RequireOnboarding.test.tsx
@@ -61,6 +61,7 @@ function renderWithContext(
     saveSettings: vi.fn(),
     savePartialSettings: vi.fn(),
     testConnection: vi.fn(),
+    testSlskdConnection: vi.fn(),
     loadLidarrOptionValues: vi.fn(),
     ...contextValue,
   };

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -206,6 +206,26 @@ export const SettingsContextProvider = ({
     };
   };
 
+  const testSlskdConnection = async (testSettings: AppSettings) => {
+    const res = await fetch("/api/settings/test-slskd", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(testSettings),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return { success: false, error: data.error || "Connection failed" };
+    }
+
+    return {
+      success: true,
+      version: data.version,
+      soulseekConnected: data.soulseekConnected,
+    };
+  };
+
   const value: SettingsContextValue = {
     options,
     settings,
@@ -214,6 +234,7 @@ export const SettingsContextProvider = ({
     saveSettings,
     savePartialSettings,
     testConnection,
+    testSlskdConnection,
     loadLidarrOptionValues: () => loadLidarrOptionValues(options, setOptions),
   };
 

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -70,6 +70,12 @@ export interface SettingsContextValue {
     metadataProfiles?: { id: number; name: string }[];
     rootFolderPaths?: { id: number; path: string }[];
   }>;
+  testSlskdConnection: (testSettings: AppSettings) => Promise<{
+    success: boolean;
+    version?: string | null;
+    soulseekConnected?: boolean;
+    error?: string;
+  }>;
   loadLidarrOptionValues: () => Promise<void>;
 }
 

--- a/src/pages/OnboardingPage/__tests__/OnboardingPage.test.tsx
+++ b/src/pages/OnboardingPage/__tests__/OnboardingPage.test.tsx
@@ -59,6 +59,7 @@ function renderOnboarding(overrides: Partial<SettingsContextValue> = {}) {
     saveSettings: mockSaveSettings,
     savePartialSettings: vi.fn(),
     testConnection: mockTestConnection,
+    testSlskdConnection: vi.fn(),
     loadLidarrOptionValues: vi.fn(),
     ...overrides,
   };

--- a/src/pages/SettingsPage/pages/IntegrationsSettingsPage.tsx
+++ b/src/pages/SettingsPage/pages/IntegrationsSettingsPage.tsx
@@ -17,6 +17,28 @@ type TestResult = {
   error?: string;
 };
 
+type SlskdTestResult = {
+  success: boolean;
+  version?: string | null;
+  soulseekConnected?: boolean;
+  error?: string;
+};
+
+function slskdBannerClass(result: SlskdTestResult): string {
+  if (!result.success) return "bg-rose-400 text-white";
+  if (!result.soulseekConnected) return "bg-amber-300 text-black";
+  return "bg-emerald-400 text-black";
+}
+
+function slskdBannerText(result: SlskdTestResult): string {
+  if (!result.success) return `Connection failed: ${result.error}`;
+  const version = result.version ? ` v${result.version}` : "";
+  if (!result.soulseekConnected) {
+    return `Reached slskd${version}, but it is not logged into the Soulseek network`;
+  }
+  return `Connected! slskd${version} is logged into Soulseek`;
+}
+
 export default function IntegrationsSettingsPage() {
   const {
     options,
@@ -25,6 +47,7 @@ export default function IntegrationsSettingsPage() {
     isConnected,
     savePartialSettings,
     testConnection,
+    testSlskdConnection,
     loadLidarrOptionValues,
   } = useSettings();
 
@@ -39,6 +62,9 @@ export default function IntegrationsSettingsPage() {
 
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [slskdTesting, setSlskdTesting] = useState(false);
+  const [slskdTestResult, setSlskdTestResult] =
+    useState<SlskdTestResult | null>(null);
   const [autoSetupModalOpen, setAutoSetupModalOpen] = useState(false);
 
   useEffect(() => {
@@ -72,6 +98,27 @@ export default function IntegrationsSettingsPage() {
       }
     },
     [fields, testConnection, loadLidarrOptionValues]
+  );
+
+  const handleTestSlskd = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      setSlskdTesting(true);
+      setSlskdTestResult(null);
+
+      try {
+        const result = await testSlskdConnection(fields);
+        setSlskdTestResult(result);
+      } catch (err) {
+        setSlskdTestResult({
+          success: false,
+          error: err instanceof Error ? err.message : "Test failed",
+        });
+      } finally {
+        setSlskdTesting(false);
+      }
+    },
+    [fields, testSlskdConnection]
   );
 
   const handlePlexLoginComplete = useCallback(
@@ -151,9 +198,11 @@ export default function IntegrationsSettingsPage() {
         url={fields.slskdUrl}
         apiKey={fields.slskdApiKey}
         downloadPath={fields.slskdDownloadPath}
+        testing={slskdTesting}
         onUrlChange={(v) => updateField("slskdUrl", v)}
         onApiKeyChange={(v) => updateField("slskdApiKey", v)}
         onDownloadPathChange={(v) => updateField("slskdDownloadPath", v)}
+        onTest={handleTestSlskd}
         isConnected={isConnected}
         autoSetupStatus={autoSetupStatus}
         autoSetupLoading={autoSetupLoading}
@@ -171,6 +220,16 @@ export default function IntegrationsSettingsPage() {
           {testResult.success
             ? `Connected! Lidarr v${testResult.version}`
             : `Connection failed: ${testResult.error}`}
+        </div>
+      )}
+
+      {slskdTestResult && (
+        <div
+          className={`mt-4 p-3 rounded-xl text-sm font-medium border-2 border-black shadow-cartoon-sm animate-slide-up ${slskdBannerClass(
+            slskdTestResult
+          )}`}
+        >
+          {slskdBannerText(slskdTestResult)}
         </div>
       )}
 

--- a/src/pages/SettingsPage/pages/__tests__/IntegrationsSettingsPage.slskd.test.tsx
+++ b/src/pages/SettingsPage/pages/__tests__/IntegrationsSettingsPage.slskd.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { AppSettings } from "@/context/settingsContextDef";
+
+const mockTestSlskdConnection = vi.fn();
+
+const settings: AppSettings = {
+  lidarrUrl: "",
+  lidarrApiKey: "",
+  lidarrQualityProfileId: 1,
+  lidarrRootFolderPath: "",
+  lidarrMetadataProfileId: 1,
+  lastfmApiKey: "",
+  plexUrl: "",
+  importPath: "",
+  slskdUrl: "http://slskd:5030",
+  slskdApiKey: "key",
+  slskdDownloadPath: "/downloads",
+};
+
+vi.mock("@/context/useSettings", () => ({
+  useSettings: () => ({
+    options: { qualityProfiles: [], metadataProfiles: [], rootFolderPaths: [] },
+    settings,
+    isConnected: false,
+    isLoading: false,
+    saveSettings: vi.fn(),
+    savePartialSettings: vi.fn(),
+    testConnection: vi.fn(),
+    testSlskdConnection: mockTestSlskdConnection,
+    loadLidarrOptionValues: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAutoSave", () => ({
+  useAutoSave: () => ({
+    fields: settings,
+    saveStatus: "idle",
+    saveError: null,
+    updateField: vi.fn(),
+    updateFields: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAutoSetupStatus", () => ({
+  default: () => ({ status: null, loading: false, refetch: vi.fn() }),
+}));
+
+vi.mock("../../shared/AutoSetupModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../sections/integrations/PlexSection", () => ({
+  default: () => null,
+}));
+
+import IntegrationsSettingsPage from "../IntegrationsSettingsPage";
+
+function getSlskdTestButton() {
+  const buttons = screen.getAllByRole("button", { name: "Test Connection" });
+  return buttons[buttons.length - 1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("IntegrationsSettingsPage slskd test connection", () => {
+  it("shows a success banner with version and soulseek state", async () => {
+    mockTestSlskdConnection.mockResolvedValue({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: true,
+    });
+
+    render(<IntegrationsSettingsPage />);
+    fireEvent.click(getSlskdTestButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Connected! slskd v0\.21\.0 is logged into Soulseek/)
+      ).toBeInTheDocument()
+    );
+    expect(mockTestSlskdConnection).toHaveBeenCalledWith(settings);
+  });
+
+  it("warns when slskd is reachable but not logged into Soulseek", async () => {
+    mockTestSlskdConnection.mockResolvedValue({
+      success: true,
+      version: "0.21.0",
+      soulseekConnected: false,
+    });
+
+    render(<IntegrationsSettingsPage />);
+    fireEvent.click(getSlskdTestButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/not logged into the Soulseek network/)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it("shows a failure banner when the connection fails", async () => {
+    mockTestSlskdConnection.mockResolvedValue({
+      success: false,
+      error: "slskd returned 401",
+    });
+
+    render(<IntegrationsSettingsPage />);
+    fireEvent.click(getSlskdTestButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Connection failed: slskd returned 401/)
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/src/pages/SettingsPage/sections/integrations/SlskdSection.tsx
+++ b/src/pages/SettingsPage/sections/integrations/SlskdSection.tsx
@@ -7,9 +7,11 @@ interface SlskdSectionProps {
   url: string;
   apiKey: string;
   downloadPath: string;
+  testing: boolean;
   onUrlChange: (url: string) => void;
   onApiKeyChange: (apiKey: string) => void;
   onDownloadPathChange: (path: string) => void;
+  onTest: (e: React.MouseEvent<HTMLButtonElement>) => void;
   isConnected: boolean;
   autoSetupStatus: AutoSetupStatus;
   autoSetupLoading: boolean;
@@ -32,9 +34,11 @@ export default function SlskdSection({
   url,
   apiKey,
   downloadPath,
+  testing,
   onUrlChange,
   onApiKeyChange,
   onDownloadPathChange,
+  onTest,
   isConnected,
   autoSetupStatus,
   autoSetupLoading,
@@ -91,7 +95,17 @@ export default function SlskdSection({
           volume mount)
         </p>
       </div>
-      <AutoSetupButton state={buttonState} onClick={onAutoSetup} />
+      <div className="flex flex-wrap gap-3 pt-2">
+        <button
+          type="button"
+          onClick={onTest}
+          disabled={testing || !url || !apiKey}
+          className="px-4 py-2 bg-amber-300 hover:bg-amber-200 disabled:opacity-50 text-black font-bold rounded-lg text-sm border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all"
+        >
+          {testing ? "Testing..." : "Test Connection"}
+        </button>
+        <AutoSetupButton state={buttonState} onClick={onAutoSetup} />
+      </div>
     </div>
   );
 }

--- a/src/pages/SettingsPage/sections/integrations/__tests__/SlskdSection.test.tsx
+++ b/src/pages/SettingsPage/sections/integrations/__tests__/SlskdSection.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SlskdSection from "../SlskdSection";
+
+const baseProps = {
+  url: "http://slskd:5030",
+  apiKey: "key",
+  downloadPath: "/downloads",
+  testing: false,
+  onUrlChange: vi.fn(),
+  onApiKeyChange: vi.fn(),
+  onDownloadPathChange: vi.fn(),
+  onTest: vi.fn(),
+  isConnected: false,
+  autoSetupStatus: null,
+  autoSetupLoading: false,
+  onAutoSetup: vi.fn(),
+};
+
+describe("SlskdSection", () => {
+  it("renders a test connection button", () => {
+    render(<SlskdSection {...baseProps} />);
+    expect(
+      screen.getByRole("button", { name: "Test Connection" })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onTest when the button is clicked", () => {
+    const onTest = vi.fn();
+    render(<SlskdSection {...baseProps} onTest={onTest} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Test Connection" }));
+    expect(onTest).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the test button when url or api key is empty", () => {
+    render(<SlskdSection {...baseProps} apiKey="" />);
+    expect(
+      screen.getByRole("button", { name: "Test Connection" })
+    ).toBeDisabled();
+  });
+
+  it("shows a testing label while testing", () => {
+    render(<SlskdSection {...baseProps} testing />);
+    const button = screen.getByRole("button", { name: "Testing..." });
+    expect(button).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Closes #143

Adds a **Test Connection** button to the slskd section of the integrations settings page, so users can verify tunearr can reach their configured slskd server during setup.

## What it does

- Calls slskd's `GET /api/v0/application` to verify reachability + auth.
- Reports both the **slskd version** and whether slskd is **logged into the Soulseek network**, giving three banner states:
  - 🟢 `Connected! slskd vX is logged into Soulseek`
  - 🟡 `Reached slskd vX, but it is not logged into the Soulseek network`
  - 🔴 `Connection failed: <error>`

## Changes

**Backend**
- `server/api/slskd/testConnection.ts` (new) — `testSlskdConnection(url, apiKey)`, parses version + Soulseek state defensively (the `/api/v0/application` shape varies slightly across slskd versions). No retry, so a bad config fails fast; 502 on unreachable.
- `server/routes/settings.ts` — new admin-gated `POST /api/settings/test-slskd`.
- `server/api/slskd/types.ts` — added `SlskdApplicationState`.

**Frontend**
- `SettingsContext` / `settingsContextDef.ts` — exposed `testSlskdConnection()`.
- `SlskdSection.tsx` — added the button (mirrors the existing Lidarr test button), grouped beside auto-setup.
- `IntegrationsSettingsPage.tsx` — handler + result banner.

## Tests

- Service unit test (6 cases), route test (3 cases), `SlskdSection` component test (4 cases), page-level banner test (3 cases). Updated 3 existing context mocks for the new member.
- Full suites pass: `typecheck`, `lint`, `format`, client (759) and server (876).

> Note: `/api/v0/application` isn't documented identically across slskd versions, so parsing is intentionally defensive. Worth a quick manual click-through against a running slskd to confirm the version + login fields land as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)