### PR TITLE
feat: persist derived user profile (Step 1 / #166)

### DIFF
--- a/docs/user-profile-stabilization-rfc.md
+++ b/docs/user-profile-stabilization-rfc.md
@@ -107,6 +107,8 @@ Purchase`. `User.plex_token` exists; **no taste columns**. `Config` is global, n
 | Trend over time                   | —                          | No                    | Yes (time-series of snapshots) | Play counts: partially (bounded, prunable history). Ratings: no |
 
 Note: backing up ratings is **net-new ingestion** — tunearr does not read `userRating` today.
+Reachability confirmed (June 2026): the existing per-user token path can fetch it — see
+"Resolved: ratings ingestion" under Open questions.
 
 ### Snapshots vs. Plex's own history
 
@@ -239,10 +241,49 @@ The in-memory `userCache`/`recentlyShownByUser` maps fold into `UserProfile`.
 
 1. **Snapshot cadence** — on login, on a timer (cron-like), or both? How many to retain?
 2. **Profile TTL** — how stale before we force a regenerate? Per-user override?
-3. **Ratings ingestion** — confirm Plex exposes `userRating` per track/album via the existing
-   per-user token path; volume/perf of pulling it.
+3. **Ratings ingestion** — ~~confirm Plex exposes `userRating` per track/album via the existing
+   per-user token path; volume/perf of pulling it.~~ **Resolved (June 2026) — yes; see below.**
 4. **Multi-user** — snapshots are per-user; confirm storage growth is acceptable for many users.
 5. **Privacy / retention** — more per-user data on disk; deletion-on-user-removal must cascade.
+
+### Resolved: ratings ingestion (open question 3)
+
+**Verdict: yes — `userRating` is reachable through the per-user token path tunearr already
+has, and Step 2 is unblocked.** Investigated June 2026 against the live Plex API and the
+existing integration.
+
+- **Same token path, no new auth.** Plex resolves `userRating` per account: querying the PMS
+  with account A's token returns account A's own rating. This is the identical mechanism the
+  app already relies on for `viewCount` / play history in `server/api/plex/topArtists.ts`
+  (`store-plex-token` → `getServerAccessToken` → `User.plex_token` → request headers). No new
+  token flow is needed — each user reads **their own** ratings with **their own** stored
+  token.
+- **Why the "shared user" limitation does not apply.** Plex blocks an _owner's_ token from
+  reading a _friend's_ personal ratings. Tunearr never does this: every user queries with
+  their own token, which is exactly the case Plex supports. We never have one user read
+  another's data.
+- **Read endpoint + perf (the volume half of the question).** Use a server-side filter for
+  rated items only — e.g. `GET /library/sections/{sectionKey}/all?type=10&userRating>>=1`
+  (the `>>=` operator is Plex's "greater-or-equal"; confirm exact encoding in impl). This
+  means we **never scan the whole library** — one paginated, filtered query returns just the
+  (small) rated set. Container pagination (`X-Plex-Container-Size`) is already wired up in
+  `topArtists.ts`. Single-item reads via `GET /library/metadata/{ratingKey}` also carry
+  `userRating`.
+- **Field semantics.** Music ratings exist at artist (`type=8`), album (`type=9`) and track
+  (`type=10`); recommend ingesting albums + tracks. `userRating` is **absent** when an item
+  is unrated — treat missing as "no rating", not 0. Scale is 0–10 (half-star = 1 unit),
+  matching the existing `{ rating: 8 }` stub in `userProfile.test.ts` and the reserved
+  `"plex_rating"` `SignalKind`.
+
+Two caveats to handle during Step 2, neither blocking:
+
+- **Managed / Plex Home users** have no full plex.tv account and follow a different token
+  flow; `userRating` will not resolve for them. The common case (full Plex accounts) is
+  unaffected — just skip or flag managed users.
+- **`view_state_sync` is a per-user toggle** (`PUT /api/v2/user/view_state_sync`) governing
+  cross-platform sync. It does not affect single-PMS reads — music ratings are stored
+  server-side keyed to the account, so the metadata query returns them regardless. Don't
+  assume ratings made on _other_ servers are present.
 
 ## Out of scope
 
@@ -258,10 +299,12 @@ The in-memory `userCache`/`recentlyShownByUser` maps fold into `UserProfile`.
 Step 1 (persist the derived profile) is implemented — see **Implementation status** above.
 Discussion now moves to what comes after, in roughly dependency order:
 
-- **Step 2 — ratings ingestion + snapshots.** Gated on confirming Plex exposes `userRating`
-  via the per-user token path (open question 3). Writes `UserSignalEvent` rows
-  (`kind = "snapshot"` / `"plex_rating"`); the regen poller already exists as the cadence
-  home. This is the first feature that makes `UserSignalEvent` earn its place.
+- **Step 2 — ratings ingestion + snapshots.** **Unblocked** — open question 3 resolved
+  (Plex exposes `userRating` via the per-user token path; see "Resolved: ratings ingestion"
+  above). Read rated items with a server-side `userRating>>=1` filter on the existing token
+  path, then write `UserSignalEvent` rows (`kind = "snapshot"` / `"plex_rating"`); the regen
+  poller already exists as the cadence home. This is the first feature that makes
+  `UserSignalEvent` earn its place.
 - **Feed new signals into the vector.** The contributor-registry seam from #166 lets a
   rating / behaviour signal add weight to the _same_ `genreVector` without restructuring the
   recommender. Worth deciding the weighting model before Step 2 lands data.
@@ -272,5 +315,5 @@ Discussion now moves to what comes after, in roughly dependency order:
   rating/trend views from the snapshot log.
 - **Step 4 — export/restore.** Out of scope until there's a reason; noted for completeness.
 
-Open questions 1 (snapshot cadence), 2 (per-user TTL override), and 3 (ratings exposure)
-are the ones that block Step 2.
+Open questions 1 (snapshot cadence) and 2 (per-user TTL override) are the remaining
+decisions for Step 2; open question 3 (ratings exposure) is resolved.

--- a/docs/user-profile-stabilization-rfc.md
+++ b/docs/user-profile-stabilization-rfc.md
@@ -1,8 +1,57 @@
 # RFC: Stabilising user profiles
 
-Status: Draft / for discussion
+Status: Step 1 implemented — discussing next steps
 Tracking issue: [#144](https://github.com/BlieNuckel/tunearr/issues/144)
+Step 1 issues: [#166](https://github.com/BlieNuckel/tunearr/issues/166) (#167 entities, #168 recommender, #169 scheduler)
 Related: #137 (explore mode), #145 (explore-vs-Plex boundary), #136 (listening window + anti-repeat)
+
+## Implementation status
+
+**Step 1 (#166) is implemented** (persist the derived profile). The sections below are
+the original design; this block records what actually shipped and where it diverged.
+
+Done:
+
+- **Entities + migration (#167).** `UserProfile` (derived cache, one versioned JSON doc
+  per user) and `UserSignalEvent` (append-only, `kind`-tagged) in `server/db/entity/`,
+  migration `8_UserProfile`, both cascade-deleting with the owning user. Access helpers in
+  `server/db/userProfile.ts`.
+- **Profile-first recommender (#168).** `server/promotedAlbum/profileService.ts`:
+  `regenerateProfile(userId, plexToken)` (request-free, reused by the scheduler) and
+  `loadFreshProfile` (read-first; regenerate only on TTL expiry, `config_hash` mismatch, or
+  `schema_version` bump), guarded by a per-user `AsyncLock`. `getPromotedAlbum` /
+  `getPromotedArtists` now key on `userId`; the in-memory `userCache` /
+  `recentlyShownByUser` maps folded into the persisted `explorationHistory`.
+- **Background regeneration (#169).** `server/services/profile/regenPoller.ts` refreshes
+  stale **and** recently-active profiles off the request path, reusing the in-flight guard.
+
+Diverged from / refined beyond the original sketch:
+
+- **`DerivedProfile` carries `artistTags`** (`{ name, viewCount, tags: {name,count}[] }[]`)
+  in addition to `genreVector` + `explorationHistory`. The within-taste recommendation
+  `trace` ("How this was recommended") renders per-artist viewCounts + tag contributions,
+  which `genreVector` alone can't rebuild — without this, the trace's first two stages go
+  empty once a recommendation is served from the persisted profile (the normal path). Both
+  are produced in one regeneration pass so they can't disagree. We deliberately do **not**
+  store the raw unfiltered Last.fm tag dump: it's re-fetchable external data, and a config /
+  algorithm change flips `config_hash` and forces a clean refetch rather than recomputing a
+  stale snapshot.
+- **Two-layer cache** (was sketched, now concrete): long-lived persisted profile
+  (`profileTtlMinutes`, default 1440) + short-lived in-memory result cache
+  (`cacheDurationMinutes`, default 30). A refresh re-picks a tag/album off the cached vector
+  without re-running the Plex + Last.fm fan-out.
+- **New config** (`promotedAlbum.*`, validated, with Settings UI): `profileTtlMinutes`,
+  `backgroundRegenEnabled`, `backgroundRegenIntervalMinutes`,
+  `backgroundRegenActiveWithinMinutes`.
+
+Deferred, as planned:
+
+- **`similarGraph`** is still not stored, so **explore mode still fans out per request**
+  (ListenBrainz + Last.fm). It needs no migration to add later — just a field in
+  `DerivedProfile`.
+- **Ratings ingestion + snapshots (`UserSignalEvent` writes)** — Step 2. The table exists
+  and the regen poller is the intended home for the snapshot cadence.
+- **Taste page** (Step 3) and **export/restore** (Step 4).
 
 ## Problem
 
@@ -206,6 +255,22 @@ The in-memory `userCache`/`recentlyShownByUser` maps fold into `UserProfile`.
 
 ## Next step
 
-Agree on the open questions above, then split into an implementation issue: entities +
-migration first, snapshot/ingestion second, recommender profile-first path third, taste page
-last. Each lands with full frontend + backend tests per project policy.
+Step 1 (persist the derived profile) is implemented — see **Implementation status** above.
+Discussion now moves to what comes after, in roughly dependency order:
+
+- **Step 2 — ratings ingestion + snapshots.** Gated on confirming Plex exposes `userRating`
+  via the per-user token path (open question 3). Writes `UserSignalEvent` rows
+  (`kind = "snapshot"` / `"plex_rating"`); the regen poller already exists as the cadence
+  home. This is the first feature that makes `UserSignalEvent` earn its place.
+- **Feed new signals into the vector.** The contributor-registry seam from #166 lets a
+  rating / behaviour signal add weight to the _same_ `genreVector` without restructuring the
+  recommender. Worth deciding the weighting model before Step 2 lands data.
+- **`similarGraph` for explore mode.** Persist the ListenBrainz similar-artist graph in
+  `DerivedProfile` so explore stops fanning out per request (currently the one un-optimised
+  path). Migration-free field add.
+- **Step 3 — taste page.** Renders `genreVector` (top genres + weights) and, with Step 2,
+  rating/trend views from the snapshot log.
+- **Step 4 — export/restore.** Out of scope until there's a reason; noted for completeness.
+
+Open questions 1 (snapshot cadence), 2 (per-user TTL override), and 3 (ratings exposure)
+are the ones that block Step 2.

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -215,6 +215,12 @@ describe("promotedAlbum config", () => {
     ).toThrow("cacheDurationMinutes must be a non-negative number");
   });
 
+  it("validates profileTtlMinutes is non-negative", () => {
+    expect(() =>
+      setConfig({ promotedAlbum: { profileTtlMinutes: -1 } as never })
+    ).toThrow("profileTtlMinutes must be a non-negative number");
+  });
+
   it("validates libraryPreference enum", () => {
     expect(() =>
       setConfig({ promotedAlbum: { libraryPreference: "invalid" } as never })

--- a/server/config.ts
+++ b/server/config.ts
@@ -39,6 +39,9 @@ export type PromotedAlbumConfig = {
   explorationRate: number;
   exploreCandidateCount: number;
   genreOverlapThreshold: number;
+  backgroundRegenEnabled: boolean;
+  backgroundRegenIntervalMinutes: number;
+  backgroundRegenActiveWithinMinutes: number;
 };
 
 export type IConfig = {
@@ -110,6 +113,9 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   explorationRate: 0.5,
   exploreCandidateCount: 12,
   genreOverlapThreshold: 0.15,
+  backgroundRegenEnabled: true,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
 };
 
 const DEFAULT_CONFIG: IConfig = {
@@ -240,6 +246,17 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
   validateRatio(config.explorationRate, "explorationRate");
   validatePositiveInt(config.exploreCandidateCount, "exploreCandidateCount");
   validateRatio(config.genreOverlapThreshold, "genreOverlapThreshold");
+  if (typeof config.backgroundRegenEnabled !== "boolean") {
+    throw new Error("backgroundRegenEnabled must be a boolean");
+  }
+  validatePositiveInt(
+    config.backgroundRegenIntervalMinutes,
+    "backgroundRegenIntervalMinutes"
+  );
+  validatePositiveInt(
+    config.backgroundRegenActiveWithinMinutes,
+    "backgroundRegenActiveWithinMinutes"
+  );
   if (
     !VALID_LIBRARY_PREFERENCES.includes(
       config.libraryPreference as LibraryPreference

--- a/server/config.ts
+++ b/server/config.ts
@@ -27,6 +27,7 @@ export type SpendingConfig = {
 
 export type PromotedAlbumConfig = {
   cacheDurationMinutes: number;
+  profileTtlMinutes: number;
   topArtistsRange: TopArtistsRange;
   topArtistsCount: number;
   pickedArtistsCount: number;
@@ -84,6 +85,7 @@ export const DEFAULT_REQUEST_STATUS_POLL_INTERVAL_MS = 2 * 60 * 1000;
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
   topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 3,
@@ -212,6 +214,12 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
     config.cacheDurationMinutes < 0
   ) {
     throw new Error("cacheDurationMinutes must be a non-negative number");
+  }
+  if (
+    typeof config.profileTtlMinutes !== "number" ||
+    config.profileTtlMinutes < 0
+  ) {
+    throw new Error("profileTtlMinutes must be a non-negative number");
   }
   if (!VALID_TOP_ARTISTS_RANGES.includes(config.topArtistsRange)) {
     throw new Error(

--- a/server/db/dataSource.ts
+++ b/server/db/dataSource.ts
@@ -9,6 +9,8 @@ import { Purchase } from "./entity/Purchase";
 import { Config } from "./entity/Config";
 import { FollowedArtist } from "./entity/FollowedArtist";
 import { SeenRelease } from "./entity/SeenRelease";
+import { UserProfile } from "./entity/UserProfile";
+import { UserSignalEvent } from "./entity/UserSignalEvent";
 import { InitialSchema1709000000000 } from "./migration/1_InitialSchema";
 import { ConfigTable1710000000000 } from "./migration/2_ConfigTable";
 import { WantedItems1711000000000 } from "./migration/3_WantedItems";
@@ -16,6 +18,7 @@ import { Purchases1712000000000 } from "./migration/4_Purchases";
 import { FollowedArtists1713000000000 } from "./migration/5_FollowedArtists";
 import { FollowedLastViewedAt1714000000000 } from "./migration/6_FollowedLastViewedAt";
 import { RequestLidarrStatus1715000000000 } from "./migration/7_RequestLidarrStatus";
+import { UserProfile1716000000000 } from "./migration/8_UserProfile";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -41,6 +44,8 @@ export function createDataSource(dbPath?: string): DataSource {
       Config,
       FollowedArtist,
       SeenRelease,
+      UserProfile,
+      UserSignalEvent,
     ],
     migrations: [
       InitialSchema1709000000000,
@@ -50,6 +55,7 @@ export function createDataSource(dbPath?: string): DataSource {
       FollowedArtists1713000000000,
       FollowedLastViewedAt1714000000000,
       RequestLidarrStatus1715000000000,
+      UserProfile1716000000000,
     ],
     synchronize: false,
     migrationsRun: true,

--- a/server/db/entity/UserProfile.ts
+++ b/server/db/entity/UserProfile.ts
@@ -15,6 +15,11 @@ import { User } from "./User";
  */
 export type DerivedProfile = {
   genreVector: { tag: string; weight: number; fromArtists: string[] }[];
+  artistTags: {
+    name: string;
+    viewCount: number;
+    tags: { name: string; count: number }[];
+  }[];
   explorationHistory: { albums: string[]; artists: string[] };
 };
 

--- a/server/db/entity/UserProfile.ts
+++ b/server/db/entity/UserProfile.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm";
+import { User } from "./User";
+
+/**
+ * The derived, regenerable profile document persisted as `profile_json`.
+ * Adding a field here is migration-free: bump {@link DERIVED_PROFILE_SCHEMA_VERSION}
+ * and a version mismatch marks the stored row stale so it regenerates.
+ */
+export type DerivedProfile = {
+  genreVector: { tag: string; weight: number; fromArtists: string[] }[];
+  explorationHistory: { albums: string[]; artists: string[] };
+};
+
+export const DERIVED_PROFILE_SCHEMA_VERSION = 1;
+
+/** Derived, regenerable cache — one row per user, the whole profile as one document. */
+@Entity("user_profiles")
+export class UserProfile {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Index("idx_user_profiles_user_id", { unique: true })
+  @Column({ type: "integer" })
+  user_id!: number;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  @Column({ type: "text" })
+  profile_json!: string;
+
+  @Column({ type: "integer" })
+  schema_version!: number;
+
+  @Column({ type: "text" })
+  config_hash!: string;
+
+  @Column({ type: "text" })
+  generated_at!: string;
+
+  @Column({ type: "text" })
+  last_used_at!: string;
+}

--- a/server/db/entity/UserSignalEvent.ts
+++ b/server/db/entity/UserSignalEvent.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm";
+import { User } from "./User";
+
+/**
+ * The `kind` discriminator for an append-only raw signal. The set grows over time
+ * (ratings, behaviour, snapshots) without a migration — a new signal is a new string.
+ */
+export type SignalKind = "snapshot" | "plex_rating" | "request" | "skip";
+
+/** Authoritative, append-only raw signals — ratings, behaviour, snapshots all land here. */
+@Entity("user_signal_events")
+export class UserSignalEvent {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Index("idx_user_signal_events_user_id")
+  @Column({ type: "integer" })
+  user_id!: number;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  @Index("idx_user_signal_events_kind")
+  @Column({ type: "text" })
+  kind!: string;
+
+  @Column({ type: "text" })
+  payload!: string;
+
+  @Column({ type: "text" })
+  recorded_at!: string;
+}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -51,3 +51,10 @@ export { Config } from "./entity/Config";
 export { FollowedArtist } from "./entity/FollowedArtist";
 export type { ReleaseSource } from "./entity/SeenRelease";
 export { SeenRelease } from "./entity/SeenRelease";
+export type { DerivedProfile } from "./entity/UserProfile";
+export {
+  UserProfile,
+  DERIVED_PROFILE_SCHEMA_VERSION,
+} from "./entity/UserProfile";
+export type { SignalKind } from "./entity/UserSignalEvent";
+export { UserSignalEvent } from "./entity/UserSignalEvent";

--- a/server/db/migration.test.ts
+++ b/server/db/migration.test.ts
@@ -280,3 +280,138 @@ describe("FollowedArtists migration", () => {
     expect(rows).toHaveLength(0);
   });
 });
+
+describe("UserProfile migration", () => {
+  it("creates user_profiles and user_signal_events tables", async () => {
+    const db = await initTestDb();
+
+    const profileCols = (await db.query(
+      "PRAGMA table_info(user_profiles)"
+    )) as { name: string }[];
+    expect(profileCols.map((c) => c.name)).toEqual([
+      "id",
+      "user_id",
+      "profile_json",
+      "schema_version",
+      "config_hash",
+      "generated_at",
+      "last_used_at",
+    ]);
+
+    const eventCols = (await db.query(
+      "PRAGMA table_info(user_signal_events)"
+    )) as { name: string }[];
+    expect(eventCols.map((c) => c.name)).toEqual([
+      "id",
+      "user_id",
+      "kind",
+      "payload",
+      "recorded_at",
+    ]);
+  });
+
+  it("creates the expected indexes", async () => {
+    const db = await initTestDb();
+
+    const indexes = (await db.query(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_user_%' ORDER BY name"
+    )) as { name: string }[];
+    const names = indexes.map((i) => i.name);
+
+    expect(names).toContain("idx_user_profiles_user_id");
+    expect(names).toContain("idx_user_signal_events_user_id");
+    expect(names).toContain("idx_user_signal_events_kind");
+  });
+
+  it("enforces unique user_id on user_profiles", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["alice"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["alice"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO user_profiles (user_id, profile_json, schema_version, config_hash) VALUES (?, ?, ?, ?)",
+      [userId, "{}", 1, "hash"]
+    );
+
+    await expect(
+      db.query(
+        "INSERT INTO user_profiles (user_id, profile_json, schema_version, config_hash) VALUES (?, ?, ?, ?)",
+        [userId, "{}", 1, "hash"]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("queries signal events by kind and user_id", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["bob"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["bob"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO user_signal_events (user_id, kind, payload) VALUES (?, ?, ?)",
+      [userId, "snapshot", "{}"]
+    );
+    await db.query(
+      "INSERT INTO user_signal_events (user_id, kind, payload) VALUES (?, ?, ?)",
+      [userId, "plex_rating", "{}"]
+    );
+
+    const snapshots = (await db.query(
+      "SELECT * FROM user_signal_events WHERE user_id = ? AND kind = ?",
+      [userId, "snapshot"]
+    )) as unknown[];
+    expect(snapshots).toHaveLength(1);
+
+    const all = (await db.query(
+      "SELECT * FROM user_signal_events WHERE user_id = ?",
+      [userId]
+    )) as unknown[];
+    expect(all).toHaveLength(2);
+  });
+
+  it("cascades user_profiles and user_signal_events when user is deleted", async () => {
+    const db = await initTestDb();
+    await db.query("INSERT INTO users (username) VALUES (?)", ["carol"]);
+    const [{ id: userId }] = (await db.query(
+      "SELECT id FROM users WHERE username = ?",
+      ["carol"]
+    )) as { id: number }[];
+
+    await db.query(
+      "INSERT INTO user_profiles (user_id, profile_json, schema_version, config_hash) VALUES (?, ?, ?, ?)",
+      [userId, "{}", 1, "hash"]
+    );
+    await db.query(
+      "INSERT INTO user_signal_events (user_id, kind, payload) VALUES (?, ?, ?)",
+      [userId, "snapshot", "{}"]
+    );
+
+    await db.query("DELETE FROM users WHERE id = ?", [userId]);
+
+    const profiles = (await db.query(
+      "SELECT * FROM user_profiles WHERE user_id = ?",
+      [userId]
+    )) as unknown[];
+    const events = (await db.query(
+      "SELECT * FROM user_signal_events WHERE user_id = ?",
+      [userId]
+    )) as unknown[];
+    expect(profiles).toHaveLength(0);
+    expect(events).toHaveLength(0);
+  });
+
+  it("enforces foreign key on user_profiles.user_id", async () => {
+    const db = await initTestDb();
+    await expect(
+      db.query(
+        "INSERT INTO user_profiles (user_id, profile_json, schema_version, config_hash) VALUES (?, ?, ?, ?)",
+        [999, "{}", 1, "hash"]
+      )
+    ).rejects.toThrow();
+  });
+});

--- a/server/db/migration/8_UserProfile.ts
+++ b/server/db/migration/8_UserProfile.ts
@@ -1,0 +1,45 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserProfile1716000000000 implements MigrationInterface {
+  name = "UserProfile1716000000000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "user_profiles" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "user_id" INTEGER NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "profile_json" TEXT NOT NULL,
+        "schema_version" INTEGER NOT NULL,
+        "config_hash" TEXT NOT NULL,
+        "generated_at" TEXT NOT NULL DEFAULT (datetime('now')),
+        "last_used_at" TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "idx_user_profiles_user_id" ON "user_profiles"("user_id")`
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "user_signal_events" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "user_id" INTEGER NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "kind" TEXT NOT NULL,
+        "payload" TEXT NOT NULL,
+        "recorded_at" TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_user_signal_events_user_id" ON "user_signal_events"("user_id")`
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_user_signal_events_kind" ON "user_signal_events"("kind")`
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_signal_events"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_profiles"`);
+  }
+}

--- a/server/db/userProfile.test.ts
+++ b/server/db/userProfile.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initializeDatabase, getDataSource, closeDatabase } from "./index";
+import type { DerivedProfile } from "./entity/UserProfile";
+import { DERIVED_PROFILE_SCHEMA_VERSION } from "./entity/UserProfile";
+import {
+  serializeDerivedProfile,
+  parseDerivedProfile,
+  computeConfigHash,
+  getUserProfile,
+  upsertUserProfile,
+  touchProfileUsed,
+  appendSignalEvent,
+  getSignalEvents,
+} from "./userProfile";
+
+const SAMPLE_PROFILE: DerivedProfile = {
+  genreVector: [
+    { tag: "shoegaze", weight: 42, fromArtists: ["Slowdive", "Ride"] },
+    { tag: "dream pop", weight: 17, fromArtists: ["Beach House"] },
+  ],
+  explorationHistory: {
+    albums: ["mbid-album-1", "mbid-album-2"],
+    artists: ["mbid-artist-1"],
+  },
+};
+
+const CONFIG_INPUTS = {
+  topArtistsRange: "6months",
+  genericTags: ["seen live", "favorites"],
+  tagsPerArtist: 5,
+  pickedArtistsCount: 3,
+};
+
+async function createUser(username: string): Promise<number> {
+  await getDataSource().query("INSERT INTO users (username) VALUES (?)", [
+    username,
+  ]);
+  const [{ id }] = (await getDataSource().query(
+    "SELECT id FROM users WHERE username = ?",
+    [username]
+  )) as { id: number }[];
+  return id;
+}
+
+beforeEach(async () => {
+  await initializeDatabase(":memory:");
+});
+
+afterEach(async () => {
+  await closeDatabase();
+});
+
+describe("serializeDerivedProfile / parseDerivedProfile", () => {
+  it("round-trips a profile", () => {
+    const json = serializeDerivedProfile(SAMPLE_PROFILE);
+    expect(parseDerivedProfile(json)).toEqual(SAMPLE_PROFILE);
+  });
+
+  it("returns an empty profile for invalid JSON", () => {
+    expect(parseDerivedProfile("not json")).toEqual({
+      genreVector: [],
+      explorationHistory: { albums: [], artists: [] },
+    });
+  });
+
+  it("fills missing fields with empty defaults", () => {
+    expect(parseDerivedProfile(JSON.stringify({ genreVector: [] }))).toEqual({
+      genreVector: [],
+      explorationHistory: { albums: [], artists: [] },
+    });
+  });
+});
+
+describe("computeConfigHash", () => {
+  it("is stable for the same inputs", () => {
+    expect(computeConfigHash(CONFIG_INPUTS)).toBe(
+      computeConfigHash(CONFIG_INPUTS)
+    );
+  });
+
+  it("is insensitive to genericTags order and case", () => {
+    expect(
+      computeConfigHash({
+        ...CONFIG_INPUTS,
+        genericTags: ["Favorites", "SEEN live"],
+      })
+    ).toBe(computeConfigHash(CONFIG_INPUTS));
+  });
+
+  it("changes when a shaping field changes", () => {
+    expect(computeConfigHash({ ...CONFIG_INPUTS, tagsPerArtist: 6 })).not.toBe(
+      computeConfigHash(CONFIG_INPUTS)
+    );
+    expect(
+      computeConfigHash({ ...CONFIG_INPUTS, topArtistsRange: "all" })
+    ).not.toBe(computeConfigHash(CONFIG_INPUTS));
+  });
+});
+
+describe("upsertUserProfile / getUserProfile", () => {
+  it("returns null when no profile exists", async () => {
+    const userId = await createUser("alice");
+    expect(await getUserProfile(userId)).toBeNull();
+  });
+
+  it("creates a profile then reads it back", async () => {
+    const userId = await createUser("alice");
+    const hash = computeConfigHash(CONFIG_INPUTS);
+
+    await upsertUserProfile(userId, SAMPLE_PROFILE, hash);
+
+    const row = await getUserProfile(userId);
+    expect(row).not.toBeNull();
+    expect(row!.user_id).toBe(userId);
+    expect(row!.config_hash).toBe(hash);
+    expect(row!.schema_version).toBe(DERIVED_PROFILE_SCHEMA_VERSION);
+    expect(parseDerivedProfile(row!.profile_json)).toEqual(SAMPLE_PROFILE);
+  });
+
+  it("updates the existing row instead of inserting a second one", async () => {
+    const userId = await createUser("alice");
+    await upsertUserProfile(userId, SAMPLE_PROFILE, "hash-1");
+
+    const updated: DerivedProfile = {
+      genreVector: [{ tag: "techno", weight: 9, fromArtists: ["Aphex Twin"] }],
+      explorationHistory: { albums: [], artists: [] },
+    };
+    await upsertUserProfile(userId, updated, "hash-2");
+
+    const rows = await getDataSource().query(
+      "SELECT * FROM user_profiles WHERE user_id = ?",
+      [userId]
+    );
+    expect(rows).toHaveLength(1);
+
+    const row = await getUserProfile(userId);
+    expect(row!.config_hash).toBe("hash-2");
+    expect(parseDerivedProfile(row!.profile_json)).toEqual(updated);
+  });
+});
+
+describe("touchProfileUsed", () => {
+  it("advances last_used_at without changing generated_at", async () => {
+    const userId = await createUser("alice");
+    await upsertUserProfile(userId, SAMPLE_PROFILE, "hash");
+    const before = await getUserProfile(userId);
+
+    await getDataSource().query(
+      "UPDATE user_profiles SET last_used_at = ? WHERE user_id = ?",
+      ["2000-01-01T00:00:00.000Z", userId]
+    );
+    await touchProfileUsed(userId);
+
+    const after = await getUserProfile(userId);
+    expect(after!.last_used_at).not.toBe("2000-01-01T00:00:00.000Z");
+    expect(after!.generated_at).toBe(before!.generated_at);
+  });
+});
+
+describe("appendSignalEvent / getSignalEvents", () => {
+  it("appends and reads back events for a user", async () => {
+    const userId = await createUser("alice");
+    await appendSignalEvent(userId, "snapshot", { artists: 3 });
+
+    const events = await getSignalEvents(userId);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("snapshot");
+    expect(JSON.parse(events[0].payload)).toEqual({ artists: 3 });
+  });
+
+  it("filters by kind", async () => {
+    const userId = await createUser("alice");
+    await appendSignalEvent(userId, "snapshot", {});
+    await appendSignalEvent(userId, "plex_rating", { rating: 8 });
+    await appendSignalEvent(userId, "snapshot", {});
+
+    expect(await getSignalEvents(userId, "snapshot")).toHaveLength(2);
+    expect(await getSignalEvents(userId, "plex_rating")).toHaveLength(1);
+  });
+
+  it("scopes events to the owning user", async () => {
+    const alice = await createUser("alice");
+    const bob = await createUser("bob");
+    await appendSignalEvent(alice, "snapshot", {});
+    await appendSignalEvent(bob, "snapshot", {});
+
+    expect(await getSignalEvents(alice)).toHaveLength(1);
+    expect(await getSignalEvents(bob)).toHaveLength(1);
+  });
+});

--- a/server/db/userProfile.test.ts
+++ b/server/db/userProfile.test.ts
@@ -18,6 +18,13 @@ const SAMPLE_PROFILE: DerivedProfile = {
     { tag: "shoegaze", weight: 42, fromArtists: ["Slowdive", "Ride"] },
     { tag: "dream pop", weight: 17, fromArtists: ["Beach House"] },
   ],
+  artistTags: [
+    {
+      name: "Slowdive",
+      viewCount: 30,
+      tags: [{ name: "shoegaze", count: 100 }],
+    },
+  ],
   explorationHistory: {
     albums: ["mbid-album-1", "mbid-album-2"],
     artists: ["mbid-artist-1"],
@@ -59,6 +66,7 @@ describe("serializeDerivedProfile / parseDerivedProfile", () => {
   it("returns an empty profile for invalid JSON", () => {
     expect(parseDerivedProfile("not json")).toEqual({
       genreVector: [],
+      artistTags: [],
       explorationHistory: { albums: [], artists: [] },
     });
   });
@@ -66,6 +74,7 @@ describe("serializeDerivedProfile / parseDerivedProfile", () => {
   it("fills missing fields with empty defaults", () => {
     expect(parseDerivedProfile(JSON.stringify({ genreVector: [] }))).toEqual({
       genreVector: [],
+      artistTags: [],
       explorationHistory: { albums: [], artists: [] },
     });
   });
@@ -123,6 +132,7 @@ describe("upsertUserProfile / getUserProfile", () => {
 
     const updated: DerivedProfile = {
       genreVector: [{ tag: "techno", weight: 9, fromArtists: ["Aphex Twin"] }],
+      artistTags: [],
       explorationHistory: { albums: [], artists: [] },
     };
     await upsertUserProfile(userId, updated, "hash-2");

--- a/server/db/userProfile.ts
+++ b/server/db/userProfile.ts
@@ -1,0 +1,122 @@
+import { createHash } from "crypto";
+import { getDataSource } from "./index";
+import {
+  UserProfile,
+  DERIVED_PROFILE_SCHEMA_VERSION,
+  type DerivedProfile,
+} from "./entity/UserProfile";
+import { UserSignalEvent } from "./entity/UserSignalEvent";
+
+/** The config fields that shape the derived profile and thus invalidate it on change. */
+export type ProfileConfigInputs = {
+  topArtistsRange: string;
+  genericTags: string[];
+  tagsPerArtist: number;
+  pickedArtistsCount: number;
+};
+
+const EMPTY_DERIVED_PROFILE: DerivedProfile = {
+  genreVector: [],
+  explorationHistory: { albums: [], artists: [] },
+};
+
+export function serializeDerivedProfile(profile: DerivedProfile): string {
+  return JSON.stringify(profile);
+}
+
+/**
+ * Parse a stored `profile_json`. Returns an empty profile when the stored shape is
+ * unreadable so callers never crash on a corrupt/legacy row — a regenerate replaces it.
+ */
+export function parseDerivedProfile(json: string): DerivedProfile {
+  try {
+    const parsed = JSON.parse(json) as Partial<DerivedProfile>;
+    return {
+      genreVector: parsed.genreVector ?? [],
+      explorationHistory: {
+        albums: parsed.explorationHistory?.albums ?? [],
+        artists: parsed.explorationHistory?.artists ?? [],
+      },
+    };
+  } catch {
+    return { ...EMPTY_DERIVED_PROFILE };
+  }
+}
+
+/** Stable hash of the config inputs that shape the vector — a mismatch forces a regenerate. */
+export function computeConfigHash(inputs: ProfileConfigInputs): string {
+  const stable = JSON.stringify({
+    topArtistsRange: inputs.topArtistsRange,
+    genericTags: [...inputs.genericTags].map((t) => t.toLowerCase()).sort(),
+    tagsPerArtist: inputs.tagsPerArtist,
+    pickedArtistsCount: inputs.pickedArtistsCount,
+  });
+  return createHash("sha256").update(stable).digest("hex");
+}
+
+export async function getUserProfile(
+  userId: number
+): Promise<UserProfile | null> {
+  const repo = getDataSource().getRepository(UserProfile);
+  return repo.findOne({ where: { user_id: userId } });
+}
+
+/**
+ * Insert or replace the derived profile for a user. Stamps `generated_at` and
+ * `last_used_at` to now and writes the current {@link DERIVED_PROFILE_SCHEMA_VERSION}.
+ */
+export async function upsertUserProfile(
+  userId: number,
+  profile: DerivedProfile,
+  configHash: string
+): Promise<UserProfile> {
+  const repo = getDataSource().getRepository(UserProfile);
+  const now = new Date().toISOString();
+  const existing = await repo.findOne({ where: { user_id: userId } });
+
+  const entity = repo.create({
+    ...(existing ?? {}),
+    user_id: userId,
+    profile_json: serializeDerivedProfile(profile),
+    schema_version: DERIVED_PROFILE_SCHEMA_VERSION,
+    config_hash: configHash,
+    generated_at: now,
+    last_used_at: now,
+  });
+
+  return repo.save(entity);
+}
+
+export async function touchProfileUsed(userId: number): Promise<void> {
+  const repo = getDataSource().getRepository(UserProfile);
+  await repo.update(
+    { user_id: userId },
+    { last_used_at: new Date().toISOString() }
+  );
+}
+
+export async function appendSignalEvent(
+  userId: number,
+  kind: string,
+  payload: unknown
+): Promise<UserSignalEvent> {
+  const repo = getDataSource().getRepository(UserSignalEvent);
+  const entity = repo.create({
+    user_id: userId,
+    kind,
+    payload: JSON.stringify(payload),
+    recorded_at: new Date().toISOString(),
+  });
+  return repo.save(entity);
+}
+
+export async function getSignalEvents(
+  userId: number,
+  kind?: string
+): Promise<UserSignalEvent[]> {
+  const repo = getDataSource().getRepository(UserSignalEvent);
+  return repo.find({
+    where: kind ? { user_id: userId, kind } : { user_id: userId },
+    order: { recorded_at: "ASC", id: "ASC" },
+  });
+}

--- a/server/db/userProfile.ts
+++ b/server/db/userProfile.ts
@@ -15,10 +15,20 @@ export type ProfileConfigInputs = {
   pickedArtistsCount: number;
 };
 
+/** A partial patch of the anti-repeat exploration memory; only provided fields are replaced. */
+export type ExplorationHistoryPatch = {
+  albums?: string[];
+  artists?: string[];
+};
+
 const EMPTY_DERIVED_PROFILE: DerivedProfile = {
   genreVector: [],
+  artistTags: [],
   explorationHistory: { albums: [], artists: [] },
 };
+
+/** Far-past timestamp so a profile row created only to hold exploration memory reads as stale. */
+const STALE_GENERATED_AT = "1970-01-01T00:00:00.000Z";
 
 export function serializeDerivedProfile(profile: DerivedProfile): string {
   return JSON.stringify(profile);
@@ -33,6 +43,7 @@ export function parseDerivedProfile(json: string): DerivedProfile {
     const parsed = JSON.parse(json) as Partial<DerivedProfile>;
     return {
       genreVector: parsed.genreVector ?? [],
+      artistTags: parsed.artistTags ?? [],
       explorationHistory: {
         albums: parsed.explorationHistory?.albums ?? [],
         artists: parsed.explorationHistory?.artists ?? [],
@@ -93,6 +104,52 @@ export async function touchProfileUsed(userId: number): Promise<void> {
     { user_id: userId },
     { last_used_at: new Date().toISOString() }
   );
+}
+
+/**
+ * Merge a patch into the persisted exploration (anti-repeat) memory without touching
+ * the derived vector or its provenance. When no profile row exists yet, a placeholder
+ * row is created stamped stale so the next recommendation regenerates the vector.
+ */
+export async function updateExplorationHistory(
+  userId: number,
+  patch: ExplorationHistoryPatch
+): Promise<void> {
+  const repo = getDataSource().getRepository(UserProfile);
+  const existing = await repo.findOne({ where: { user_id: userId } });
+
+  if (existing) {
+    const profile = parseDerivedProfile(existing.profile_json);
+    const next: DerivedProfile = {
+      ...profile,
+      explorationHistory: {
+        albums: patch.albums ?? profile.explorationHistory.albums,
+        artists: patch.artists ?? profile.explorationHistory.artists,
+      },
+    };
+    await repo.update(
+      { user_id: userId },
+      { profile_json: serializeDerivedProfile(next) }
+    );
+    return;
+  }
+
+  const placeholder: DerivedProfile = {
+    ...EMPTY_DERIVED_PROFILE,
+    explorationHistory: {
+      albums: patch.albums ?? [],
+      artists: patch.artists ?? [],
+    },
+  };
+  const entity = repo.create({
+    user_id: userId,
+    profile_json: serializeDerivedProfile(placeholder),
+    schema_version: DERIVED_PROFILE_SCHEMA_VERSION,
+    config_hash: "",
+    generated_at: STALE_GENERATED_AT,
+    last_used_at: new Date().toISOString(),
+  });
+  await repo.save(entity);
 }
 
 export async function appendSignalEvent(

--- a/server/db/userProfile.ts
+++ b/server/db/userProfile.ts
@@ -167,6 +167,36 @@ export async function appendSignalEvent(
   return repo.save(entity);
 }
 
+/** A persisted profile paired with its owner's Plex token, for background regeneration. */
+export type ProfileRegenCandidate = {
+  userId: number;
+  plexToken: string;
+  profile: UserProfile;
+};
+
+/**
+ * Every persisted profile owned by an enabled user with a stored Plex token. The
+ * background regenerator filters these by staleness + activity; users who never
+ * used discovery have no row and are intentionally absent (no quota spent on them).
+ */
+export async function getProfileRegenCandidates(): Promise<
+  ProfileRegenCandidate[]
+> {
+  const rows = (await getDataSource().query(
+    `SELECT p.id, p.user_id, p.profile_json, p.schema_version, p.config_hash,
+            p.generated_at, p.last_used_at, u.plex_token AS plex_token
+     FROM user_profiles p
+     JOIN users u ON u.id = p.user_id
+     WHERE u.plex_token IS NOT NULL AND u.enabled = 1`
+  )) as (UserProfile & { plex_token: string })[];
+
+  return rows.map((row) => ({
+    userId: row.user_id,
+    plexToken: row.plex_token,
+    profile: row,
+  }));
+}
+
 export async function getSignalEvents(
   userId: number,
   kind?: string

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import wantedRoutes from "./routes/wanted";
 import followedRoutes from "./routes/followed";
 import { startFollowedArtistPoller } from "./services/followed/poller";
 import { startRequestStatusPoller } from "./services/requests/statusPoller";
+import { startProfileRegenPoller } from "./services/profile/regenPoller";
 import { getConfig } from "./config";
 
 const log = createLogger("Server");
@@ -78,6 +79,10 @@ startFollowedArtistPoller(followedPollIntervalMs);
 const requestStatusPollIntervalMs =
   getConfig().requestStatusPollIntervalMs ?? 2 * 60 * 1000;
 startRequestStatusPoller(requestStatusPollIntervalMs);
+
+const profileRegenIntervalMs =
+  getConfig().promotedAlbum.backgroundRegenIntervalMinutes * 60 * 1000;
+startProfileRegenPoller(profileRegenIntervalMs);
 
 app.listen(PORT, () => {
   log.info(`Listening on port ${PORT}`);

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -108,6 +108,9 @@ const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
     "all",
   ],
   libraryPreference: "prefer_new",
+  backgroundRegenEnabled: false,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
 };
 
 let userId: number;

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { PromotedAlbumConfig } from "../config";
 
 const mockGetTopArtists = vi.fn();
@@ -47,6 +47,7 @@ vi.mock("../config", () => ({
 }));
 
 import { getPromotedAlbum, clearPromotedAlbumCache } from "./getPromotedAlbum";
+import { initializeDatabase, closeDatabase, getDataSource } from "../db";
 import type { WithinTasteResult, ExploreResult } from "./types";
 
 /** Narrows a result to within-taste; the suite forces this via explorationRate: 0. */
@@ -68,8 +69,21 @@ function ex(
   return result;
 }
 
+async function createUserWithToken(token: string): Promise<number> {
+  const ds = getDataSource();
+  await ds.query(
+    "INSERT INTO users (plex_token, user_type, enabled) VALUES (?, 'plex', 1)",
+    [token]
+  );
+  const rows = (await ds.query("SELECT id FROM users WHERE plex_token = ?", [
+    token,
+  ])) as { id: number }[];
+  return rows[rows.length - 1].id;
+}
+
 const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
   topArtistsRange: "6months",
   topArtistsCount: 10,
   explorationRate: 0,
@@ -96,7 +110,9 @@ const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   libraryPreference: "prefer_new",
 };
 
-beforeEach(() => {
+let userId: number;
+
+beforeEach(async () => {
   vi.clearAllMocks();
   clearPromotedAlbumCache();
   vi.spyOn(Math, "random").mockReturnValue(0.1);
@@ -104,6 +120,12 @@ beforeEach(() => {
   mockGetReleaseGroupIdFromRelease.mockImplementation((mbid: string) =>
     Promise.resolve({ id: `rg-${mbid}`, firstReleaseDate: "1997-06-16" })
   );
+  await initializeDatabase(":memory:");
+  userId = await createUserWithToken("test-plex-token");
+});
+
+afterEach(async () => {
+  await closeDatabase();
 });
 
 const plexArtists = [
@@ -144,7 +166,7 @@ describe("getPromotedAlbum", () => {
       data: [],
     });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     expect(result!.album).toEqual({
       name: expect.any(String),
@@ -165,13 +187,25 @@ describe("getPromotedAlbum", () => {
     );
   });
 
+  it("returns null when the user has no stored Plex token", async () => {
+    const tokenlessId = (
+      (await getDataSource().query(
+        "INSERT INTO users (user_type, enabled) VALUES ('local', 1) RETURNING id"
+      )) as { id: number }[]
+    )[0].id;
+
+    const result = await getPromotedAlbum(tokenlessId);
+    expect(result).toBeNull();
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+  });
+
   it("fetches both page 1 and a deep page of tag albums", async () => {
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    await getPromotedAlbum("test-plex-token");
+    await getPromotedAlbum(userId);
 
     expect(mockGetTopAlbumsByTag).toHaveBeenCalledTimes(2);
     const calls = mockGetTopAlbumsByTag.mock.calls;
@@ -184,7 +218,7 @@ describe("getPromotedAlbum", () => {
   it("returns null when Plex has no artists", async () => {
     mockGetTopArtists.mockResolvedValue([]);
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
@@ -195,7 +229,7 @@ describe("getPromotedAlbum", () => {
       { name: "favorites", count: 80 },
     ]);
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
@@ -203,7 +237,7 @@ describe("getPromotedAlbum", () => {
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockRejectedValue(new Error("API error"));
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
@@ -218,7 +252,7 @@ describe("getPromotedAlbum", () => {
     });
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
@@ -239,7 +273,7 @@ describe("getPromotedAlbum", () => {
       });
     });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     expect(result!.inLibrary).toBe(true);
   });
@@ -258,35 +292,40 @@ describe("getPromotedAlbum", () => {
       return Promise.resolve({ ok: true, data: [] });
     });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     expect(result!.inLibrary).toBe(false);
   });
 
-  it("returns cached result within 30 minutes", async () => {
+  it("returns the cached result within the result-cache TTL", async () => {
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    const first = await getPromotedAlbum("test-plex-token");
+    const first = await getPromotedAlbum(userId);
     mockGetTopArtists.mockClear();
+    mockGetTopAlbumsByTag.mockClear();
 
-    const second = await getPromotedAlbum("test-plex-token");
+    const second = await getPromotedAlbum(userId);
     expect(second).toEqual(first);
     expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockGetTopAlbumsByTag).not.toHaveBeenCalled();
   });
 
-  it("caches results per user — different tokens get independent results", async () => {
+  it("caches results per user — different users get independent results", async () => {
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    await getPromotedAlbum("user-a-token");
+    const userA = await createUserWithToken("user-a-token");
+    const userB = await createUserWithToken("user-b-token");
+
+    await getPromotedAlbum(userA);
     mockGetTopArtists.mockClear();
 
-    await getPromotedAlbum("user-b-token");
+    await getPromotedAlbum(userB);
     expect(mockGetTopArtists).toHaveBeenCalledWith(
       "user-b-token",
       10,
@@ -294,17 +333,19 @@ describe("getPromotedAlbum", () => {
     );
   });
 
-  it("busts cache when forceRefresh is true", async () => {
+  it("force refresh re-selects an album without re-running the fan-out", async () => {
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    await getPromotedAlbum("test-plex-token");
+    await getPromotedAlbum(userId);
     mockGetTopArtists.mockClear();
+    mockGetTopAlbumsByTag.mockClear();
 
-    await getPromotedAlbum("test-plex-token", true);
-    expect(mockGetTopArtists).toHaveBeenCalled();
+    await getPromotedAlbum(userId, true);
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockGetTopAlbumsByTag).toHaveBeenCalled();
   });
 
   it("falls back gracefully when Lidarr is unavailable", async () => {
@@ -313,7 +354,7 @@ describe("getPromotedAlbum", () => {
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockRejectedValue(new Error("Connection refused"));
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     expect(result!.inLibrary).toBe(false);
   });
@@ -324,29 +365,48 @@ describe("getPromotedAlbum", () => {
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: false, status: 500, data: {} });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     expect(result!.inLibrary).toBe(false);
   });
 
-  it("refetches after cache expires based on config duration", async () => {
+  it("re-selects an album after the result cache expires, without re-fanning-out", async () => {
     vi.useFakeTimers();
     mockGetTopArtists.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    await getPromotedAlbum("test-plex-token");
+    await getPromotedAlbum(userId);
     mockGetTopArtists.mockClear();
+    mockGetTopAlbumsByTag.mockClear();
 
     vi.advanceTimersByTime(31 * 60 * 1000);
-    await getPromotedAlbum("test-plex-token");
+    await getPromotedAlbum(userId);
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockGetTopAlbumsByTag).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("regenerates the profile after the profile TTL expires", async () => {
+    vi.useFakeTimers();
+    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockGetArtistTopTags.mockResolvedValue(tags);
+    mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+    mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+    await getPromotedAlbum(userId);
+    mockGetTopArtists.mockClear();
+
+    vi.advanceTimersByTime((1440 + 1) * 60 * 1000);
+    await getPromotedAlbum(userId);
     expect(mockGetTopArtists).toHaveBeenCalled();
 
     vi.useRealTimers();
   });
 
-  it("respects custom cache duration from config", async () => {
+  it("respects custom result-cache duration from config", async () => {
     vi.useFakeTimers();
     mockGetConfigValue.mockReturnValue({
       ...defaultPromotedAlbumConfig,
@@ -357,12 +417,12 @@ describe("getPromotedAlbum", () => {
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    await getPromotedAlbum("test-plex-token");
-    mockGetTopArtists.mockClear();
+    await getPromotedAlbum(userId);
+    mockGetTopAlbumsByTag.mockClear();
 
     vi.advanceTimersByTime(6 * 60 * 1000);
-    await getPromotedAlbum("test-plex-token");
-    expect(mockGetTopArtists).toHaveBeenCalled();
+    await getPromotedAlbum(userId);
+    expect(mockGetTopAlbumsByTag).toHaveBeenCalled();
 
     vi.useRealTimers();
   });
@@ -385,7 +445,7 @@ describe("getPromotedAlbum", () => {
     mockGetTopAlbumsByTag.mockResolvedValue(duplicatedPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).not.toBeNull();
     // MBID is converted from release to release-group
     expect(result!.album.mbid).toBe("rg-alb-1");
@@ -398,7 +458,7 @@ describe("getPromotedAlbum", () => {
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
     mockGetReleaseGroupIdFromRelease.mockResolvedValue(null);
 
-    const result = await getPromotedAlbum("test-plex-token");
+    const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
@@ -409,11 +469,26 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const first = await getPromotedAlbum("test-plex-token");
-      const second = await getPromotedAlbum("test-plex-token", true);
+      const first = await getPromotedAlbum(userId);
+      const second = await getPromotedAlbum(userId, true);
 
       expect(first).not.toBeNull();
       expect(second).not.toBeNull();
+      expect(second!.album.mbid).not.toBe(first!.album.mbid);
+    });
+
+    it("persists anti-repeat memory across a simulated restart", async () => {
+      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockGetArtistTopTags.mockResolvedValue(tags);
+      mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
+      mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+      const first = await getPromotedAlbum(userId);
+
+      // Simulate a restart: in-memory result cache is gone, DB persists.
+      clearPromotedAlbumCache();
+
+      const second = await getPromotedAlbum(userId, true);
       expect(second!.album.mbid).not.toBe(first!.album.mbid);
     });
 
@@ -426,8 +501,8 @@ describe("getPromotedAlbum", () => {
       });
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const first = await getPromotedAlbum("test-plex-token");
-      const second = await getPromotedAlbum("test-plex-token", true);
+      const first = await getPromotedAlbum(userId);
+      const second = await getPromotedAlbum(userId, true);
 
       expect(first).not.toBeNull();
       expect(second!.album.mbid).toBe(first!.album.mbid);
@@ -441,7 +516,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(wt(result).trace.plexArtists).toHaveLength(2);
       expect(wt(result).trace.plexArtists.map((a) => a.name)).toEqual([
         "Radiohead",
@@ -449,13 +524,13 @@ describe("getPromotedAlbum", () => {
       ]);
     });
 
-    it("marks the correct artists as picked", async () => {
+    it("marks the picked artists", async () => {
       mockGetTopArtists.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       const picked = wt(result).trace.plexArtists.filter((a) => a.picked);
       expect(picked).toHaveLength(2);
     });
@@ -466,7 +541,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(wt(result).trace.chosenTag.name).toBe(wt(result).tag);
     });
 
@@ -476,7 +551,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       const { albumPool } = wt(result).trace;
       expect(albumPool.page1Count).toBe(2);
       expect(albumPool.deepPageCount).toBe(2);
@@ -491,7 +566,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result!.trace.selectionReason).toBe("preferred_non_library");
     });
 
@@ -515,7 +590,7 @@ describe("getPromotedAlbum", () => {
         });
       });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result!.trace.selectionReason).toBe("fallback_in_library");
     });
 
@@ -525,7 +600,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       const altTag = wt(result).trace.weightedTags.find(
         (t) => t.name === "alternative"
       );
@@ -541,7 +616,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       const radiohead = wt(result).trace.plexArtists.find(
         (a) => a.name === "Radiohead"
       );
@@ -561,7 +636,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      await getPromotedAlbum("test-plex-token");
+      await getPromotedAlbum(userId);
       expect(mockGetTopArtists).toHaveBeenCalledWith(
         "test-plex-token",
         5,
@@ -579,7 +654,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      await getPromotedAlbum("test-plex-token");
+      await getPromotedAlbum(userId);
       expect(mockGetTopArtists).toHaveBeenCalledWith(
         "test-plex-token",
         10,
@@ -597,7 +672,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       if (result) {
         expect(wt(result).tag).toBe("rock");
       }
@@ -640,7 +715,7 @@ describe("getPromotedAlbum", () => {
         return Promise.resolve({ ok: true, data: [] });
       });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result).not.toBeNull();
       expect(result!.trace.selectionReason).toBe("preferred_library");
       expect(result!.album.artistMbid).toBe("lib-art-1");
@@ -656,7 +731,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result).not.toBeNull();
       expect(result!.trace.selectionReason).toBe("no_preference");
     });
@@ -672,7 +747,7 @@ describe("getPromotedAlbum", () => {
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
-      await getPromotedAlbum("test-plex-token");
+      await getPromotedAlbum(userId);
       const calls = mockGetTopAlbumsByTag.mock.calls;
       expect(calls[1][1]).toBe("5");
     });
@@ -747,7 +822,7 @@ describe("getPromotedAlbum", () => {
     it("surfaces a genre-distant album from a similar artist", async () => {
       setupExplore();
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(ex(result).mode).toBe("explore");
       expect(ex(result).seedArtist).toBe("Radiohead");
       expect(ex(result).album.name).toBe("Blue Album");
@@ -759,14 +834,14 @@ describe("getPromotedAlbum", () => {
     it("reports the new genres the seed does not share", async () => {
       setupExplore();
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(ex(result).newGenres).toEqual(["jazz", "bebop"]);
     });
 
     it("chooses the genre-distant candidate, not the same-genre one", async () => {
       setupExplore();
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       const { candidates, chosenArtist } = ex(result).trace;
       expect(chosenArtist).toBe("Jazz Cat");
 
@@ -783,7 +858,7 @@ describe("getPromotedAlbum", () => {
       mockGetArtistMbidByName.mockResolvedValue(null);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result!.mode).toBe("within_taste");
     });
 
@@ -792,7 +867,7 @@ describe("getPromotedAlbum", () => {
       mockGetSimilarArtists.mockResolvedValue([]);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result!.mode).toBe("within_taste");
     });
 
@@ -801,7 +876,7 @@ describe("getPromotedAlbum", () => {
       mockGetArtistTopTags.mockResolvedValue(genreByArtist["Radiohead"]);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
 
-      const result = await getPromotedAlbum("test-plex-token");
+      const result = await getPromotedAlbum(userId);
       expect(result!.mode).toBe("within_taste");
     });
 
@@ -818,8 +893,8 @@ describe("getPromotedAlbum", () => {
         )
       );
 
-      const first = await getPromotedAlbum("test-plex-token");
-      const second = await getPromotedAlbum("test-plex-token", true);
+      const first = await getPromotedAlbum(userId);
+      const second = await getPromotedAlbum(userId, true);
       expect(ex(first).album.mbid).not.toBe(ex(second).album.mbid);
     });
   });

--- a/server/promotedAlbum/getPromotedAlbum.ts
+++ b/server/promotedAlbum/getPromotedAlbum.ts
@@ -1,5 +1,4 @@
 import { getTopArtists } from "../api/plex/topArtists";
-import { getArtistTopTags } from "../api/lastfm/artists";
 import { getTopAlbumsByTag } from "../api/lastfm/albums";
 import { lidarrGet } from "../api/lidarr/get";
 import type { LidarrAlbum, LidarrArtist } from "../api/lidarr/types";
@@ -8,7 +7,11 @@ import type { ReleaseGroupInfo } from "../api/musicbrainz/types";
 import { getConfigValue } from "../config";
 import type { LibraryPreference, PromotedAlbumConfig } from "../config";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { findUserById } from "../auth/users";
+import { updateExplorationHistory } from "../db/userProfile";
+import type { DerivedProfile } from "../db/entity/UserProfile";
 import { buildExploreResult } from "./explore";
+import { loadFreshProfile } from "./profileService";
 import type {
   BuiltAlbum,
   PromotedAlbumResult,
@@ -22,135 +25,46 @@ import type {
 
 export type { PromotedAlbumResult } from "./types";
 
-type BuildContext = {
-  plexArtists: { name: string; viewCount: number }[];
-  config: PromotedAlbumConfig;
-  recentlyShown: Set<string>;
-  artistInLibrary: (artistMbid: string) => boolean;
-  albumInLibrary: (rgMbid: string) => boolean;
-};
-
 type WeightedTag = { name: string; weight: number };
-
-type TagAccumulator = { weight: number; fromArtists: Set<string> };
-
-type TagResultEntry = {
-  artist: { name: string; viewCount: number };
-  tags: { name: string; count: number }[];
-};
 
 type CacheEntry = { result: PromotedAlbumResult; cachedAt: number };
 
-const userCache = new Map<string, CacheEntry>();
-
 const RECENT_SHOWN_LIMIT = 10;
-const recentlyShownByUser = new Map<string, string[]>();
+
+/** Short-lived final-result cache (layer 2) — keeps album selection off MusicBrainz on every load. */
+const resultCache = new Map<number, CacheEntry>();
 
 export function clearPromotedAlbumCache() {
-  userCache.clear();
-  recentlyShownByUser.clear();
+  resultCache.clear();
 }
 
-function rememberShown(plexToken: string, mbid: string) {
-  const previous = recentlyShownByUser.get(plexToken) ?? [];
-  const next = [mbid, ...previous.filter((m) => m !== mbid)].slice(
-    0,
-    RECENT_SHOWN_LIMIT
-  );
-  recentlyShownByUser.set(plexToken, next);
-}
-
-function mergeTagsFromResults(
-  tagResults: TagResultEntry[],
-  genericTags: Set<string>,
-  tagsPerArtist: number
-): {
-  weightedTags: WeightedTag[];
-  tagMap: Map<string, TagAccumulator>;
-} {
-  const tagMap = new Map<string, TagAccumulator>();
-
-  for (const { artist, tags } of tagResults) {
-    const filtered = tags
-      .filter((t) => !genericTags.has(t.name.toLowerCase()))
-      .slice(0, tagsPerArtist);
-
-    for (const tag of filtered) {
-      const key = tag.name.toLowerCase();
-      const existing = tagMap.get(key);
-      const weight = tag.count * artist.viewCount;
-
-      if (existing) {
-        existing.weight += weight;
-        existing.fromArtists.add(artist.name);
-      } else {
-        tagMap.set(key, {
-          weight,
-          fromArtists: new Set([artist.name]),
-        });
-      }
-    }
-  }
-
-  const weightedTags: WeightedTag[] = Array.from(tagMap.entries()).map(
-    ([key, { weight }]) => {
-      const originalName =
-        tagResults
-          .flatMap((r) => r.tags)
-          .find((t) => t.name.toLowerCase() === key)?.name ?? key;
-      return { name: originalName, weight };
-    }
-  );
-
-  return { weightedTags, tagMap };
-}
-
-function buildTrace(
-  plexArtists: { name: string; viewCount: number }[],
-  pickedArtistNames: Set<string>,
-  tagResults: TagResultEntry[],
-  tagMap: Map<string, TagAccumulator>,
+function buildTraceFromProfile(
+  profile: DerivedProfile,
   chosenTag: WeightedTag,
   albumPool: TraceAlbumPoolInfo,
-  selectionReason: TraceSelectionReason,
-  genericTags: Set<string>,
-  tagsPerArtist: number
+  selectionReason: TraceSelectionReason
 ): WithinTasteTrace {
-  const traceArtists: TraceArtistEntry[] = plexArtists.map((a) => {
-    const picked = pickedArtistNames.has(a.name);
-    const result = tagResults.find((r) => r.artist.name === a.name);
-    const filtered = (result?.tags ?? [])
-      .filter((t) => !genericTags.has(t.name.toLowerCase()))
-      .slice(0, tagsPerArtist);
+  const plexArtists: TraceArtistEntry[] = profile.artistTags.map((a) => ({
+    name: a.name,
+    viewCount: a.viewCount,
+    picked: true,
+    tagContributions: a.tags.map((t) => ({
+      tagName: t.name,
+      rawCount: t.count,
+      weight: t.count * a.viewCount,
+    })),
+  }));
 
-    return {
-      name: a.name,
-      viewCount: a.viewCount,
-      picked,
-      tagContributions: picked
-        ? filtered.map((t) => ({
-            tagName: t.name,
-            rawCount: t.count,
-            weight: t.count * a.viewCount,
-          }))
-        : [],
-    };
-  });
-
-  const traceWeightedTags: TraceWeightedTag[] = Array.from(
-    tagMap.entries()
-  ).map(([key, { weight, fromArtists }]) => {
-    const originalName =
-      tagResults
-        .flatMap((r) => r.tags)
-        .find((t) => t.name.toLowerCase() === key)?.name ?? key;
-    return { name: originalName, weight, fromArtists: Array.from(fromArtists) };
-  });
+  const weightedTags: TraceWeightedTag[] = profile.genreVector.map((g) => ({
+    name: g.tag,
+    weight: g.weight,
+    fromArtists: g.fromArtists,
+  }));
 
   return {
     kind: "within_taste",
-    plexArtists: traceArtists,
-    weightedTags: traceWeightedTags,
+    plexArtists,
+    weightedTags,
     chosenTag: { name: chosenTag.name, weight: chosenTag.weight },
     albumPool,
     selectionReason,
@@ -291,41 +205,22 @@ function selectAlbum(
   }
 }
 
-async function buildWithinTasteResult(
-  ctx: BuildContext
+/**
+ * Per-request within-taste selection off the persisted profile: pick a tag from the
+ * stored genre vector, fetch a fresh album pool for it, and select an album. The
+ * expensive Plex + Last.fm fan-out is NOT re-run here — that lives in the profile.
+ */
+async function buildWithinTasteFromProfile(
+  profile: DerivedProfile,
+  config: PromotedAlbumConfig,
+  recentlyShown: Set<string>,
+  artistInLibrary: (mbid: string) => boolean,
+  albumInLibrary: (mbid: string) => boolean
 ): Promise<BuiltAlbum | null> {
-  const {
-    plexArtists,
-    config,
-    recentlyShown,
-    artistInLibrary,
-    albumInLibrary,
-  } = ctx;
-  const genericTags = new Set(config.genericTags.map((t) => t.toLowerCase()));
-
-  const pickedArtists = weightedRandomPick(
-    plexArtists,
-    (a) => a.viewCount,
-    config.pickedArtistsCount
-  );
-  const pickedArtistNames = new Set(pickedArtists.map((a) => a.name));
-
-  const tagResults: TagResultEntry[] = await Promise.all(
-    pickedArtists.map(async (artist) => {
-      try {
-        const tags = await getArtistTopTags(artist.name);
-        return { artist, tags };
-      } catch {
-        return { artist, tags: [] };
-      }
-    })
-  );
-
-  const { weightedTags, tagMap } = mergeTagsFromResults(
-    tagResults,
-    genericTags,
-    config.tagsPerArtist
-  );
+  const weightedTags: WeightedTag[] = profile.genreVector.map((g) => ({
+    name: g.tag,
+    weight: g.weight,
+  }));
   if (weightedTags.length === 0) return null;
 
   const [chosenTag] = weightedRandomPick(weightedTags, (t) => t.weight, 1);
@@ -368,16 +263,11 @@ async function buildWithinTasteResult(
     totalAfterDedup: allAlbums.length,
   };
 
-  const trace = buildTrace(
-    plexArtists,
-    pickedArtistNames,
-    tagResults,
-    tagMap,
+  const trace = buildTraceFromProfile(
+    profile,
     chosenTag,
     albumPoolInfo,
-    picked.reason,
-    genericTags,
-    config.tagsPerArtist
+    picked.reason
   );
 
   const result: WithinTasteResult = {
@@ -429,50 +319,78 @@ async function loadLibraryMbids(): Promise<{
   };
 }
 
-export async function getPromotedAlbum(
+async function buildExplore(
   plexToken: string,
-  forceRefresh = false
-): Promise<PromotedAlbumResult> {
-  const config = getConfigValue("promotedAlbum");
-  const cacheDurationMs = config.cacheDurationMinutes * 60 * 1000;
-
-  const cached = userCache.get(plexToken);
-  if (
-    !forceRefresh &&
-    cached &&
-    Date.now() - cached.cachedAt < cacheDurationMs
-  ) {
-    return cached.result;
-  }
-
-  const { artistInLibrary, albumInLibrary } = await loadLibraryMbids();
-
+  config: PromotedAlbumConfig,
+  recentlyShown: Set<string>,
+  artistInLibrary: (mbid: string) => boolean,
+  albumInLibrary: (mbid: string) => boolean
+): Promise<BuiltAlbum | null> {
   const plexArtists = await getTopArtists(
     plexToken,
     config.topArtistsCount,
     config.topArtistsRange
   );
   if (plexArtists.length === 0) return null;
-
-  const ctx: BuildContext = {
+  return buildExploreResult({
     plexArtists,
     config,
-    recentlyShown: new Set(recentlyShownByUser.get(plexToken) ?? []),
+    recentlyShown,
     artistInLibrary,
     albumInLibrary,
-  };
+  });
+}
+
+export async function getPromotedAlbum(
+  userId: number,
+  forceRefresh = false
+): Promise<PromotedAlbumResult> {
+  const config = getConfigValue("promotedAlbum");
+  const resultTtlMs = config.cacheDurationMinutes * 60 * 1000;
+
+  const cached = resultCache.get(userId);
+  if (!forceRefresh && cached && Date.now() - cached.cachedAt < resultTtlMs) {
+    return cached.result;
+  }
+
+  const user = await findUserById(userId);
+  const plexToken = user?.plexToken;
+  if (!plexToken) return null;
+
+  const profile = await loadFreshProfile(userId, plexToken, config);
+
+  const { artistInLibrary, albumInLibrary } = await loadLibraryMbids();
+  const recentAlbums = profile?.explorationHistory.albums ?? [];
+  const recentlyShown = new Set(recentAlbums);
 
   let built: BuiltAlbum | null = null;
   if (Math.random() < config.explorationRate) {
-    built = await buildExploreResult(ctx);
+    built = await buildExplore(
+      plexToken,
+      config,
+      recentlyShown,
+      artistInLibrary,
+      albumInLibrary
+    );
   }
-  if (!built) {
-    built = await buildWithinTasteResult(ctx);
+  if (!built && profile) {
+    built = await buildWithinTasteFromProfile(
+      profile,
+      config,
+      recentlyShown,
+      artistInLibrary,
+      albumInLibrary
+    );
   }
   if (!built) return null;
 
-  rememberShown(plexToken, built.rememberKey);
-  userCache.set(plexToken, { result: built.result, cachedAt: Date.now() });
+  const nextAlbums = [
+    built.rememberKey,
+    ...recentAlbums.filter((m) => m !== built.rememberKey),
+  ].slice(0, RECENT_SHOWN_LIMIT);
+  await updateExplorationHistory(userId, { albums: nextAlbums });
+
+  resultCache.set(userId, { result: built.result, cachedAt: Date.now() });
 
   return built.result;
 }

--- a/server/promotedAlbum/profileService.test.ts
+++ b/server/promotedAlbum/profileService.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PromotedAlbumConfig } from "../config";
+
+const mockGetTopArtists = vi.fn();
+const mockGetArtistTopTags = vi.fn();
+const mockGetConfigValue = vi.fn();
+
+vi.mock("../api/plex/topArtists", () => ({
+  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+}));
+
+vi.mock("../api/lastfm/artists", () => ({
+  getArtistTopTags: (...args: unknown[]) => mockGetArtistTopTags(...args),
+}));
+
+vi.mock("../config", () => ({
+  getConfigValue: (...args: unknown[]) => mockGetConfigValue(...args),
+}));
+
+import { regenerateProfile, loadFreshProfile } from "./profileService";
+import { initializeDatabase, closeDatabase, getDataSource } from "../db";
+import { getUserProfile, updateExplorationHistory } from "../db/userProfile";
+import { parseDerivedProfile } from "../db/userProfile";
+
+const baseConfig: PromotedAlbumConfig = {
+  cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
+  topArtistsRange: "6months",
+  topArtistsCount: 10,
+  pickedArtistsCount: 3,
+  tagsPerArtist: 5,
+  deepPageMin: 2,
+  deepPageMax: 10,
+  genericTags: ["seen live"],
+  libraryPreference: "prefer_new",
+  explorationRate: 0,
+  exploreCandidateCount: 12,
+  genreOverlapThreshold: 0.15,
+};
+
+const plexArtists = [
+  { name: "Radiohead", viewCount: 100, thumb: "", genres: [] },
+  { name: "Bjork", viewCount: 50, thumb: "", genres: [] },
+];
+
+const tags = [
+  { name: "alternative", count: 100 },
+  { name: "seen live", count: 90 },
+];
+
+async function createUser(token: string): Promise<number> {
+  const ds = getDataSource();
+  await ds.query(
+    "INSERT INTO users (plex_token, user_type, enabled) VALUES (?, 'plex', 1)",
+    [token]
+  );
+  const rows = (await ds.query("SELECT id FROM users WHERE plex_token = ?", [
+    token,
+  ])) as { id: number }[];
+  return rows[rows.length - 1].id;
+}
+
+let userId: number;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.spyOn(Math, "random").mockReturnValue(0.1);
+  mockGetConfigValue.mockReturnValue(baseConfig);
+  mockGetTopArtists.mockResolvedValue(plexArtists);
+  mockGetArtistTopTags.mockResolvedValue(tags);
+  await initializeDatabase(":memory:");
+  userId = await createUser("token");
+});
+
+afterEach(async () => {
+  await closeDatabase();
+  vi.restoreAllMocks();
+});
+
+describe("regenerateProfile", () => {
+  it("builds and persists the genre vector and artist breakdown", async () => {
+    const profile = await regenerateProfile(userId, "token");
+    expect(profile).not.toBeNull();
+
+    expect(profile!.genreVector).toEqual([
+      {
+        tag: "alternative",
+        weight: 100 * 100 + 100 * 50,
+        fromArtists: ["Radiohead", "Bjork"],
+      },
+    ]);
+    expect(profile!.artistTags).toEqual([
+      {
+        name: "Radiohead",
+        viewCount: 100,
+        tags: [{ name: "alternative", count: 100 }],
+      },
+      {
+        name: "Bjork",
+        viewCount: 50,
+        tags: [{ name: "alternative", count: 100 }],
+      },
+    ]);
+
+    const row = await getUserProfile(userId);
+    expect(row).not.toBeNull();
+    expect(parseDerivedProfile(row!.profile_json).genreVector).toHaveLength(1);
+  });
+
+  it("returns null and leaves no vector when every tag is generic", async () => {
+    mockGetArtistTopTags.mockResolvedValue([{ name: "seen live", count: 90 }]);
+    expect(await regenerateProfile(userId, "token")).toBeNull();
+    expect(await getUserProfile(userId)).toBeNull();
+  });
+
+  it("carries existing exploration memory forward across a regenerate", async () => {
+    await updateExplorationHistory(userId, {
+      albums: ["alb-x"],
+      artists: ["art-y"],
+    });
+
+    const profile = await regenerateProfile(userId, "token");
+    expect(profile!.explorationHistory).toEqual({
+      albums: ["alb-x"],
+      artists: ["art-y"],
+    });
+  });
+});
+
+describe("loadFreshProfile", () => {
+  it("serves a fresh profile from the DB without re-fanning-out", async () => {
+    await regenerateProfile(userId, "token");
+    mockGetTopArtists.mockClear();
+    mockGetArtistTopTags.mockClear();
+
+    const profile = await loadFreshProfile(userId, "token", baseConfig);
+    expect(profile!.genreVector).toHaveLength(1);
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockGetArtistTopTags).not.toHaveBeenCalled();
+  });
+
+  it("regenerates when the config hash no longer matches", async () => {
+    await regenerateProfile(userId, "token");
+    mockGetTopArtists.mockClear();
+
+    const changedConfig = { ...baseConfig, tagsPerArtist: 2 };
+    mockGetConfigValue.mockReturnValue(changedConfig);
+
+    await loadFreshProfile(userId, "token", changedConfig);
+    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+  });
+
+  it("regenerates when the stored schema_version is stale", async () => {
+    await regenerateProfile(userId, "token");
+    await getDataSource().query(
+      "UPDATE user_profiles SET schema_version = 0 WHERE user_id = ?",
+      [userId]
+    );
+    mockGetTopArtists.mockClear();
+
+    await loadFreshProfile(userId, "token", baseConfig);
+    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+  });
+
+  it("in-flight guard prevents concurrent double-regeneration", async () => {
+    let resolveTop: (v: unknown) => void = () => {};
+    mockGetTopArtists.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTop = resolve;
+        })
+    );
+
+    const p1 = loadFreshProfile(userId, "token", baseConfig);
+    const p2 = loadFreshProfile(userId, "token", baseConfig);
+
+    await vi.waitFor(() => expect(mockGetTopArtists).toHaveBeenCalledTimes(1));
+    resolveTop(plexArtists);
+    await Promise.all([p1, p2]);
+
+    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/promotedAlbum/profileService.test.ts
+++ b/server/promotedAlbum/profileService.test.ts
@@ -36,6 +36,9 @@ const baseConfig: PromotedAlbumConfig = {
   explorationRate: 0,
   exploreCandidateCount: 12,
   genreOverlapThreshold: 0.15,
+  backgroundRegenEnabled: false,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
 };
 
 const plexArtists = [

--- a/server/promotedAlbum/profileService.ts
+++ b/server/promotedAlbum/profileService.ts
@@ -1,0 +1,177 @@
+import { getTopArtists } from "../api/plex/topArtists";
+import { getArtistTopTags } from "../api/lastfm/artists";
+import { getConfigValue } from "../config";
+import type { PromotedAlbumConfig } from "../config";
+import { weightedRandomPick } from "../utils/random";
+import { AsyncLock } from "../api/asyncLock";
+import {
+  getUserProfile,
+  upsertUserProfile,
+  touchProfileUsed,
+  computeConfigHash,
+  parseDerivedProfile,
+} from "../db/userProfile";
+import type { UserProfile, DerivedProfile } from "../db/entity/UserProfile";
+import { DERIVED_PROFILE_SCHEMA_VERSION } from "../db/entity/UserProfile";
+
+type TagResultEntry = {
+  artist: { name: string; viewCount: number };
+  tags: { name: string; count: number }[];
+};
+
+type TagAccumulator = {
+  displayName: string;
+  weight: number;
+  fromArtists: Set<string>;
+};
+
+/**
+ * Per-user lock so a live request and a background regeneration can't both rebuild
+ * the same profile and race the upsert. Keyed by user id.
+ */
+const profileLock = new AsyncLock();
+
+function buildProfileArtifacts(
+  tagResults: TagResultEntry[],
+  genericTags: Set<string>,
+  tagsPerArtist: number
+): Pick<DerivedProfile, "genreVector" | "artistTags"> {
+  const artistTags: DerivedProfile["artistTags"] = tagResults.map(
+    ({ artist, tags }) => ({
+      name: artist.name,
+      viewCount: artist.viewCount,
+      tags: tags
+        .filter((t) => !genericTags.has(t.name.toLowerCase()))
+        .slice(0, tagsPerArtist),
+    })
+  );
+
+  const tagMap = new Map<string, TagAccumulator>();
+  for (const { name, viewCount, tags } of artistTags) {
+    for (const tag of tags) {
+      const key = tag.name.toLowerCase();
+      const weight = tag.count * viewCount;
+      const existing = tagMap.get(key);
+      if (existing) {
+        existing.weight += weight;
+        existing.fromArtists.add(name);
+      } else {
+        tagMap.set(key, {
+          displayName: tag.name,
+          weight,
+          fromArtists: new Set([name]),
+        });
+      }
+    }
+  }
+
+  const genreVector: DerivedProfile["genreVector"] = Array.from(
+    tagMap.values()
+  ).map((v) => ({
+    tag: v.displayName,
+    weight: v.weight,
+    fromArtists: Array.from(v.fromArtists),
+  }));
+
+  return { genreVector, artistTags };
+}
+
+async function fetchTagResults(
+  pickedArtists: { name: string; viewCount: number }[]
+): Promise<TagResultEntry[]> {
+  return Promise.all(
+    pickedArtists.map(async (artist) => {
+      try {
+        return { artist, tags: await getArtistTopTags(artist.name) };
+      } catch {
+        return { artist, tags: [] };
+      }
+    })
+  );
+}
+
+/**
+ * Rebuild a user's derived profile from Plex top-artists + Last.fm tags and persist it.
+ * Request-free (token in, profile out) so the Phase 3 scheduler can call it directly.
+ * Returns null when the user has no top artists or every tag is generic; the existing
+ * row (if any) is left untouched in that case. Existing exploration memory is carried
+ * forward across the regenerate.
+ */
+export async function regenerateProfile(
+  userId: number,
+  plexToken: string
+): Promise<DerivedProfile | null> {
+  const config = getConfigValue("promotedAlbum");
+
+  const plexArtists = await getTopArtists(
+    plexToken,
+    config.topArtistsCount,
+    config.topArtistsRange
+  );
+  if (plexArtists.length === 0) return null;
+
+  const pickedArtists = weightedRandomPick(
+    plexArtists,
+    (a) => a.viewCount,
+    config.pickedArtistsCount
+  );
+  if (pickedArtists.length === 0) return null;
+
+  const tagResults = await fetchTagResults(pickedArtists);
+  const genericTags = new Set(config.genericTags.map((t) => t.toLowerCase()));
+  const { genreVector, artistTags } = buildProfileArtifacts(
+    tagResults,
+    genericTags,
+    config.tagsPerArtist
+  );
+  if (genreVector.length === 0) return null;
+
+  const existing = await getUserProfile(userId);
+  const explorationHistory = existing
+    ? parseDerivedProfile(existing.profile_json).explorationHistory
+    : { albums: [], artists: [] };
+
+  const profile: DerivedProfile = {
+    genreVector,
+    artistTags,
+    explorationHistory,
+  };
+
+  await upsertUserProfile(userId, profile, computeConfigHash(config));
+  return profile;
+}
+
+/** A persisted profile is fresh when its provenance matches and it is within TTL. */
+export function isProfileFresh(
+  row: UserProfile,
+  config: PromotedAlbumConfig,
+  now: number
+): boolean {
+  if (row.config_hash !== computeConfigHash(config)) return false;
+  if (row.schema_version !== DERIVED_PROFILE_SCHEMA_VERSION) return false;
+  if (parseDerivedProfile(row.profile_json).genreVector.length === 0) {
+    return false;
+  }
+  const age = now - Date.parse(row.generated_at);
+  return age < config.profileTtlMinutes * 60 * 1000;
+}
+
+/**
+ * Read-first profile load: returns the persisted profile when fresh (bumping
+ * `last_used_at`), otherwise regenerates and upserts. Guarded per-user so concurrent
+ * callers share one regeneration instead of racing.
+ */
+export async function loadFreshProfile(
+  userId: number,
+  plexToken: string,
+  config: PromotedAlbumConfig
+): Promise<DerivedProfile | null> {
+  return profileLock.acquire(String(userId), async () => {
+    const existing = await getUserProfile(userId);
+    if (existing && isProfileFresh(existing, config, Date.now())) {
+      await touchProfileUsed(userId);
+      return parseDerivedProfile(existing.profile_json);
+    }
+    return regenerateProfile(userId, plexToken);
+  });
+}

--- a/server/promotedArtists/getPromotedArtists.test.ts
+++ b/server/promotedArtists/getPromotedArtists.test.ts
@@ -32,6 +32,7 @@ import {
   getPromotedArtists,
   clearPromotedArtistsCache,
 } from "./getPromotedArtists";
+import { initializeDatabase, closeDatabase, getDataSource } from "../db";
 
 type SimilarArtist = {
   name: string;
@@ -40,8 +41,21 @@ type SimilarArtist = {
   imageUrl: string;
 };
 
+async function createUserWithToken(token: string): Promise<number> {
+  const ds = getDataSource();
+  await ds.query(
+    "INSERT INTO users (plex_token, user_type, enabled) VALUES (?, 'plex', 1)",
+    [token]
+  );
+  const rows = (await ds.query("SELECT id FROM users WHERE plex_token = ?", [
+    token,
+  ])) as { id: number }[];
+  return rows[rows.length - 1].id;
+}
+
 const baseConfig: PromotedAlbumConfig = {
   cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
   topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 2,
@@ -72,7 +86,9 @@ const SIMILAR: Record<string, SimilarArtist[]> = {
   ],
 };
 
-beforeEach(() => {
+let userId: number;
+
+beforeEach(async () => {
   vi.clearAllMocks();
   clearPromotedArtistsCache();
   vi.spyOn(Math, "random").mockReturnValue(0);
@@ -89,25 +105,37 @@ beforeEach(() => {
     ok: true,
     data: [{ artistName: "Tycho", foreignArtistId: "ty" }],
   });
+
+  await initializeDatabase(":memory:");
+  userId = await createUserWithToken("token");
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await closeDatabase();
   vi.restoreAllMocks();
 });
 
 describe("getPromotedArtists", () => {
+  it("returns null when the user has no stored Plex token", async () => {
+    const rows = (await getDataSource().query(
+      "INSERT INTO users (user_type, enabled) VALUES ('local', 1) RETURNING id"
+    )) as { id: number }[];
+    expect(await getPromotedArtists(rows[0].id)).toBeNull();
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+  });
+
   it("returns null when the user has no top artists", async () => {
     mockGetTopArtists.mockResolvedValue([]);
-    expect(await getPromotedArtists("token")).toBeNull();
+    expect(await getPromotedArtists(userId)).toBeNull();
   });
 
   it("uses the listening window config to fetch top artists", async () => {
-    await getPromotedArtists("token");
+    await getPromotedArtists(userId);
     expect(mockGetTopArtists).toHaveBeenCalledWith("token", 10, "6months");
   });
 
   it("returns similar artists seeded from the top artists", async () => {
-    const result = await getPromotedArtists("token");
+    const result = await getPromotedArtists(userId);
     expect(result).not.toBeNull();
     expect(result!.seedArtists).toEqual(["Aphex Twin", "Plaid"]);
     const names = result!.artists.map((a) => a.name).sort();
@@ -115,19 +143,19 @@ describe("getPromotedArtists", () => {
   });
 
   it("excludes artists already in the user's top list", async () => {
-    const result = await getPromotedArtists("token");
+    const result = await getPromotedArtists(userId);
     const names = result!.artists.map((a) => a.name);
     expect(names).not.toContain("Plaid");
   });
 
   it("dedupes by name and keeps the highest match", async () => {
-    const result = await getPromotedArtists("token");
+    const result = await getPromotedArtists(userId);
     const boc = result!.artists.find((a) => a.name === "Boards of Canada");
     expect(boc?.match).toBe(0.95);
   });
 
   it("marks artists in the library", async () => {
-    const result = await getPromotedArtists("token");
+    const result = await getPromotedArtists(userId);
     const tycho = result!.artists.find((a) => a.name === "Tycho");
     const boc = result!.artists.find((a) => a.name === "Boards of Canada");
     expect(tycho?.inLibrary).toBe(true);
@@ -138,21 +166,37 @@ describe("getPromotedArtists", () => {
     mockGetSimilarArtists.mockResolvedValue([
       { name: "Aphex Twin", mbid: "at", match: 0.9, imageUrl: "" },
     ]);
-    expect(await getPromotedArtists("token")).toBeNull();
+    expect(await getPromotedArtists(userId)).toBeNull();
   });
 
   it("caches results per user and recomputes on refresh", async () => {
-    await getPromotedArtists("token");
-    await getPromotedArtists("token");
+    await getPromotedArtists(userId);
+    await getPromotedArtists(userId);
     expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
 
-    await getPromotedArtists("token", true);
+    await getPromotedArtists(userId, true);
     expect(mockGetTopArtists).toHaveBeenCalledTimes(2);
+  });
+
+  it("persists anti-repeat memory so a refresh avoids re-showing artists", async () => {
+    const first = await getPromotedArtists(userId);
+    const firstNames = new Set(first!.artists.map((a) => a.name.toLowerCase()));
+
+    const row = await getDataSource().query(
+      "SELECT profile_json FROM user_profiles WHERE user_id = ?",
+      [userId]
+    );
+    const stored = JSON.parse(row[0].profile_json) as {
+      explorationHistory: { artists: string[] };
+    };
+    for (const name of firstNames) {
+      expect(stored.explorationHistory.artists).toContain(name);
+    }
   });
 
   it("survives Lidarr being unavailable", async () => {
     mockLidarrGet.mockRejectedValue(new Error("down"));
-    const result = await getPromotedArtists("token");
+    const result = await getPromotedArtists(userId);
     expect(result).not.toBeNull();
     expect(result!.artists.every((a) => a.inLibrary === false)).toBe(true);
   });

--- a/server/promotedArtists/getPromotedArtists.test.ts
+++ b/server/promotedArtists/getPromotedArtists.test.ts
@@ -67,6 +67,9 @@ const baseConfig: PromotedAlbumConfig = {
   explorationRate: 0,
   exploreCandidateCount: 12,
   genreOverlapThreshold: 0.15,
+  backgroundRegenEnabled: false,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
 };
 
 const TOP_ARTISTS = [

--- a/server/promotedArtists/getPromotedArtists.ts
+++ b/server/promotedArtists/getPromotedArtists.ts
@@ -5,6 +5,12 @@ import { lidarrGet } from "../api/lidarr/get";
 import type { LidarrArtist } from "../api/lidarr/types";
 import { getConfigValue } from "../config";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { findUserById } from "../auth/users";
+import {
+  getUserProfile,
+  updateExplorationHistory,
+  parseDerivedProfile,
+} from "../db/userProfile";
 import type { PromotedArtist, PromotedArtistsResult } from "./types";
 
 export type { PromotedArtistsResult } from "./types";
@@ -23,19 +29,17 @@ type LibraryLookup = (name: string, mbid: string) => boolean;
 const RESULT_COUNT = 6;
 const RECENT_SHOWN_LIMIT = 18;
 
-const userCache = new Map<string, CacheEntry>();
-const recentlyShownByUser = new Map<string, string[]>();
+const resultCache = new Map<number, CacheEntry>();
 
 export function clearPromotedArtistsCache() {
-  userCache.clear();
-  recentlyShownByUser.clear();
+  resultCache.clear();
 }
 
-function rememberShown(plexToken: string, names: string[]) {
-  const previous = recentlyShownByUser.get(plexToken) ?? [];
-  const merged = [...names, ...previous];
-  const deduped = Array.from(new Set(merged)).slice(0, RECENT_SHOWN_LIMIT);
-  recentlyShownByUser.set(plexToken, deduped);
+function mergeRecentArtists(names: string[], previous: string[]): string[] {
+  return Array.from(new Set([...names, ...previous])).slice(
+    0,
+    RECENT_SHOWN_LIMIT
+  );
 }
 
 async function safeSimilar(name: string): Promise<SimilarArtist[]> {
@@ -93,13 +97,13 @@ function pickArtists(
 }
 
 export async function getPromotedArtists(
-  plexToken: string,
+  userId: number,
   forceRefresh = false
 ): Promise<PromotedArtistsResult> {
   const config = getConfigValue("promotedAlbum");
   const cacheDurationMs = config.cacheDurationMinutes * 60 * 1000;
 
-  const cached = userCache.get(plexToken);
+  const cached = resultCache.get(userId);
   if (
     !forceRefresh &&
     cached &&
@@ -107,6 +111,10 @@ export async function getPromotedArtists(
   ) {
     return cached.result;
   }
+
+  const user = await findUserById(userId);
+  const plexToken = user?.plexToken;
+  if (!plexToken) return null;
 
   const topArtists = await getTopArtists(
     plexToken,
@@ -130,8 +138,11 @@ export async function getPromotedArtists(
   const merged = mergeSimilar(similarLists, topNames);
   if (merged.length === 0) return null;
 
-  const recentlyShown = new Set(recentlyShownByUser.get(plexToken) ?? []);
-  const chosen = pickArtists(merged, recentlyShown);
+  const profileRow = await getUserProfile(userId);
+  const recentArtists = profileRow
+    ? parseDerivedProfile(profileRow.profile_json).explorationHistory.artists
+    : [];
+  const chosen = pickArtists(merged, new Set(recentArtists));
 
   const enriched = await enrichArtistsWithImages(chosen);
   const inLibrary = await loadLibraryLookup();
@@ -149,11 +160,12 @@ export async function getPromotedArtists(
     seedArtists: seeds.map((s) => s.name),
   };
 
-  rememberShown(
-    plexToken,
-    artists.map((a) => a.name.toLowerCase())
+  const nextArtists = mergeRecentArtists(
+    artists.map((a) => a.name.toLowerCase()),
+    recentArtists
   );
-  userCache.set(plexToken, { result, cachedAt: Date.now() });
+  await updateExplorationHistory(userId, { artists: nextArtists });
+  resultCache.set(userId, { result, cachedAt: Date.now() });
 
   return result;
 }

--- a/server/routes/promotedAlbum.test.ts
+++ b/server/routes/promotedAlbum.test.ts
@@ -55,7 +55,7 @@ describe("GET /", () => {
     const res = await request(app).get("/");
     expect(res.status).toBe(200);
     expect(res.body).toEqual(data);
-    expect(mockGetPromotedAlbum).toHaveBeenCalledWith("plex-token-123", false);
+    expect(mockGetPromotedAlbum).toHaveBeenCalledWith(1, false);
   });
 
   it("returns null when no album found", async () => {
@@ -78,12 +78,11 @@ describe("GET /", () => {
     mockGetPromotedAlbum.mockResolvedValue(null);
 
     await request(app).get("/?refresh=true");
-    expect(mockGetPromotedAlbum).toHaveBeenCalledWith("plex-token-123", true);
+    expect(mockGetPromotedAlbum).toHaveBeenCalledWith(1, true);
   });
 
-  it("returns null without calling service when user has no plex token", async () => {
+  it("returns null without calling service when there is no authenticated user", async () => {
     const app = express();
-    app.use(withUser());
     app.use("/", promotedAlbumRouter);
 
     const res = await request(app).get("/");

--- a/server/routes/promotedAlbum.ts
+++ b/server/routes/promotedAlbum.ts
@@ -5,13 +5,13 @@ import { getPromotedAlbum } from "../promotedAlbum/getPromotedAlbum";
 const router = express.Router();
 
 router.get("/", async (req: Request, res: Response) => {
-  const plexToken = req.user?.plexToken;
-  if (!plexToken) {
+  const userId = req.user?.id;
+  if (!userId) {
     res.json(null);
     return;
   }
   const forceRefresh = req.query.refresh === "true";
-  const result = await getPromotedAlbum(plexToken, forceRefresh);
+  const result = await getPromotedAlbum(userId, forceRefresh);
   res.json(result);
 });
 

--- a/server/routes/promotedArtists.ts
+++ b/server/routes/promotedArtists.ts
@@ -5,13 +5,13 @@ import { getPromotedArtists } from "../promotedArtists/getPromotedArtists";
 const router = express.Router();
 
 router.get("/", async (req: Request, res: Response) => {
-  const plexToken = req.user?.plexToken;
-  if (!plexToken) {
+  const userId = req.user?.id;
+  if (!userId) {
     res.json(null);
     return;
   }
   const forceRefresh = req.query.refresh === "true";
-  const result = await getPromotedArtists(plexToken, forceRefresh);
+  const result = await getPromotedArtists(userId, forceRefresh);
   res.json(result);
 });
 

--- a/server/services/profile/regenPoller.test.ts
+++ b/server/services/profile/regenPoller.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PromotedAlbumConfig } from "../../config";
+
+const mockGetTopArtists = vi.fn();
+const mockGetArtistTopTags = vi.fn();
+const mockGetConfigValue = vi.fn();
+
+vi.mock("../../api/plex/topArtists", () => ({
+  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+}));
+
+vi.mock("../../api/lastfm/artists", () => ({
+  getArtistTopTags: (...args: unknown[]) => mockGetArtistTopTags(...args),
+}));
+
+vi.mock("../../config", () => ({
+  getConfigValue: (...args: unknown[]) => mockGetConfigValue(...args),
+}));
+
+import { runProfileRegenOnce } from "./regenPoller";
+import {
+  regenerateProfile,
+  loadFreshProfile,
+} from "../../promotedAlbum/profileService";
+import { initializeDatabase, closeDatabase, getDataSource } from "../../db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const baseConfig: PromotedAlbumConfig = {
+  cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
+  topArtistsRange: "6months",
+  topArtistsCount: 10,
+  pickedArtistsCount: 3,
+  tagsPerArtist: 5,
+  deepPageMin: 2,
+  deepPageMax: 10,
+  genericTags: [],
+  libraryPreference: "prefer_new",
+  explorationRate: 0,
+  exploreCandidateCount: 12,
+  genreOverlapThreshold: 0.15,
+  backgroundRegenEnabled: true,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
+};
+
+const plexArtists = [
+  { name: "Radiohead", viewCount: 100, thumb: "", genres: [] },
+];
+const tags = [{ name: "alternative", count: 100 }];
+
+async function createUser(token: string): Promise<number> {
+  const ds = getDataSource();
+  await ds.query(
+    "INSERT INTO users (plex_token, user_type, enabled) VALUES (?, 'plex', 1)",
+    [token]
+  );
+  const rows = (await ds.query("SELECT id FROM users WHERE plex_token = ?", [
+    token,
+  ])) as { id: number }[];
+  return rows[rows.length - 1].id;
+}
+
+async function stampProfile(
+  userId: number,
+  generatedAtMs: number,
+  lastUsedAtMs: number
+): Promise<void> {
+  await getDataSource().query(
+    "UPDATE user_profiles SET generated_at = ?, last_used_at = ? WHERE user_id = ?",
+    [
+      new Date(generatedAtMs).toISOString(),
+      new Date(lastUsedAtMs).toISOString(),
+      userId,
+    ]
+  );
+}
+
+let now: number;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.spyOn(Math, "random").mockReturnValue(0.1);
+  mockGetConfigValue.mockReturnValue(baseConfig);
+  mockGetTopArtists.mockResolvedValue(plexArtists);
+  mockGetArtistTopTags.mockResolvedValue(tags);
+  await initializeDatabase(":memory:");
+  now = Date.now();
+});
+
+afterEach(async () => {
+  await closeDatabase();
+  vi.restoreAllMocks();
+});
+
+describe("runProfileRegenOnce", () => {
+  it("regenerates only stale and active profiles", async () => {
+    const staleActive = await createUser("stale-active");
+    const fresh = await createUser("fresh");
+    const staleDormant = await createUser("stale-dormant");
+
+    await regenerateProfile(staleActive, "stale-active");
+    await regenerateProfile(fresh, "fresh");
+    await regenerateProfile(staleDormant, "stale-dormant");
+
+    await stampProfile(staleActive, now - 2 * DAY_MS, now);
+    await stampProfile(fresh, now, now);
+    await stampProfile(staleDormant, now - 2 * DAY_MS, now - 30 * DAY_MS);
+
+    mockGetTopArtists.mockClear();
+    await runProfileRegenOnce(now);
+
+    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockGetTopArtists).toHaveBeenCalledWith(
+      "stale-active",
+      10,
+      "6months"
+    );
+  });
+
+  it("does no work when the toggle is disabled", async () => {
+    const userId = await createUser("stale-active");
+    await regenerateProfile(userId, "stale-active");
+    await stampProfile(userId, now - 2 * DAY_MS, now);
+
+    mockGetConfigValue.mockReturnValue({
+      ...baseConfig,
+      backgroundRegenEnabled: false,
+    });
+    mockGetTopArtists.mockClear();
+
+    await runProfileRegenOnce(now);
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+  });
+
+  it("skips users without a profile row (never used discovery)", async () => {
+    await createUser("no-profile");
+    mockGetTopArtists.mockClear();
+
+    await runProfileRegenOnce(now);
+    expect(mockGetTopArtists).not.toHaveBeenCalled();
+  });
+
+  it("does not double-regenerate when a live request holds the in-flight guard", async () => {
+    const userId = await createUser("stale-active");
+    await regenerateProfile(userId, "stale-active");
+    await stampProfile(userId, now - 2 * DAY_MS, now);
+
+    let resolveTop: (v: unknown) => void = () => {};
+    mockGetTopArtists.mockClear();
+    mockGetTopArtists.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTop = resolve;
+        })
+    );
+
+    const live = loadFreshProfile(userId, "stale-active", baseConfig);
+    await vi.waitFor(() => expect(mockGetTopArtists).toHaveBeenCalledTimes(1));
+
+    const tick = runProfileRegenOnce(now);
+    resolveTop(plexArtists);
+    await Promise.all([live, tick]);
+
+    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/profile/regenPoller.ts
+++ b/server/services/profile/regenPoller.ts
@@ -1,0 +1,86 @@
+import { getConfigValue } from "../../config";
+import { getProfileRegenCandidates } from "../../db/userProfile";
+import {
+  isProfileFresh,
+  loadFreshProfile,
+} from "../../promotedAlbum/profileService";
+import { createLogger } from "../../logger";
+
+const log = createLogger("profile-regen-poller");
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+const FIRST_RUN_DELAY_MS = 60 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+/**
+ * One regeneration sweep: refresh every profile that is stale AND belongs to a
+ * recently-active user, so live requests always hit a warm row. Fresh profiles
+ * and dormant users are skipped. Regeneration goes through `loadFreshProfile`, so
+ * the Phase 2 per-user in-flight guard prevents collisions with live requests.
+ *
+ * NOTE: single-instance assumption. A naive interval double-runs under multiple
+ * replicas; the in-flight guard is per-process and does not coordinate across them.
+ */
+export async function runProfileRegenOnce(now = Date.now()): Promise<void> {
+  if (running) {
+    log.warn("Regen already running, skipping this tick");
+    return;
+  }
+  running = true;
+  try {
+    const config = getConfigValue("promotedAlbum");
+    if (!config.backgroundRegenEnabled) return;
+
+    const activeWindowMs =
+      config.backgroundRegenActiveWithinMinutes * 60 * 1000;
+    const candidates = await getProfileRegenCandidates();
+
+    let regenerated = 0;
+    for (const candidate of candidates) {
+      if (isProfileFresh(candidate.profile, config, now)) continue;
+      const lastUsed = Date.parse(candidate.profile.last_used_at);
+      if (now - lastUsed > activeWindowMs) continue;
+
+      try {
+        await loadFreshProfile(candidate.userId, candidate.plexToken, config);
+        regenerated += 1;
+      } catch (error) {
+        log.error(`Regen failed for user ${candidate.userId}`, error);
+      }
+    }
+
+    if (regenerated > 0) {
+      log.info(`Regenerated ${regenerated} stale profile(s)`);
+    }
+  } finally {
+    running = false;
+  }
+}
+
+export function startProfileRegenPoller(
+  intervalMs: number = DEFAULT_INTERVAL_MS
+): void {
+  if (timer) return;
+
+  const tick = async () => {
+    try {
+      await runProfileRegenOnce();
+    } catch (error) {
+      log.error("Regen tick failed", error);
+    } finally {
+      timer = setTimeout(tick, intervalMs);
+    }
+  };
+
+  timer = setTimeout(tick, FIRST_RUN_DELAY_MS);
+  log.info(`Profile regen poller scheduled (interval: ${intervalMs / 1000}s)`);
+}
+
+export function stopProfileRegenPoller(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -27,4 +27,7 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
   explorationRate: 0.5,
   exploreCandidateCount: 12,
   genreOverlapThreshold: 0.15,
+  backgroundRegenEnabled: true,
+  backgroundRegenIntervalMinutes: 60,
+  backgroundRegenActiveWithinMinutes: 10080,
 };

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -2,6 +2,7 @@ import type { PromotedAlbumSettings } from "./settingsContextDef";
 
 export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
   cacheDurationMinutes: 30,
+  profileTtlMinutes: 1440,
   topArtistsRange: "6months",
   topArtistsCount: 10,
   pickedArtistsCount: 3,

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -21,6 +21,9 @@ export interface PromotedAlbumSettings {
   explorationRate: number;
   exploreCandidateCount: number;
   genreOverlapThreshold: number;
+  backgroundRegenEnabled: boolean;
+  backgroundRegenIntervalMinutes: number;
+  backgroundRegenActiveWithinMinutes: number;
 }
 
 export interface PurchaseDecisionSettings {

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -9,6 +9,7 @@ export type TopArtistsRange = "all" | "4weeks" | "6months" | "12months";
 
 export interface PromotedAlbumSettings {
   cacheDurationMinutes: number;
+  profileTtlMinutes: number;
   topArtistsRange: TopArtistsRange;
   topArtistsCount: number;
   pickedArtistsCount: number;

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -167,6 +167,49 @@ export default function RecommendationsSection({
         description="How long your derived taste profile (genre vector) is reused before the expensive Plex + Last.fm rebuild runs again. Longer is cheaper; shorter tracks taste changes faster."
       />
 
+      <div className="flex items-center gap-3">
+        <input
+          type="checkbox"
+          id="background-regen-enabled"
+          checked={config.backgroundRegenEnabled}
+          onChange={(e) => update("backgroundRegenEnabled", e.target.checked)}
+          className="h-4 w-4 rounded border-2 border-black"
+        />
+        <label
+          htmlFor="background-regen-enabled"
+          className="text-sm font-medium text-gray-900 dark:text-gray-100"
+        >
+          Keep taste profiles warm in the background
+        </label>
+      </div>
+      <p className="text-gray-400 dark:text-gray-500 text-xs -mt-2">
+        Periodically rebuilds stale profiles for recently-active users so no
+        request waits on the rate-limited rebuild. Single-instance only.
+      </p>
+
+      {config.backgroundRegenEnabled && (
+        <>
+          <NumberField
+            label="Background Refresh Interval (minutes)"
+            value={config.backgroundRegenIntervalMinutes}
+            onChange={(v) => update("backgroundRegenIntervalMinutes", v)}
+            min={5}
+            max={1440}
+            step={5}
+            description="How often the background refresh checks for stale profiles."
+          />
+          <NumberField
+            label="Active User Window (minutes)"
+            value={config.backgroundRegenActiveWithinMinutes}
+            onChange={(v) => update("backgroundRegenActiveWithinMinutes", v)}
+            min={60}
+            max={43200}
+            step={60}
+            description="Only refresh profiles for users who viewed recommendations within this window, so dormant accounts don't burn Plex / Last.fm quota."
+          />
+        </>
+      )}
+
       <div>
         <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
           Listening Window

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -157,6 +157,16 @@ export default function RecommendationsSection({
         description="How long to cache a promoted album before picking a new one. Set to 0 to disable caching."
       />
 
+      <NumberField
+        label="Taste Profile Lifetime (minutes)"
+        value={config.profileTtlMinutes}
+        onChange={(v) => update("profileTtlMinutes", v)}
+        min={0}
+        max={10080}
+        step={60}
+        description="How long your derived taste profile (genre vector) is reused before the expensive Plex + Last.fm rebuild runs again. Longer is cheaper; shorter tracks taste changes faster."
+      />
+
       <div>
         <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
           Listening Window


### PR DESCRIPTION
Implements **Step 1** of user-profile stabilisation (#166): persist the derived
profile that the recommender previously recomputed on every cold request and threw
away. Closes #167, #168, #169.

Design rationale and what shipped vs the original sketch are recorded in
`docs/user-profile-stabilization-rfc.md` (updated here).

## Phases (one commit each)

**Phase 1 — entities + migration (#167)**
- `UserProfile` (derived cache: one versioned JSON doc per user — `profile_json`,
  `schema_version`, `config_hash` provenance) and `UserSignalEvent` (append-only,
  `kind`-tagged; subsumes the RFC's snapshot).
- Migration `8_UserProfile`, both tables cascade-delete with the owning user.
- Access helpers in `server/db/userProfile.ts` (`computeConfigHash`,
  serialise/parse, CRUD, exploration-history merge).

**Phase 2 — profile-first recommender (#168, the value slice)**
- `regenerateProfile(userId, plexToken)`: request-free, rebuilds the genre vector
  + per-artist breakdown and upserts (carrying exploration memory forward).
- `loadFreshProfile`: read-first — serve the persisted profile when fresh
  (`config_hash`/`schema_version` match, within TTL), else regenerate. Guarded by a
  per-user `AsyncLock` so a live request and the scheduler can't double-regenerate.
- Two-layer cache: long-lived profile (`profileTtlMinutes`) + short result cache
  (`cacheDurationMinutes`). Refresh re-picks a tag/album off the cached vector
  without re-running the Plex + Last.fm fan-out.
- In-memory anti-repeat maps folded into the persisted `explorationHistory`; both
  recommenders now key on `userId`.

**Phase 3 — background regeneration (#169)**
- `runProfileRegenOnce` refreshes only stale **and** recently-active profiles off
  the request path, reusing the in-flight guard. Wired into the server lifecycle.
- Configurable toggle + interval + active window. Single-instance caveat documented.

## Notable design decision
`DerivedProfile` carries `artistTags` (picked artists + contributing tags) beyond
the issue's literal `{ genreVector, explorationHistory }`, so the within-taste
`trace` ("How this was recommended") survives a restart instead of rendering two
empty stages on the normal cached path. Both are produced in one pass so they can't
disagree; the raw unfiltered Last.fm tag dump is deliberately not stored
(re-fetchable; `config_hash` invalidation forces a clean refetch on algorithm change).

## Deferred (as planned in #166)
- `similarGraph` — explore mode still fans out per request (migration-free to add).
- Ratings ingestion + snapshot writes (Step 2), taste page (Step 3), export (Step 4).

## Tests
Full FE + BE coverage per project policy. New: migration, `userProfile` helpers,
`profileService` (fresh→no fan-out, config-hash/schema-version regen, in-flight
guard, exploration carry-forward), `regenPoller` (stale+active only, skip
fresh/dormant/profileless, disabled toggle, guard holds). Existing
`getPromotedAlbum`/`getPromotedArtists` suites rewritten for the two-layer,
DB-backed semantics. Server 928 + frontend 773 passing; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)