### PR TITLE
feat: add IMPORT permission for file uploads

### DIFF
--- a/server/routes/lidarr/import.test.ts
+++ b/server/routes/lidarr/import.test.ts
@@ -27,9 +27,15 @@ vi.mock("../../services/lidarr/helpers", () => ({
   getOrAddAlbum: vi.fn(),
 }));
 
+const { recordedPermissions } = vi.hoisted(() => ({
+  recordedPermissions: [] as unknown[],
+}));
+
 vi.mock("../../middleware/requirePermission", () => ({
-  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) =>
-    next(),
+  requirePermission: (required: unknown) => {
+    recordedPermissions.push(required);
+    return (_req: unknown, _res: unknown, next: () => void) => next();
+  },
 }));
 
 vi.mock("fs", () => ({
@@ -75,6 +81,7 @@ vi.mock("multer", () => {
 import express from "express";
 import request from "supertest";
 import importRouter from "./import";
+import { Permission } from "../../../shared/permissions";
 
 const app = express();
 app.use(express.json());
@@ -95,6 +102,14 @@ beforeEach(() => {
   mockMkdirSync = vi.fn();
   mockRmSync = vi.fn();
   vi.clearAllMocks();
+});
+
+describe("import route permissions", () => {
+  it("guards endpoints with IMPORT permission, not ADMIN", () => {
+    expect(recordedPermissions.length).toBeGreaterThan(0);
+    expect(recordedPermissions).toContain(Permission.IMPORT);
+    expect(recordedPermissions).not.toContain(Permission.ADMIN);
+  });
 });
 
 describe("POST /import/upload", () => {

--- a/server/routes/lidarr/import.ts
+++ b/server/routes/lidarr/import.ts
@@ -103,7 +103,7 @@ const singleUpload = multer({
 });
 
 const router = express.Router();
-const adminOnly = requirePermission(Permission.ADMIN);
+const requireImport = requirePermission(Permission.IMPORT);
 
 const requireImportPath = (_req: Request, res: Response, next: () => void) => {
   const importPath = getConfigValue("importPath");
@@ -122,7 +122,7 @@ const requireImportPath = (_req: Request, res: Response, next: () => void) => {
 
 router.post(
   "/import/upload",
-  adminOnly,
+  requireImport,
   requireImportPath,
   upload.array("files"),
   async (req: Request, res: Response) => {
@@ -167,7 +167,7 @@ router.post(
 
 router.post(
   "/import/upload-file",
-  adminOnly,
+  requireImport,
   requireImportPath,
   singleUpload.single("file"),
   async (_req: Request, res: Response) => {
@@ -177,7 +177,7 @@ router.post(
 
 router.post(
   "/import/scan",
-  adminOnly,
+  requireImport,
   requireImportPath,
   async (req: Request, res: Response) => {
     const { uploadId, albumMbid } = req.body;
@@ -225,7 +225,7 @@ router.post(
 
 router.post(
   "/import/confirm",
-  adminOnly,
+  requireImport,
   async (req: Request, res: Response) => {
     const { items }: { items: LidarrManualImportItem[] } = req.body;
     if (!items?.length) {
@@ -250,7 +250,7 @@ router.post(
 
 router.delete(
   "/import/:uploadId",
-  adminOnly,
+  requireImport,
   async (req: Request<{ uploadId: string }>, res: Response) => {
     const importPath = getConfigValue("importPath");
     if (!importPath) {

--- a/shared/permissions.ts
+++ b/shared/permissions.ts
@@ -6,6 +6,7 @@ export enum Permission {
   REQUEST = 8,
   AUTO_APPROVE = 16,
   REQUEST_VIEW = 32,
+  IMPORT = 64,
 }
 
 type HasPermissionOptions = {
@@ -40,6 +41,7 @@ export const PERMISSION_LABELS: Record<Permission, string> = {
   [Permission.REQUEST]: "Request",
   [Permission.AUTO_APPROVE]: "Auto Approve",
   [Permission.REQUEST_VIEW]: "View Requests",
+  [Permission.IMPORT]: "Import",
 };
 
 type ActivePermission = {
@@ -54,6 +56,7 @@ const DISPLAYABLE_PERMISSIONS = [
   Permission.REQUEST,
   Permission.AUTO_APPROVE,
   Permission.REQUEST_VIEW,
+  Permission.IMPORT,
 ] as const;
 
 export function getActivePermissions(

--- a/src/components/PurchaseCard.tsx
+++ b/src/components/PurchaseCard.tsx
@@ -25,8 +25,8 @@ function formatDate(iso: string): string {
 export default function PurchaseCard({ item, onRemove }: PurchaseCardProps) {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const isAdmin =
-    user !== null && hasPermission(user.permissions, Permission.ADMIN);
+  const canImport =
+    user !== null && hasPermission(user.permissions, Permission.IMPORT);
 
   const [coverError, setCoverError] = useState(false);
   const pastelBg = useMemo(
@@ -39,7 +39,7 @@ export default function PurchaseCard({ item, onRemove }: PurchaseCardProps) {
 
   const options: Option[] = [
     { label: "Remove purchase", onClick: () => onRemove(item.albumMbid) },
-    ...(isAdmin
+    ...(canImport
       ? [
           {
             label: "Upload files",

--- a/src/components/ReleaseGroupCard.tsx
+++ b/src/components/ReleaseGroupCard.tsx
@@ -47,8 +47,8 @@ export default function ReleaseGroupCard({
 }: ReleaseGroupCardProps) {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const isAdmin =
-    user !== null && hasPermission(user.permissions, Permission.ADMIN);
+  const canImport =
+    user !== null && hasPermission(user.permissions, Permission.IMPORT);
 
   const [isFlipped, setIsFlipped] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -166,7 +166,7 @@ export default function ReleaseGroupCard({
             onClick: () => setIsPurchaseModalOpen(true),
           },
         ]),
-    ...(isAdmin
+    ...(canImport
       ? [
           {
             label: "Upload files",

--- a/src/components/__tests__/PurchaseCard.test.tsx
+++ b/src/components/__tests__/PurchaseCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import PurchaseCard from "../PurchaseCard";
 import { Permission } from "@shared/permissions";
 import type { PurchaseItem } from "@/types";
@@ -7,9 +7,14 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => vi.fn(),
 }));
 
+let mockUser: { id: number; permissions: number } | null = {
+  id: 1,
+  permissions: Permission.IMPORT,
+};
+
 vi.mock("@/context/useAuth", () => ({
   useAuth: () => ({
-    user: { id: 1, permissions: Permission.ADMIN },
+    user: mockUser,
   }),
 }));
 
@@ -32,6 +37,10 @@ const mockItem: PurchaseItem = {
 };
 
 describe("PurchaseCard", () => {
+  afterEach(() => {
+    mockUser = { id: 1, permissions: Permission.IMPORT };
+  });
+
   it("renders album title and artist name", () => {
     render(<PurchaseCard item={mockItem} onRemove={vi.fn()} />);
 
@@ -64,10 +73,21 @@ describe("PurchaseCard", () => {
     expect(screen.getAllByText(/¥1,500/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows upload option for admin users", () => {
+  it("shows 'Upload files' option for a user with IMPORT permission", () => {
+    mockUser = { id: 2, permissions: Permission.IMPORT };
     render(<PurchaseCard item={mockItem} onRemove={vi.fn()} />);
 
-    const optionButtons = screen.getAllByLabelText("More options");
-    expect(optionButtons.length).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByLabelText("More options")[0]);
+
+    expect(screen.getByText("Upload files")).toBeInTheDocument();
+  });
+
+  it("hides 'Upload files' option for a user without IMPORT permission", () => {
+    mockUser = { id: 3, permissions: Permission.REQUEST };
+    render(<PurchaseCard item={mockItem} onRemove={vi.fn()} />);
+
+    fireEvent.click(screen.getAllByLabelText("More options")[0]);
+
+    expect(screen.queryByText("Upload files")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/ReleaseGroupCard.test.tsx
+++ b/src/components/__tests__/ReleaseGroupCard.test.tsx
@@ -7,9 +7,14 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => vi.fn(),
 }));
 
+let mockUser: { id: number; permissions: number } | null = {
+  id: 1,
+  permissions: Permission.IMPORT,
+};
+
 vi.mock("../../context/useAuth", () => ({
   useAuth: () => ({
-    user: { id: 1, permissions: Permission.ADMIN },
+    user: mockUser,
   }),
 }));
 
@@ -128,6 +133,7 @@ describe("ReleaseGroupCard", () => {
   afterEach(() => {
     vi.clearAllMocks();
     mockIsFollowing.mockReturnValue(false);
+    mockUser = { id: 1, permissions: Permission.IMPORT };
   });
 
   it("renders album title, artist name, and year", () => {
@@ -396,6 +402,26 @@ describe("ReleaseGroupCard", () => {
 
       expect(screen.queryByText("Follow artist")).not.toBeInTheDocument();
       expect(screen.queryByText("Unfollow artist")).not.toBeInTheDocument();
+    });
+
+    it("shows 'Upload files' option for a user with IMPORT permission", () => {
+      mockUser = { id: 2, permissions: Permission.IMPORT };
+      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
+
+      const moreButtons = screen.getAllByLabelText("More options");
+      fireEvent.click(moreButtons[0]);
+
+      expect(screen.getByText("Upload files")).toBeInTheDocument();
+    });
+
+    it("hides 'Upload files' option for a user without IMPORT permission", () => {
+      mockUser = { id: 3, permissions: Permission.REQUEST };
+      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
+
+      const moreButtons = screen.getAllByLabelText("More options");
+      fireEvent.click(moreButtons[0]);
+
+      expect(screen.queryByText("Upload files")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/LibraryPage/UploadPage.tsx
+++ b/src/pages/LibraryPage/UploadPage.tsx
@@ -50,12 +50,12 @@ export default function UploadPage() {
   const { user } = useAuth();
   const mbid = searchParams.get("mbid");
 
-  const isAdmin =
-    user !== null && hasPermission(user.permissions, Permission.ADMIN);
+  const canImport =
+    user !== null && hasPermission(user.permissions, Permission.IMPORT);
 
   useEffect(() => {
-    if (!isAdmin) navigate("/library/wanted", { replace: true });
-  }, [isAdmin, navigate]);
+    if (!canImport) navigate("/library/wanted", { replace: true });
+  }, [canImport, navigate]);
 
   const { info, loading: infoLoading } = useReleaseGroupInfo(mbid);
   const {
@@ -95,7 +95,7 @@ export default function UploadPage() {
     );
   }
 
-  if (!isAdmin) return null;
+  if (!canImport) return null;
 
   const hasFiles = files.length > 0;
   const isUploading = step === "uploading";

--- a/src/pages/LibraryPage/__tests__/UploadPage.test.tsx
+++ b/src/pages/LibraryPage/__tests__/UploadPage.test.tsx
@@ -4,6 +4,11 @@ import { Permission } from "@shared/permissions";
 
 const mockNavigate = vi.fn();
 
+let mockUser: { id: number; permissions: number } | null = {
+  id: 1,
+  permissions: Permission.IMPORT,
+};
+
 vi.mock("react-router-dom", () => ({
   useSearchParams: () => [new URLSearchParams("mbid=test-mbid-123")],
   useNavigate: () => mockNavigate,
@@ -23,7 +28,7 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/context/useAuth", () => ({
   useAuth: () => ({
-    user: { id: 1, permissions: Permission.ADMIN },
+    user: mockUser,
   }),
 }));
 
@@ -48,6 +53,7 @@ vi.mock("@/components/ImageWithShimmer", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUser = { id: 1, permissions: Permission.IMPORT };
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(
       JSON.stringify({
@@ -101,5 +107,22 @@ describe("UploadPage", () => {
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/musicbrainz/release-group/test-mbid-123"
     );
+  });
+
+  it("renders upload UI for a non-admin user with IMPORT permission", () => {
+    mockUser = { id: 2, permissions: Permission.IMPORT };
+    render(<UploadPage />);
+    expect(
+      screen.getByText("Drop audio files or a folder here, or click to browse")
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("redirects users without IMPORT permission", () => {
+    mockUser = { id: 3, permissions: Permission.REQUEST };
+    render(<UploadPage />);
+    expect(mockNavigate).toHaveBeenCalledWith("/library/wanted", {
+      replace: true,
+    });
   });
 });

--- a/src/pages/SettingsPage/sections/users/UsersSection/constants.ts
+++ b/src/pages/SettingsPage/sections/users/UsersSection/constants.ts
@@ -13,6 +13,7 @@ export const ASSIGNABLE_PERMISSIONS = [
   Permission.REQUEST,
   Permission.AUTO_APPROVE,
   Permission.REQUEST_VIEW,
+  Permission.IMPORT,
 ] as const;
 
 export const INITIAL_FORM: CreateFormState = {


### PR DESCRIPTION
Closes #153

## Summary
Adds a dedicated `IMPORT` permission so file uploads are no longer gated behind `ADMIN`. Users without the permission don't see the upload option, can't reach the upload page, and are blocked at every upload/import endpoint.

## Changes
- **New permission** `IMPORT = 64` (`shared/permissions.ts`), registered in `PERMISSION_LABELS`, `DISPLAYABLE_PERMISSIONS`, and the assignable list in **Settings → Users**.
- **Backend**: all 5 import endpoints (`/import/upload`, `/import/upload-file`, `/import/scan`, `/import/confirm`, `DELETE /import/:uploadId`) now require `Permission.IMPORT`.
- **Frontend**: "Upload files" menu item (`ReleaseGroupCard`, `PurchaseCard`) and the upload page route guard (`UploadPage`) check `IMPORT` instead of `ADMIN`.

## Notes
- Opt-in: no backfill migration. Existing non-admins do **not** gain upload access; admins keep it since `ADMIN` bypasses all checks. No DB migration needed — the new bit is simply unset on existing users.

## Tests
- `import.test.ts` asserts endpoints are guarded by `IMPORT`, not `ADMIN`.
- `UploadPage`, `ReleaseGroupCard`, `PurchaseCard` cover a non-admin user *with* `IMPORT` (sees upload) and one *without* (hidden / redirected).
- Full suites pass: `pnpm test` (770) and `pnpm test:server` (889); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)