### PR TITLE
Collapse album and artist search into a single input

### DIFF
--- a/server/api/musicbrainz/artists.ts
+++ b/server/api/musicbrainz/artists.ts
@@ -13,6 +13,7 @@ function toArtistInfo(artist: MusicBrainzArtist): ArtistInfo {
   return {
     mbid: artist.id,
     name: artist.name,
+    score: artist.score,
     disambiguation: artist.disambiguation || undefined,
     type: artist.type || undefined,
     country: artist.country || undefined,

--- a/server/api/musicbrainz/types.ts
+++ b/server/api/musicbrainz/types.ts
@@ -23,6 +23,7 @@ export type MusicBrainzSearchResponse = {
 export type MusicBrainzArtist = {
   id: string;
   name: string;
+  score?: number;
   disambiguation?: string;
   type?: string;
   country?: string;
@@ -35,6 +36,7 @@ export type MusicBrainzArtistSearchResponse = {
 export type ArtistInfo = {
   mbid: string;
   name: string;
+  score?: number;
   disambiguation?: string;
   type?: string;
   country?: string;

--- a/server/routes/musicbrainz.test.ts
+++ b/server/routes/musicbrainz.test.ts
@@ -90,6 +90,71 @@ describe("GET /search", () => {
   });
 });
 
+describe("GET /search/all", () => {
+  it("returns 400 when q param is missing", async () => {
+    const res = await request(app).get("/search/all");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("q is required");
+  });
+
+  it("merges release groups with top-ranked enriched artists", async () => {
+    mockSearchReleaseGroups.mockResolvedValue({
+      "release-groups": [{ id: "rg-1", title: "OK Computer" }],
+      count: 1,
+      offset: 0,
+    });
+    mockSearchArtists.mockResolvedValue([
+      { mbid: "a1", name: "Radiohead", score: 100 },
+      { mbid: "a2", name: "Radio Dept.", score: 90 },
+      { mbid: "a3", name: "Radio Noise", score: 50 },
+    ]);
+    mockGetArtistsImages.mockResolvedValue(
+      new Map([["radiohead", "https://img/rh.jpg"]])
+    );
+
+    const res = await request(app).get("/search/all?q=radio");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      "release-groups": [{ id: "rg-1", title: "OK Computer" }],
+      count: 1,
+      artists: [
+        {
+          mbid: "a1",
+          name: "Radiohead",
+          score: 100,
+          imageUrl: "https://img/rh.jpg",
+        },
+        { mbid: "a2", name: "Radio Dept.", score: 90 },
+      ],
+    });
+    expect(mockSearchReleaseGroups).toHaveBeenCalledWith("radio");
+    expect(mockSearchArtists).toHaveBeenCalledWith("radio");
+    expect(mockGetArtistsImages).toHaveBeenCalledWith([
+      "Radiohead",
+      "Radio Dept.",
+    ]);
+  });
+
+  it("caps low-scoring artists out of the results", async () => {
+    mockSearchReleaseGroups.mockResolvedValue({
+      "release-groups": [],
+      count: 0,
+      offset: 0,
+    });
+    mockSearchArtists.mockResolvedValue([
+      { mbid: "a1", name: "Weak Match", score: 60 },
+    ]);
+    mockGetArtistsImages.mockResolvedValue(new Map());
+
+    const res = await request(app).get("/search/all?q=weak");
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toEqual([]);
+    expect(mockGetArtistsImages).toHaveBeenCalledWith([]);
+  });
+});
+
 describe("GET /artist/search", () => {
   it("returns 400 when q param is missing", async () => {
     const res = await request(app).get("/artist/search");

--- a/server/routes/musicbrainz.ts
+++ b/server/routes/musicbrainz.ts
@@ -14,6 +14,7 @@ import {
   getArtistMbidByName,
 } from "../api/musicbrainz/artists";
 import { getArtistImage, getArtistsImages } from "../api/deezer/artists";
+import type { ArtistInfo } from "../api/musicbrainz/types";
 import { getLabelAncestors } from "../api/musicbrainz/labels";
 import { getReleaseTracks } from "../api/musicbrainz/tracks";
 import { enrichTracksWithPreviews } from "../services/musicbrainz";
@@ -21,6 +22,45 @@ import { getConfigValue } from "../config";
 import { evaluatePurchaseDecision } from "../services/purchaseDecision/evaluatePurchaseDecision";
 
 const router = express.Router();
+
+const ARTIST_SCORE_THRESHOLD = 85;
+const ARTIST_RESULT_LIMIT = 5;
+
+/** Keep only the strongest artist matches so they don't bury album results */
+function topArtists(artists: ArtistInfo[]): ArtistInfo[] {
+  return artists
+    .filter((a) => (a.score ?? 0) >= ARTIST_SCORE_THRESHOLD)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, ARTIST_RESULT_LIMIT);
+}
+
+async function enrichArtistsWithImages(artists: ArtistInfo[]) {
+  const images = await getArtistsImages(artists.map((a) => a.name));
+  return artists.map((a) => ({
+    ...a,
+    imageUrl: images.get(a.name.toLowerCase()) || undefined,
+  }));
+}
+
+router.get("/search/all", rateLimiter, async (req: Request, res: Response) => {
+  const { q } = req.query;
+  if (typeof q !== "string") {
+    return res.status(400).json({ error: "Query parameter q is required" });
+  }
+
+  const [releaseGroups, artists] = await Promise.all([
+    searchReleaseGroups(q),
+    searchArtists(q),
+  ]);
+
+  const enrichedArtists = await enrichArtistsWithImages(topArtists(artists));
+
+  res.json({
+    "release-groups": releaseGroups["release-groups"],
+    count: releaseGroups.count,
+    artists: enrichedArtists,
+  });
+});
 
 router.get("/search", rateLimiter, async (req: Request, res: Response) => {
   const { q } = req.query;
@@ -41,13 +81,7 @@ router.get(
     }
 
     const artists = await searchArtists(q);
-    const images = await getArtistsImages(artists.map((a) => a.name));
-    const enriched = artists.map((a) => ({
-      ...a,
-      imageUrl: images.get(a.name.toLowerCase()) || undefined,
-    }));
-
-    res.json({ artists: enriched });
+    res.json({ artists: await enrichArtistsWithImages(artists) });
   }
 );
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -107,7 +107,7 @@ describe("App", () => {
   it("renders search page at /search", () => {
     renderApp("/search");
     expect(
-      screen.getByRole("heading", { level: 1, name: "Search Albums" })
+      screen.getByRole("heading", { level: 1, name: "Search" })
     ).toBeInTheDocument();
   });
 

--- a/src/hooks/__tests__/useSearch.test.ts
+++ b/src/hooks/__tests__/useSearch.test.ts
@@ -14,51 +14,47 @@ describe("useSearch", () => {
     const { result } = renderHook(() => useSearch());
     expect(result.current.albums).toEqual([]);
     expect(result.current.artists).toEqual([]);
-    expect(result.current.kind).toBe("album");
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
   it("skips empty query", async () => {
     const { result } = renderHook(() => useSearch());
-    await act(() => result.current.search("  ", "album"));
+    await act(() => result.current.search("  "));
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("sets albums on a successful album search", async () => {
+  it("sets both albums and artists from the combined endpoint", async () => {
     const releaseGroups = [{ id: "1", title: "OK Computer" }];
+    const artists = [{ mbid: "a1", name: "Radiohead" }];
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ "release-groups": releaseGroups }), {
-        status: 200,
-      })
+      new Response(
+        JSON.stringify({ "release-groups": releaseGroups, artists }),
+        { status: 200 }
+      )
     );
 
     const { result } = renderHook(() => useSearch());
-    await act(() => result.current.search("radiohead", "album"));
+    await act(() => result.current.search("radiohead"));
 
     expect(result.current.albums).toEqual(releaseGroups);
-    expect(result.current.kind).toBe("album");
+    expect(result.current.artists).toEqual(artists);
     expect(result.current.error).toBeNull();
     expect(vi.mocked(fetch).mock.calls[0][0]).toContain(
-      "/api/musicbrainz/search?"
+      "/api/musicbrainz/search/all?"
     );
   });
 
-  it("sets artists on a successful artist search", async () => {
-    const artists = [{ mbid: "a1", name: "Radiohead" }];
+  it("defaults missing arrays to empty", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ artists }), { status: 200 })
+      new Response(JSON.stringify({}), { status: 200 })
     );
 
     const { result } = renderHook(() => useSearch());
-    await act(() => result.current.search("radiohead", "artist"));
+    await act(() => result.current.search("radiohead"));
 
-    expect(result.current.artists).toEqual(artists);
     expect(result.current.albums).toEqual([]);
-    expect(result.current.kind).toBe("artist");
-    expect(vi.mocked(fetch).mock.calls[0][0]).toContain(
-      "/api/musicbrainz/artist/search?"
-    );
+    expect(result.current.artists).toEqual([]);
   });
 
   it("sets error on a failed search", async () => {
@@ -67,9 +63,10 @@ describe("useSearch", () => {
     );
 
     const { result } = renderHook(() => useSearch());
-    await act(() => result.current.search("test", "album"));
+    await act(() => result.current.search("test"));
 
     expect(result.current.albums).toEqual([]);
+    expect(result.current.artists).toEqual([]);
     expect(result.current.error).toBe("Rate limited");
   });
 
@@ -77,7 +74,7 @@ describe("useSearch", () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error("Network failure"));
 
     const { result } = renderHook(() => useSearch());
-    await act(() => result.current.search("test", "album"));
+    await act(() => result.current.search("test"));
 
     expect(result.current.error).toBe("Network failure");
     expect(result.current.albums).toEqual([]);

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,43 +1,31 @@
 import { useState, useCallback } from "react";
 import { ArtistSearchResult, ReleaseGroup } from "../types";
 
-type SearchKind = "album" | "artist";
-
 export default function useSearch() {
   const [albums, setAlbums] = useState<ReleaseGroup[]>([]);
   const [artists, setArtists] = useState<ArtistSearchResult[]>([]);
-  const [kind, setKind] = useState<SearchKind>("album");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const search = useCallback(async (query: string, searchType: string) => {
+  const search = useCallback(async (query: string) => {
     if (!query.trim()) return;
 
-    const isArtist = searchType === "artist";
     setLoading(true);
     setError(null);
-    setKind(isArtist ? "artist" : "album");
 
     try {
       const params = new URLSearchParams({ q: query });
-      const path = isArtist
-        ? `/api/musicbrainz/artist/search?${params.toString()}`
-        : `/api/musicbrainz/search?${params.toString()}`;
-
-      const res = await fetch(path);
+      const res = await fetch(
+        `/api/musicbrainz/search/all?${params.toString()}`
+      );
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || "Search failed");
       }
       const data = await res.json();
 
-      if (isArtist) {
-        setArtists(data.artists || []);
-        setAlbums([]);
-      } else {
-        setAlbums(data["release-groups"] || []);
-        setArtists([]);
-      }
+      setArtists(data.artists || []);
+      setAlbums(data["release-groups"] || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Search failed");
       setAlbums([]);
@@ -47,5 +35,5 @@ export default function useSearch() {
     }
   }, []);
 
-  return { albums, artists, kind, loading, error, search };
+  return { albums, artists, loading, error, search };
 }

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -192,7 +192,7 @@ export default function PromotedAlbum({
                     </h3>
                     <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
                       <Link
-                        to={`/search?q=${encodeURIComponent(album.artistName)}&searchType=artist`}
+                        to={`/search?q=${encodeURIComponent(album.artistName)}`}
                         className="hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
                       >
                         {album.artistName}

--- a/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
@@ -258,10 +258,7 @@ describe("PromotedAlbum", () => {
       <PromotedAlbum data={albumData} loading={false} onRefresh={mockRefresh} />
     );
     const artistLink = screen.getByText("Radiohead").closest("a");
-    expect(artistLink).toHaveAttribute(
-      "href",
-      "/search?q=Radiohead&searchType=artist"
-    );
+    expect(artistLink).toHaveAttribute("href", "/search?q=Radiohead");
   });
 
   it("renders cover image", () => {

--- a/src/pages/LibraryPage/components/FollowingList.tsx
+++ b/src/pages/LibraryPage/components/FollowingList.tsx
@@ -8,7 +8,7 @@ import type { SeenReleaseItem } from "@/types";
 
 function buildSearchHref(release: SeenReleaseItem): string {
   const query = `${release.artistName} ${release.albumTitle}`.trim();
-  const params = new URLSearchParams({ q: query, searchType: "album" });
+  const params = new URLSearchParams({ q: query });
   return `/search?${params.toString()}`;
 }
 

--- a/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
+++ b/src/pages/LibraryPage/components/__tests__/FollowingList.test.tsx
@@ -120,9 +120,7 @@ describe("FollowingList", () => {
     const link = (await screen.findByRole("link", {
       name: /Search for New EP/i,
     })) as HTMLAnchorElement;
-    expect(link.getAttribute("href")).toBe(
-      "/search?q=Radiohead+New+EP&searchType=album"
-    );
+    expect(link.getAttribute("href")).toBe("/search?q=Radiohead+New+EP");
   });
 
   it("shows release feed error message on failure", async () => {

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -10,21 +10,73 @@ import useWantedAlbums from "@/hooks/useWantedAlbums";
 
 const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
 
+const SECTION_HEADING_CLASS =
+  "text-sm font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3";
+const ALBUM_GRID_CLASS =
+  "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-4";
+
+function AlbumSkeletonCard() {
+  return (
+    <div>
+      <div className="sm:hidden bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden">
+        <div className="flex items-center">
+          <Skeleton className="w-24 aspect-square flex-shrink-0 rounded-none" />
+          <div className="flex-1 min-w-0 px-4 py-3 space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+        </div>
+      </div>
+      <div className="hidden sm:block bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden">
+        <Skeleton className="aspect-square rounded-none" />
+        <div className="p-3 border-t-2 border-black space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-3 w-1/2" />
+          <Skeleton className="h-3 w-1/3" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SearchSkeletons() {
+  return (
+    <div className="mt-6 space-y-8">
+      <div className="space-y-2">
+        {[...Array(3)].map((_, i) => (
+          <div
+            key={i}
+            className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm flex items-center gap-3 p-3"
+          >
+            <Skeleton className="w-12 h-12 rounded-lg flex-shrink-0" />
+            <Skeleton className="h-4 w-1/3" />
+          </div>
+        ))}
+      </div>
+      <div className={ALBUM_GRID_CLASS}>
+        {[...Array(6)].map((_, i) => (
+          <AlbumSkeletonCard key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { albums, artists, kind, loading, error, search } = useSearch();
+  const { albums, artists, loading, error, search } = useSearch();
   const { isAlbumInLibrary } = useLibraryAlbums();
   const { isAlbumWanted } = useWantedAlbums();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const query = searchParams.get("q") ?? "";
-  const searchType = searchParams.get("searchType") ?? "album";
 
   useEffect(() => {
     if (query) {
-      search(query, searchType);
+      search(query);
     }
-  }, [query, searchType, search]);
+  }, [query, search]);
 
   useEffect(() => {
     const handleReset = () => {
@@ -36,103 +88,71 @@ export default function SearchPage() {
   }, [setSearchParams]);
 
   const handleSearch = useCallback(
-    (newQuery: string, newSearchType: string) => {
-      setSearchParams({ q: newQuery, searchType: newSearchType });
+    (newQuery: string) => {
+      setSearchParams({ q: newQuery });
     },
     [setSearchParams]
   );
 
-  const isArtist = kind === "artist";
-  const hasResults = isArtist ? artists.length > 0 : albums.length > 0;
+  const hasResults = artists.length > 0 || albums.length > 0;
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">
-        {searchType === "artist" ? "Search Artists" : "Search Albums"}
-      </h1>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Search</h1>
 
       <SearchBar
         onSearch={handleSearch}
         initialQuery={query}
-        initialSearchType={searchType}
         inputRef={inputRef}
       />
 
-      {loading &&
-        (searchType === "artist" ? (
-          <div className="mt-6 space-y-2">
-            {[...Array(6)].map((_, i) => (
-              <div
-                key={i}
-                className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm flex items-center gap-3 p-3"
-              >
-                <Skeleton className="w-12 h-12 rounded-lg flex-shrink-0" />
-                <Skeleton className="h-4 w-1/3" />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-4">
-            {[...Array(6)].map((_, i) => (
-              <div key={i}>
-                <div className="sm:hidden bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden">
-                  <div className="flex items-center">
-                    <Skeleton className="w-24 aspect-square flex-shrink-0 rounded-none" />
-                    <div className="flex-1 min-w-0 px-4 py-3 space-y-2">
-                      <Skeleton className="h-4 w-3/4" />
-                      <Skeleton className="h-3 w-1/2" />
-                      <Skeleton className="h-3 w-1/3" />
-                    </div>
-                  </div>
-                </div>
-                <div className="hidden sm:block bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden">
-                  <Skeleton className="aspect-square rounded-none" />
-                  <div className="p-3 border-t-2 border-black space-y-2">
-                    <Skeleton className="h-4 w-3/4" />
-                    <Skeleton className="h-3 w-1/2" />
-                    <Skeleton className="h-3 w-1/3" />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        ))}
+      {loading && <SearchSkeletons />}
 
       {error && <p className="text-rose-500 mt-4">Error: {error}</p>}
 
-      {!loading && isArtist && artists.length > 0 && (
-        <div className="mt-6 space-y-2">
-          {artists.map((artist) => (
-            <ArtistCard
-              key={artist.mbid}
-              name={artist.name}
-              mbid={artist.mbid}
-              imageUrl={artist.imageUrl}
-            />
-          ))}
-        </div>
-      )}
+      {!loading && !error && hasResults && (
+        <div className="mt-6 space-y-8">
+          {artists.length > 0 && (
+            <section>
+              <h2 className={SECTION_HEADING_CLASS}>Artists</h2>
+              <div className="space-y-2">
+                {artists.map((artist) => (
+                  <ArtistCard
+                    key={artist.mbid}
+                    name={artist.name}
+                    mbid={artist.mbid}
+                    imageUrl={artist.imageUrl}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
 
-      {!loading && !isArtist && albums.length > 0 && (
-        <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-4">
-          {albums.map((rg, index) => (
-            <div
-              key={rg.id}
-              className="cascade-deal-in"
-              style={
-                {
-                  "--deal-index": index,
-                  "--deal-rotate": `${DEAL_ROTATIONS[index % DEAL_ROTATIONS.length]}deg`,
-                } as React.CSSProperties
-              }
-            >
-              <ReleaseGroupCard
-                releaseGroup={rg}
-                inLibrary={isAlbumInLibrary(rg.id)}
-                initialWanted={isAlbumWanted(rg.id)}
-              />
-            </div>
-          ))}
+          {albums.length > 0 && (
+            <section>
+              <h2 className={SECTION_HEADING_CLASS}>Albums</h2>
+              <div className={ALBUM_GRID_CLASS}>
+                {albums.map((rg, index) => (
+                  <div
+                    key={rg.id}
+                    className="cascade-deal-in"
+                    style={
+                      {
+                        "--deal-index": index,
+                        "--deal-rotate": `${DEAL_ROTATIONS[index % DEAL_ROTATIONS.length]}deg`,
+                      } as React.CSSProperties
+                    }
+                  >
+                    <ReleaseGroupCard
+                      releaseGroup={rg}
+                      inLibrary={isAlbumInLibrary(rg.id)}
+                      initialWanted={isAlbumWanted(rg.id)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
         </div>
       )}
 
@@ -156,9 +176,7 @@ export default function SearchPage() {
               <p className="text-lg font-medium text-gray-500">
                 No results found
               </p>
-              <p className="mt-1 text-center">
-                Try a different search term or change the search type.
-              </p>
+              <p className="mt-1 text-center">Try a different search term.</p>
             </>
           ) : (
             <>

--- a/src/pages/SearchPage/__tests__/SearchPage.test.tsx
+++ b/src/pages/SearchPage/__tests__/SearchPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import SearchPage from "../SearchPage";
 import type { ArtistSearchResult, ReleaseGroup } from "@/types";
@@ -6,7 +6,6 @@ import type { ArtistSearchResult, ReleaseGroup } from "@/types";
 let mockSearchState: {
   albums: ReleaseGroup[];
   artists: ArtistSearchResult[];
-  kind: "album" | "artist";
   loading: boolean;
   error: string | null;
   search: ReturnType<typeof vi.fn>;
@@ -52,10 +51,21 @@ vi.mock("@/pages/DiscoverPage/components/ArtistCard", () => ({
   ),
 }));
 
-function renderSearchPage(query = "", searchType = "album") {
-  const path = query
-    ? `/search?q=${query}&searchType=${searchType}`
-    : "/search";
+function makeAlbum(id: string, title: string, score = 100): ReleaseGroup {
+  return {
+    id,
+    title,
+    score,
+    "primary-type": "Album",
+    "first-release-date": "1997-06-16",
+    "artist-credit": [
+      { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
+    ],
+  };
+}
+
+function renderSearchPage(query = "") {
+  const path = query ? `/search?q=${query}` : "/search";
   return render(
     <MemoryRouter initialEntries={[path]}>
       <SearchPage />
@@ -67,7 +77,6 @@ beforeEach(() => {
   mockSearchState = {
     albums: [],
     artists: [],
-    kind: "album",
     loading: false,
     error: null,
     search: vi.fn(),
@@ -75,14 +84,11 @@ beforeEach(() => {
 });
 
 describe("SearchPage", () => {
-  it("renders the album heading by default", () => {
+  it("renders a single Search heading", () => {
     renderSearchPage();
-    expect(screen.getByText("Search Albums")).toBeInTheDocument();
-  });
-
-  it("renders the artist heading in artist mode", () => {
-    renderSearchPage("Radiohead", "artist");
-    expect(screen.getByText("Search Artists")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Search" })
+    ).toBeInTheDocument();
   });
 
   it("renders the search bar", () => {
@@ -95,47 +101,44 @@ describe("SearchPage", () => {
     expect(screen.getByText("Search for music")).toBeInTheDocument();
   });
 
-  it("renders album cards in album mode", () => {
-    mockSearchState.albums = [
-      {
-        id: "rg-1",
-        title: "OK Computer",
-        score: 100,
-        "primary-type": "Album",
-        "first-release-date": "1997-06-16",
-        "artist-credit": [
-          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
-        ],
-      },
-    ];
-    renderSearchPage("OK", "album");
+  it("renders both artist and album sections together", () => {
+    mockSearchState.artists = [{ mbid: "a1", name: "Radiohead" }];
+    mockSearchState.albums = [makeAlbum("rg-1", "OK Computer")];
+
+    renderSearchPage("Radiohead");
+
+    expect(screen.getByText("Artists")).toBeInTheDocument();
+    expect(screen.getByText("Albums")).toBeInTheDocument();
+    expect(screen.getByText("Radiohead")).toBeInTheDocument();
     expect(screen.getByText("OK Computer")).toBeInTheDocument();
+  });
+
+  it("orders the artist section before the album section", () => {
+    mockSearchState.artists = [{ mbid: "a1", name: "Radiohead" }];
+    mockSearchState.albums = [makeAlbum("rg-1", "OK Computer")];
+
+    const { container } = renderSearchPage("Radiohead");
+    const headings = within(container).getAllByRole("heading", { level: 2 });
+    expect(headings.map((h) => h.textContent)).toEqual(["Artists", "Albums"]);
+  });
+
+  it("omits the artists section when there are no artist results", () => {
+    mockSearchState.albums = [makeAlbum("rg-1", "OK Computer")];
+
+    renderSearchPage("OK");
+
+    expect(screen.queryByText("Artists")).not.toBeInTheDocument();
+    expect(screen.getByText("Albums")).toBeInTheDocument();
   });
 
   it("seeds initialWanted from the wanted list for matching albums", () => {
     mockSearchState.albums = [
-      {
-        id: "rg-wanted",
-        title: "In Rainbows",
-        score: 100,
-        "primary-type": "Album",
-        "first-release-date": "2007-10-10",
-        "artist-credit": [
-          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
-        ],
-      },
-      {
-        id: "rg-other",
-        title: "Amnesiac",
-        score: 90,
-        "primary-type": "Album",
-        "first-release-date": "2001-06-05",
-        "artist-credit": [
-          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
-        ],
-      },
+      makeAlbum("rg-wanted", "In Rainbows"),
+      makeAlbum("rg-other", "Amnesiac", 90),
     ];
-    renderSearchPage("Radiohead", "album");
+
+    renderSearchPage("Radiohead");
+
     expect(screen.getByText("In Rainbows")).toHaveAttribute(
       "data-wanted",
       "true"
@@ -146,15 +149,9 @@ describe("SearchPage", () => {
     );
   });
 
-  it("renders artist cards in artist mode", () => {
-    mockSearchState.kind = "artist";
-    mockSearchState.artists = [
-      { mbid: "a1", name: "Radiohead" },
-      { mbid: "a2", name: "Radio Dept." },
-    ];
-    renderSearchPage("Radio", "artist");
-    expect(screen.getByText("Radiohead")).toBeInTheDocument();
-    expect(screen.getByText("Radio Dept.")).toBeInTheDocument();
+  it("shows the no-results state when a query returns nothing", () => {
+    renderSearchPage("nonexistent");
+    expect(screen.getByText("No results found")).toBeInTheDocument();
   });
 
   it("clears input and focuses it on search:reset event", () => {

--- a/src/pages/SearchPage/components/SearchBar.tsx
+++ b/src/pages/SearchPage/components/SearchBar.tsx
@@ -1,23 +1,19 @@
 import { useEffect, useState, SubmitEvent, RefObject } from "react";
-import Dropdown from "@/components/Dropdown";
 import { SearchIcon } from "@/components/icons";
 import useHaptics from "@/hooks/useHaptics";
 
 interface SearchBarProps {
-  onSearch: (query: string, searchType: string) => void;
+  onSearch: (query: string) => void;
   initialQuery?: string;
-  initialSearchType?: string;
   inputRef?: RefObject<HTMLInputElement | null>;
 }
 
 export default function SearchBar({
   onSearch,
   initialQuery = "",
-  initialSearchType = "album",
   inputRef,
 }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery);
-  const [searchType, setSearchType] = useState(initialSearchType);
   const haptics = useHaptics();
 
   useEffect(() => {
@@ -28,7 +24,7 @@ export default function SearchBar({
     e.preventDefault();
     if (query.trim()) {
       haptics.medium();
-      onSearch(query, searchType);
+      onSearch(query);
     }
   };
 
@@ -36,40 +32,24 @@ export default function SearchBar({
     <form
       data-testid="search-form"
       onSubmit={handleSubmit}
-      className="space-y-3"
+      className="flex gap-2"
     >
-      <div>
-        <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
-          Search by
-        </label>
-        <Dropdown
-          options={[
-            { value: "album", label: "Album" },
-            { value: "artist", label: "Artist" },
-          ]}
-          value={searchType}
-          onChange={setSearchType}
-        />
-      </div>
-
-      <div className="flex gap-2">
-        <input
-          ref={inputRef}
-          data-testid="search-input"
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search..."
-          className="flex-1 px-4 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-200 dark:placeholder-gray-600 focus:outline-none focus:border-amber-400 shadow-cartoon-md"
-        />
-        <button
-          type="submit"
-          className="px-3 sm:px-6 py-2 bg-pink-400 hover:bg-pink-300 text-black font-bold rounded-lg border-2 border-black shadow-cartoon-md hover:translate-y-[-1px] hover:shadow-cartoon-lg active:translate-y-[1px] active:shadow-cartoon-pressed transition-all"
-        >
-          <SearchIcon className="w-5 h-5 sm:hidden" />
-          <span className="hidden sm:inline">Search</span>
-        </button>
-      </div>
+      <input
+        ref={inputRef}
+        data-testid="search-input"
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search artists and albums..."
+        className="flex-1 px-4 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-200 dark:placeholder-gray-600 focus:outline-none focus:border-amber-400 shadow-cartoon-md"
+      />
+      <button
+        type="submit"
+        className="px-3 sm:px-6 py-2 bg-pink-400 hover:bg-pink-300 text-black font-bold rounded-lg border-2 border-black shadow-cartoon-md hover:translate-y-[-1px] hover:shadow-cartoon-lg active:translate-y-[1px] active:shadow-cartoon-pressed transition-all"
+      >
+        <SearchIcon className="w-5 h-5 sm:hidden" />
+        <span className="hidden sm:inline">Search</span>
+      </button>
     </form>
   );
 }

--- a/src/pages/SearchPage/components/__tests__/SearchBar.test.tsx
+++ b/src/pages/SearchPage/components/__tests__/SearchBar.test.tsx
@@ -3,12 +3,14 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import SearchBar from "../SearchBar";
 
 describe("SearchBar", () => {
-  it("defaults to album search type", () => {
+  it("renders a single search input without a type selector", () => {
     render(<SearchBar onSearch={vi.fn()} />);
-    expect(screen.getByText("Album")).toBeInTheDocument();
+    expect(screen.getByTestId("search-input")).toBeInTheDocument();
+    expect(screen.queryByText("Album")).not.toBeInTheDocument();
+    expect(screen.queryByText("Artist")).not.toBeInTheDocument();
   });
 
-  it("calls onSearch with query and search type on submit", () => {
+  it("calls onSearch with the query on submit", () => {
     const onSearch = vi.fn();
     render(<SearchBar onSearch={onSearch} />);
 
@@ -17,7 +19,7 @@ describe("SearchBar", () => {
     });
     fireEvent.submit(screen.getByTestId("search-form"));
 
-    expect(onSearch).toHaveBeenCalledWith("Radiohead", "album");
+    expect(onSearch).toHaveBeenCalledWith("Radiohead");
   });
 
   it("does not call onSearch for whitespace-only query", () => {
@@ -30,21 +32,6 @@ describe("SearchBar", () => {
     fireEvent.submit(screen.getByTestId("search-form"));
 
     expect(onSearch).not.toHaveBeenCalled();
-  });
-
-  it("allows changing search type", () => {
-    const onSearch = vi.fn();
-    render(<SearchBar onSearch={onSearch} />);
-
-    fireEvent.click(screen.getByText("Album"));
-    fireEvent.click(screen.getByText("Artist"));
-
-    fireEvent.change(screen.getByTestId("search-input"), {
-      target: { value: "Bjork" },
-    });
-    fireEvent.submit(screen.getByTestId("search-form"));
-
-    expect(onSearch).toHaveBeenCalledWith("Bjork", "artist");
   });
 
   it("syncs input value when initialQuery prop changes", () => {


### PR DESCRIPTION
Closes #146

## What

Replaces the Album/Artist search toggle with a single input that searches both at once. Results render as an **Artists** section followed by an **Albums** section, so typing an artist name surfaces the artist card first, with matching albums/singles after.

## Backend
- New `GET /api/musicbrainz/search/all?q=` — fans out `searchReleaseGroups` + `searchArtists` concurrently (same pattern already used by `purchase-context`) and returns `{ "release-groups", count, artists }`.
- Artist noise control: `topArtists()` keeps only artists with MB `score >= 85`, max 5, so loosely-matching artists don't bury album results. Required threading `score` through `MusicBrainzArtist` → `ArtistInfo` (it was previously dropped in `toArtistInfo`).
- Extracted `enrichArtistsWithImages()` helper; the existing `/artist/search` route now reuses it.
- Old `/search` and `/artist/search` endpoints left in place (no remaining callers) — can be removed in a follow-up.

## Frontend
- `useSearch` — dropped the `searchType`/`kind` branch; calls the combined endpoint and populates `albums` + `artists` together.
- `SearchBar` — removed the dropdown; single input + button.
- `SearchPage` — heading is now "Search"; renders both sections with combined loading skeletons.
- Stripped the now-dead `searchType` param from the two outbound `/search` links (`FollowingList`, `PromotedAlbum`).

## Scope notes
- MusicBrainz only — it's the only backend that does text search today (Deezer/Apple are image enrichment).
- Issue part 2 ("reconsider the dedicated search page") was resolved by keeping the dedicated `/search` page and just merging the toggle. A global-nav or command-palette direction would be a separate change.

## Tests
- Backend: new `/search/all` route tests (merge + enrich, artist score cap).
- Frontend: updated `useSearch`, `SearchBar`, `SearchPage`, `App`, `FollowingList`, `PromotedAlbum` tests.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (765), `pnpm test:server` (891) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)