### PR TITLE
feat: ratings ingestion + daily backup snapshots (Step 2, #172)

### DIFF
--- a/docs/user-profile-stabilization-rfc.md
+++ b/docs/user-profile-stabilization-rfc.md
@@ -1,8 +1,9 @@
 # RFC: Stabilising user profiles
 
-Status: Step 1 implemented — discussing next steps
+Status: Step 1 implemented — Step 2 scoped, ratings reader prototyped
 Tracking issue: [#144](https://github.com/BlieNuckel/tunearr/issues/144)
 Step 1 issues: [#166](https://github.com/BlieNuckel/tunearr/issues/166) (#167 entities, #168 recommender, #169 scheduler)
+Step 2 issue: [#172](https://github.com/BlieNuckel/tunearr/issues/172)
 Related: #137 (explore mode), #145 (explore-vs-Plex boundary), #136 (listening window + anti-repeat)
 
 ## Implementation status
@@ -49,8 +50,10 @@ Deferred, as planned:
 - **`similarGraph`** is still not stored, so **explore mode still fans out per request**
   (ListenBrainz + Last.fm). It needs no migration to add later — just a field in
   `DerivedProfile`.
-- **Ratings ingestion + snapshots (`UserSignalEvent` writes)** — Step 2. The table exists
-  and the regen poller is the intended home for the snapshot cadence.
+- **Ratings ingestion + snapshots (`UserSignalEvent` writes)** — Step 2 ([#172](https://github.com/BlieNuckel/tunearr/issues/172)).
+  The table exists and the regen poller is the intended home for the snapshot cadence. The
+  Plex ratings **reader** is prototyped (`server/api/plex/ratings.ts`, with `getMusicSectionKey`
+  extracted to `sections.ts`); the `UserSignalEvent` **writes** and cadence are still to do.
 - **Taste page** (Step 3) and **export/restore** (Step 4).
 
 ## Problem
@@ -263,12 +266,14 @@ existing integration.
   their own token, which is exactly the case Plex supports. We never have one user read
   another's data.
 - **Read endpoint + perf (the volume half of the question).** Use a server-side filter for
-  rated items only — e.g. `GET /library/sections/{sectionKey}/all?type=10&userRating>>=1`
-  (the `>>=` operator is Plex's "greater-or-equal"; confirm exact encoding in impl). This
+  rated items only — `GET /library/sections/{sectionKey}/all?type=10&userRating>=1`. This
   means we **never scan the whole library** — one paginated, filtered query returns just the
   (small) rated set. Container pagination (`X-Plex-Container-Size`) is already wired up in
   `topArtists.ts`. Single-item reads via `GET /library/metadata/{ratingKey}` also carry
-  `userRating`.
+  `userRating`. **Prototype note (June 2026):** `server/api/plex/ratings.ts` implements this
+  with `userRating%3E=1` (i.e. `userRating>=1`, matching the proven `viewedAt>=` filter in
+  `topArtists.ts`) rather than the `>>=` operator originally sketched here. The exact encoding
+  a live PMS accepts is the one item still to confirm against a real server.
 - **Field semantics.** Music ratings exist at artist (`type=8`), album (`type=9`) and track
   (`type=10`); recommend ingesting albums + tracks. `userRating` is **absent** when an item
   is unrated — treat missing as "no rating", not 0. Scale is 0–10 (half-star = 1 unit),
@@ -299,12 +304,13 @@ Two caveats to handle during Step 2, neither blocking:
 Step 1 (persist the derived profile) is implemented — see **Implementation status** above.
 Discussion now moves to what comes after, in roughly dependency order:
 
-- **Step 2 — ratings ingestion + snapshots.** **Unblocked** — open question 3 resolved
-  (Plex exposes `userRating` via the per-user token path; see "Resolved: ratings ingestion"
-  above). Read rated items with a server-side `userRating>>=1` filter on the existing token
-  path, then write `UserSignalEvent` rows (`kind = "snapshot"` / `"plex_rating"`); the regen
-  poller already exists as the cadence home. This is the first feature that makes
-  `UserSignalEvent` earn its place.
+- **Step 2 — ratings ingestion + snapshots ([#172](https://github.com/BlieNuckel/tunearr/issues/172)).**
+  **Unblocked** — open question 3 resolved (Plex exposes `userRating` via the per-user token
+  path; see "Resolved: ratings ingestion" above) and the reader is prototyped
+  (`server/api/plex/ratings.ts`, server-side `userRating>=1` filter, paginated, albums + tracks).
+  Remaining: write `UserSignalEvent` rows (`kind = "snapshot"` / `"plex_rating"`) and wire the
+  cadence into the regen poller, which already exists as the cadence home. This is the first
+  feature that makes `UserSignalEvent` earn its place.
 - **Feed new signals into the vector.** The contributor-registry seam from #166 lets a
   rating / behaviour signal add weight to the _same_ `genreVector` without restructuring the
   recommender. Worth deciding the weighting model before Step 2 lands data.

--- a/server/api/plex/ratings.test.ts
+++ b/server/api/plex/ratings.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getRatedItems } from "./ratings";
+
+vi.mock("./config", () => ({
+  getPlexConfig: vi.fn(() => ({
+    baseUrl: "http://plex:32400",
+    headers: { "X-Plex-Token": "tok", Accept: "application/json" },
+    token: "tok",
+  })),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function okResponse(data: unknown) {
+  return { ok: true, json: () => Promise.resolve(data) };
+}
+
+const musicSection = okResponse({
+  MediaContainer: {
+    Directory: [
+      { key: "1", type: "movie", title: "Movies" },
+      { key: "2", type: "artist", title: "Music" },
+    ],
+  },
+});
+
+describe("getRatedItems", () => {
+  it("maps rated albums and tracks across both types", async () => {
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce(
+        okResponse({
+          MediaContainer: {
+            totalSize: 1,
+            Metadata: [
+              {
+                ratingKey: "10",
+                title: "In Rainbows",
+                userRating: 10,
+                parentTitle: "Radiohead",
+              },
+            ],
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        okResponse({
+          MediaContainer: {
+            totalSize: 1,
+            Metadata: [
+              {
+                ratingKey: "55",
+                title: "Nude",
+                userRating: 8,
+                grandparentTitle: "Radiohead",
+                parentTitle: "In Rainbows",
+              },
+            ],
+          },
+        })
+      );
+
+    const result = await getRatedItems("tok");
+
+    expect(result).toEqual([
+      {
+        ratingKey: "10",
+        kind: "album",
+        title: "In Rainbows",
+        artist: "Radiohead",
+        rating: 10,
+      },
+      {
+        ratingKey: "55",
+        kind: "track",
+        title: "Nude",
+        artist: "Radiohead",
+        rating: 8,
+      },
+    ]);
+  });
+
+  it("applies the server-side userRating filter and the music section", async () => {
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce(okResponse({ MediaContainer: { Metadata: [] } }))
+      .mockResolvedValueOnce(okResponse({ MediaContainer: { Metadata: [] } }));
+
+    await getRatedItems("tok");
+
+    const albumUrl = mockFetch.mock.calls[1][0] as string;
+    expect(albumUrl).toContain("/library/sections/2/all");
+    expect(albumUrl).toContain("type=9");
+    expect(albumUrl).toContain("userRating%3E=1");
+
+    const trackUrl = mockFetch.mock.calls[2][0] as string;
+    expect(trackUrl).toContain("type=10");
+  });
+
+  it("paginates until totalSize is reached", async () => {
+    const page = (start: number) =>
+      okResponse({
+        MediaContainer: {
+          totalSize: 150,
+          Metadata: Array.from({ length: 100 }, (_, i) => ({
+            ratingKey: `${start + i}`,
+            title: `t${start + i}`,
+            userRating: 6,
+            grandparentTitle: "X",
+            parentTitle: "Y",
+          })),
+        },
+      });
+
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce(page(0))
+      .mockResolvedValueOnce(
+        okResponse({
+          MediaContainer: {
+            totalSize: 150,
+            Metadata: Array.from({ length: 50 }, (_, i) => ({
+              ratingKey: `${100 + i}`,
+              title: `t${100 + i}`,
+              userRating: 6,
+              grandparentTitle: "X",
+              parentTitle: "Y",
+            })),
+          },
+        })
+      );
+
+    const result = await getRatedItems("tok", [10]);
+
+    expect(result).toHaveLength(150);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("drops items with no userRating field", async () => {
+    mockFetch.mockResolvedValueOnce(musicSection).mockResolvedValueOnce(
+      okResponse({
+        MediaContainer: {
+          totalSize: 2,
+          Metadata: [
+            { ratingKey: "1", title: "Rated", userRating: 4, parentTitle: "A" },
+            { ratingKey: "2", title: "Unrated", parentTitle: "A" },
+          ],
+        },
+      })
+    );
+
+    const result = await getRatedItems("tok", [9]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Rated");
+  });
+
+  it("throws on a Plex API error", async () => {
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce({ ok: false, status: 401 });
+
+    await expect(getRatedItems("tok", [9])).rejects.toThrow(
+      "Plex returned 401"
+    );
+  });
+});

--- a/server/api/plex/ratings.ts
+++ b/server/api/plex/ratings.ts
@@ -1,0 +1,106 @@
+import { resilientFetch } from "../resilientFetch";
+import { getPlexConfig } from "./config";
+import { getMusicSectionKey } from "./sections";
+import type {
+  PlexRatedItem,
+  PlexRatedItemMetadata,
+  PlexRatedItemsResponse,
+  PlexRatingType,
+} from "./types";
+
+const PAGE_SIZE = 100;
+
+const DEFAULT_RATING_TYPES: PlexRatingType[] = [9, 10];
+
+const KIND_BY_TYPE: Record<PlexRatingType, PlexRatedItem["kind"]> = {
+  9: "album",
+  10: "track",
+};
+
+const buildPageUrl = (
+  baseUrl: string,
+  sectionKey: string,
+  type: PlexRatingType,
+  start: number
+): string =>
+  `${baseUrl}/library/sections/${sectionKey}/all?type=${type}` +
+  `&userRating%3E=1&sort=userRating:desc` +
+  `&X-Plex-Container-Start=${start}&X-Plex-Container-Size=${PAGE_SIZE}`;
+
+const mapRatedItem = (
+  raw: PlexRatedItemMetadata,
+  type: PlexRatingType
+): PlexRatedItem => {
+  const kind = KIND_BY_TYPE[type];
+  const artist = kind === "track" ? raw.grandparentTitle : raw.parentTitle;
+  return {
+    ratingKey: raw.ratingKey,
+    kind,
+    title: raw.title,
+    artist: artist ?? "",
+    rating: raw.userRating ?? 0,
+  };
+};
+
+async function fetchRatedPage(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sectionKey: string,
+  type: PlexRatingType,
+  start: number
+): Promise<{ items: PlexRatedItem[]; totalSize: number }> {
+  const url = buildPageUrl(baseUrl, sectionKey, type, start);
+  const res = await resilientFetch(url, { headers });
+  if (!res.ok) throw new Error(`Plex returned ${res.status}`);
+
+  const data: PlexRatedItemsResponse = await res.json();
+  const container = data.MediaContainer;
+  const metadata = container?.Metadata ?? [];
+  const items = metadata
+    .filter((m) => typeof m.userRating === "number")
+    .map((m) => mapRatedItem(m, type));
+  return { items, totalSize: container?.totalSize ?? items.length };
+}
+
+async function fetchRatedByType(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sectionKey: string,
+  type: PlexRatingType
+): Promise<PlexRatedItem[]> {
+  const all: PlexRatedItem[] = [];
+  let start = 0;
+  for (;;) {
+    const { items, totalSize } = await fetchRatedPage(
+      baseUrl,
+      headers,
+      sectionKey,
+      type,
+      start
+    );
+    all.push(...items);
+    start += PAGE_SIZE;
+    if (items.length === 0 || start >= totalSize) break;
+  }
+  return all;
+}
+
+/**
+ * Read the current user's rated music via the per-user token path.
+ * Uses a server-side `userRating>=1` filter so only the (small) rated set is
+ * fetched — the full library is never scanned. Missing `userRating` is treated
+ * as unrated and excluded by the filter; an item read with `userRating` absent
+ * is also dropped client-side rather than coerced to 0.
+ */
+export async function getRatedItems(
+  plexToken: string,
+  types: PlexRatingType[] = DEFAULT_RATING_TYPES
+): Promise<PlexRatedItem[]> {
+  const { baseUrl, headers } = getPlexConfig(plexToken);
+  const sectionKey = await getMusicSectionKey(baseUrl, headers);
+
+  const perType = await Promise.all(
+    types.map((type) => fetchRatedByType(baseUrl, headers, sectionKey, type))
+  );
+  return perType.flat();
+}

--- a/server/api/plex/sections.ts
+++ b/server/api/plex/sections.ts
@@ -1,0 +1,16 @@
+import { resilientFetch } from "../resilientFetch";
+import type { PlexSectionsResponse } from "./types";
+
+export const getMusicSectionKey = async (
+  baseUrl: string,
+  headers: Record<string, string>
+): Promise<string> => {
+  const res = await resilientFetch(`${baseUrl}/library/sections`, { headers });
+  if (!res.ok) throw new Error(`Plex returned ${res.status}`);
+
+  const data: PlexSectionsResponse = await res.json();
+  const sections = data.MediaContainer?.Directory || [];
+  const musicSection = sections.find((s) => s.type === "artist");
+  if (!musicSection) throw new Error("No music library found in Plex");
+  return musicSection.key;
+};

--- a/server/api/plex/topArtists.ts
+++ b/server/api/plex/topArtists.ts
@@ -1,7 +1,7 @@
 import { resilientFetch } from "../resilientFetch";
 import { getPlexConfig } from "./config";
+import { getMusicSectionKey } from "./sections";
 import type {
-  PlexSectionsResponse,
   PlexArtistsResponse,
   PlexHistoryResponse,
   PlexTopArtist,
@@ -19,20 +19,6 @@ const SECONDS_PER_DAY = 86400;
 
 const buildThumbUrl = (thumb?: string): string =>
   thumb ? `/api/plex/thumb?path=${encodeURIComponent(thumb)}` : "";
-
-const getMusicSectionKey = async (
-  baseUrl: string,
-  headers: Record<string, string>
-): Promise<string> => {
-  const res = await resilientFetch(`${baseUrl}/library/sections`, { headers });
-  if (!res.ok) throw new Error(`Plex returned ${res.status}`);
-
-  const data: PlexSectionsResponse = await res.json();
-  const sections = data.MediaContainer?.Directory || [];
-  const musicSection = sections.find((s) => s.type === "artist");
-  if (!musicSection) throw new Error("No music library found in Plex");
-  return musicSection.key;
-};
 
 async function getTopArtistsAllTime(
   baseUrl: string,

--- a/server/api/plex/types.ts
+++ b/server/api/plex/types.ts
@@ -37,3 +37,30 @@ export type PlexTopArtist = {
   thumb: string;
   genres: string[];
 };
+
+/** Plex `type` ids for the rateable music entities tunearr ingests. */
+export type PlexRatingType = 9 | 10; // 9 = album, 10 = track
+
+export type PlexRatedItemMetadata = {
+  ratingKey: string;
+  title: string;
+  userRating?: number;
+  parentTitle?: string;
+  grandparentTitle?: string;
+};
+
+export type PlexRatedItemsResponse = {
+  MediaContainer: {
+    totalSize?: number;
+    Metadata?: PlexRatedItemMetadata[];
+  };
+};
+
+export type PlexRatedItem = {
+  ratingKey: string;
+  kind: "album" | "track";
+  title: string;
+  artist: string;
+  /** Plex scale 0–10 (half-star = 1 unit). */
+  rating: number;
+};

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -233,6 +233,12 @@ describe("promotedAlbum config", () => {
     ).toThrow("genericTags must be an array");
   });
 
+  it("validates ratingsBackupEnabled is a boolean", () => {
+    expect(() =>
+      setConfig({ promotedAlbum: { ratingsBackupEnabled: "yes" } as never })
+    ).toThrow("ratingsBackupEnabled must be a boolean");
+  });
+
   it("allows valid promotedAlbum config", () => {
     setConfig({
       promotedAlbum: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -42,6 +42,7 @@ export type PromotedAlbumConfig = {
   backgroundRegenEnabled: boolean;
   backgroundRegenIntervalMinutes: number;
   backgroundRegenActiveWithinMinutes: number;
+  ratingsBackupEnabled: boolean;
 };
 
 export type IConfig = {
@@ -116,6 +117,7 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   backgroundRegenEnabled: true,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };
 
 const DEFAULT_CONFIG: IConfig = {
@@ -257,6 +259,9 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
     config.backgroundRegenActiveWithinMinutes,
     "backgroundRegenActiveWithinMinutes"
   );
+  if (typeof config.ratingsBackupEnabled !== "boolean") {
+    throw new Error("ratingsBackupEnabled must be a boolean");
+  }
   if (
     !VALID_LIBRARY_PREFERENCES.includes(
       config.libraryPreference as LibraryPreference

--- a/server/db/userProfile.ts
+++ b/server/db/userProfile.ts
@@ -197,6 +197,32 @@ export async function getProfileRegenCandidates(): Promise<
   }));
 }
 
+/** A user eligible for signal ingestion: enabled and holding a Plex token. */
+export type SignalIngestionUser = {
+  userId: number;
+  plexToken: string;
+};
+
+/**
+ * Every enabled user with a stored Plex token — the daily signal-ingestion sweep
+ * runs for all of them, not just users who have a derived profile. Home servers
+ * have few users, so a full sweep is cheap.
+ */
+export async function getSignalIngestionUsers(): Promise<
+  SignalIngestionUser[]
+> {
+  const rows = (await getDataSource().query(
+    `SELECT id AS user_id, plex_token
+     FROM users
+     WHERE plex_token IS NOT NULL AND enabled = 1`
+  )) as { user_id: number; plex_token: string }[];
+
+  return rows.map((row) => ({
+    userId: row.user_id,
+    plexToken: row.plex_token,
+  }));
+}
+
 export async function getSignalEvents(
   userId: number,
   kind?: string

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import followedRoutes from "./routes/followed";
 import { startFollowedArtistPoller } from "./services/followed/poller";
 import { startRequestStatusPoller } from "./services/requests/statusPoller";
 import { startProfileRegenPoller } from "./services/profile/regenPoller";
+import { startSignalIngestionPoller } from "./services/profile/signalPoller";
 import { getConfig } from "./config";
 
 const log = createLogger("Server");
@@ -83,6 +84,8 @@ startRequestStatusPoller(requestStatusPollIntervalMs);
 const profileRegenIntervalMs =
   getConfig().promotedAlbum.backgroundRegenIntervalMinutes * 60 * 1000;
 startProfileRegenPoller(profileRegenIntervalMs);
+
+startSignalIngestionPoller();
 
 app.listen(PORT, () => {
   log.info(`Listening on port ${PORT}`);

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -111,6 +111,7 @@ const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   backgroundRegenEnabled: false,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };
 
 let userId: number;

--- a/server/promotedAlbum/profileService.test.ts
+++ b/server/promotedAlbum/profileService.test.ts
@@ -39,6 +39,7 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenEnabled: false,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };
 
 const plexArtists = [

--- a/server/promotedArtists/getPromotedArtists.test.ts
+++ b/server/promotedArtists/getPromotedArtists.test.ts
@@ -70,6 +70,7 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenEnabled: false,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };
 
 const TOP_ARTISTS = [

--- a/server/services/profile/regenPoller.test.ts
+++ b/server/services/profile/regenPoller.test.ts
@@ -43,6 +43,7 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenEnabled: true,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };
 
 const plexArtists = [

--- a/server/services/profile/signalIngestion.test.ts
+++ b/server/services/profile/signalIngestion.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetRatedItems = vi.fn();
+const mockGetTopArtists = vi.fn();
+
+vi.mock("../../api/plex/ratings", () => ({
+  getRatedItems: (...args: unknown[]) => mockGetRatedItems(...args),
+}));
+vi.mock("../../api/plex/topArtists", () => ({
+  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+}));
+
+import {
+  latestRatings,
+  diffRatings,
+  snapshotDue,
+  ingestUserRatings,
+  ingestUserSnapshot,
+  type PlexRatingPayload,
+  type SnapshotPayload,
+} from "./signalIngestion";
+import { initializeDatabase, closeDatabase, getDataSource } from "../../db";
+import { getSignalEvents } from "../../db/userProfile";
+import type { UserSignalEvent } from "../../db/entity/UserSignalEvent";
+
+function ratingEvent(
+  payload: PlexRatingPayload,
+  recordedAt = "2026-01-01T00:00:00.000Z"
+): UserSignalEvent {
+  return {
+    id: 0,
+    user_id: 1,
+    kind: "plex_rating",
+    payload: JSON.stringify(payload),
+    recorded_at: recordedAt,
+  } as UserSignalEvent;
+}
+
+const ratedTrack = {
+  ratingKey: "451",
+  kind: "track" as const,
+  title: "Air",
+  artist: "Andromedik",
+  rating: 10,
+};
+
+describe("latestRatings", () => {
+  it("replays the log so a later write wins", () => {
+    const map = latestRatings([
+      ratingEvent({ ...ratedTrack, rating: 6 }, "2026-01-01T00:00:00.000Z"),
+      ratingEvent({ ...ratedTrack, rating: 8 }, "2026-02-01T00:00:00.000Z"),
+    ]);
+    expect(map.get("451")?.rating).toBe(8);
+  });
+
+  it("skips corrupt rows", () => {
+    const corrupt = { ...ratingEvent(ratedTrack), payload: "not json" };
+    const map = latestRatings([corrupt as UserSignalEvent]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("diffRatings", () => {
+  it("emits new and changed ratings, skips unchanged", () => {
+    const previous = new Map<string, PlexRatingPayload>([
+      ["451", { ...ratedTrack, rating: 10 }],
+      [
+        "999",
+        { ratingKey: "999", kind: "album", title: "X", artist: "Y", rating: 4 },
+      ],
+    ]);
+    const current = [
+      { ...ratedTrack, rating: 10 }, // unchanged → skip
+      {
+        ratingKey: "999",
+        kind: "album" as const,
+        title: "X",
+        artist: "Y",
+        rating: 6,
+      }, // changed
+      {
+        ratingKey: "1577",
+        kind: "track" as const,
+        title: "New",
+        artist: "Z",
+        rating: 8,
+      }, // new
+    ];
+    const changes = diffRatings(previous, current);
+    expect(changes.map((c) => c.ratingKey).sort()).toEqual(["1577", "999"]);
+    expect(changes.find((c) => c.ratingKey === "999")?.rating).toBe(6);
+  });
+
+  it("does not emit a clear for an item dropping out of the rated set", () => {
+    const previous = new Map<string, PlexRatingPayload>([
+      ["451", { ...ratedTrack, rating: 10 }],
+    ]);
+    expect(diffRatings(previous, [])).toEqual([]);
+  });
+});
+
+describe("snapshotDue", () => {
+  const now = Date.parse("2026-06-28T12:00:00.000Z");
+  const day = 24 * 60 * 60 * 1000;
+
+  it("is due when no snapshot exists", () => {
+    expect(snapshotDue([], now, day)).toBe(true);
+  });
+
+  it("is not due when the last snapshot is within the interval", () => {
+    const recent = {
+      recorded_at: "2026-06-28T06:00:00.000Z",
+    } as UserSignalEvent;
+    expect(snapshotDue([recent], now, day)).toBe(false);
+  });
+
+  it("is due when the last snapshot is older than the interval", () => {
+    const old = { recorded_at: "2026-06-26T06:00:00.000Z" } as UserSignalEvent;
+    expect(snapshotDue([old], now, day)).toBe(true);
+  });
+});
+
+describe("ingestion (with DB)", () => {
+  beforeEach(async () => {
+    await initializeDatabase(":memory:");
+    await getDataSource().query("INSERT INTO users (username) VALUES (?)", [
+      "alice",
+    ]);
+  });
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it("writes all ratings on first run, then nothing on an unchanged re-run", async () => {
+    mockGetRatedItems.mockResolvedValue([ratedTrack]);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(1);
+    expect(await ingestUserRatings(1, "tok")).toBe(0);
+
+    const events = await getSignalEvents(1, "plex_rating");
+    expect(events).toHaveLength(1);
+    expect(JSON.parse(events[0].payload).artist).toBe("Andromedik");
+  });
+
+  it("appends one event when an existing rating changes", async () => {
+    mockGetRatedItems.mockResolvedValueOnce([ratedTrack]);
+    await ingestUserRatings(1, "tok");
+    mockGetRatedItems.mockResolvedValueOnce([{ ...ratedTrack, rating: 4 }]);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(1);
+    const events = await getSignalEvents(1, "plex_rating");
+    expect(events).toHaveLength(2);
+    expect(JSON.parse(events[1].payload).rating).toBe(4);
+  });
+
+  it("writes a snapshot of per-artist play counts", async () => {
+    mockGetTopArtists.mockResolvedValue([
+      { name: "Andromedik", viewCount: 120, thumb: "", genres: [] },
+      { name: "Durry", viewCount: 30, thumb: "", genres: [] },
+    ]);
+
+    await ingestUserSnapshot(1, "tok");
+
+    const events = await getSignalEvents(1, "snapshot");
+    expect(events).toHaveLength(1);
+    const payload = JSON.parse(events[0].payload) as SnapshotPayload;
+    expect(payload.artists).toEqual([
+      { name: "Andromedik", playCount: 120 },
+      { name: "Durry", playCount: 30 },
+    ]);
+    expect(mockGetTopArtists).toHaveBeenCalledWith("tok", 200, "all");
+  });
+});

--- a/server/services/profile/signalIngestion.ts
+++ b/server/services/profile/signalIngestion.ts
@@ -1,0 +1,114 @@
+import { getRatedItems } from "../../api/plex/ratings";
+import { getTopArtists } from "../../api/plex/topArtists";
+import { appendSignalEvent, getSignalEvents } from "../../db/userProfile";
+import type { UserSignalEvent } from "../../db/entity/UserSignalEvent";
+import type { PlexRatedItem } from "../../api/plex/types";
+
+/** Payload of a `kind = "plex_rating"` event — maps 1:1 to a `PlexRatedItem`. */
+export type PlexRatingPayload = {
+  ratingKey: string;
+  kind: PlexRatedItem["kind"];
+  title: string;
+  artist: string;
+  /** Plex scale 0–10. */
+  rating: number;
+};
+
+/** Payload of a `kind = "snapshot"` event — per-artist play counts at one instant. */
+export type SnapshotPayload = {
+  artists: { name: string; playCount: number }[];
+};
+
+/** How many top artists to back up per snapshot (covers the long tail, not just the top few). */
+const SNAPSHOT_ARTIST_COUNT = 200;
+
+/**
+ * Latest known rating per `ratingKey`, replayed from the append-only `plex_rating`
+ * log. Events arrive oldest-first, so a later write overwrites an earlier one.
+ */
+export function latestRatings(
+  events: UserSignalEvent[]
+): Map<string, PlexRatingPayload> {
+  const map = new Map<string, PlexRatingPayload>();
+  for (const event of events) {
+    try {
+      const payload = JSON.parse(event.payload) as PlexRatingPayload;
+      if (payload && typeof payload.ratingKey === "string") {
+        map.set(payload.ratingKey, payload);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return map;
+}
+
+/**
+ * Change events for the current rated set vs. the latest known ratings: a row for
+ * each new or changed rating. Un-rating (an item dropping out of the rated set) is
+ * deliberately NOT recorded — a transient empty/200 response would otherwise emit
+ * mass "cleared" events and corrupt the backup. Cleared ratings can be handled
+ * later behind a non-empty-response guard.
+ */
+export function diffRatings(
+  previous: Map<string, PlexRatingPayload>,
+  current: PlexRatedItem[]
+): PlexRatingPayload[] {
+  const changes: PlexRatingPayload[] = [];
+  for (const item of current) {
+    const prior = previous.get(item.ratingKey);
+    if (!prior || prior.rating !== item.rating) {
+      changes.push({
+        ratingKey: item.ratingKey,
+        kind: item.kind,
+        title: item.title,
+        artist: item.artist,
+        rating: item.rating,
+      });
+    }
+  }
+  return changes;
+}
+
+/**
+ * Read the user's current Plex ratings and append a `plex_rating` event for each
+ * one that is new or changed since the last ingestion. Returns the number written.
+ */
+export async function ingestUserRatings(
+  userId: number,
+  plexToken: string
+): Promise<number> {
+  const current = await getRatedItems(plexToken);
+  const previous = latestRatings(await getSignalEvents(userId, "plex_rating"));
+  const changes = diffRatings(previous, current);
+  for (const change of changes) {
+    await appendSignalEvent(userId, "plex_rating", change);
+  }
+  return changes.length;
+}
+
+/**
+ * Append a `snapshot` event capturing the user's all-time per-artist play counts —
+ * tunearr's own durable copy of the signal Plex can lose on a history clear / re-import.
+ */
+export async function ingestUserSnapshot(
+  userId: number,
+  plexToken: string
+): Promise<void> {
+  const artists = await getTopArtists(plexToken, SNAPSHOT_ARTIST_COUNT, "all");
+  const payload: SnapshotPayload = {
+    artists: artists.map((a) => ({ name: a.name, playCount: a.viewCount })),
+  };
+  await appendSignalEvent(userId, "snapshot", payload);
+}
+
+/** Whether a new snapshot is due — true when none exists or the last is older than the interval. */
+export function snapshotDue(
+  events: UserSignalEvent[],
+  now: number,
+  intervalMs: number
+): boolean {
+  const last = events[events.length - 1];
+  if (!last) return true;
+  return now - Date.parse(last.recorded_at) >= intervalMs;
+}

--- a/server/services/profile/signalPoller.test.ts
+++ b/server/services/profile/signalPoller.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetConfigValue = vi.fn();
+const mockGetRatedItems = vi.fn();
+const mockGetTopArtists = vi.fn();
+
+vi.mock("../../config", () => ({
+  getConfigValue: (...args: unknown[]) => mockGetConfigValue(...args),
+}));
+vi.mock("../../api/plex/ratings", () => ({
+  getRatedItems: (...args: unknown[]) => mockGetRatedItems(...args),
+}));
+vi.mock("../../api/plex/topArtists", () => ({
+  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+}));
+
+import { runSignalIngestionOnce } from "./signalPoller";
+import { initializeDatabase, closeDatabase, getDataSource } from "../../db";
+import { getSignalEvents } from "../../db/userProfile";
+
+async function createUser(
+  username: string,
+  plexToken: string | null,
+  enabled = 1
+): Promise<void> {
+  await getDataSource().query(
+    "INSERT INTO users (username, plex_token, enabled) VALUES (?, ?, ?)",
+    [username, plexToken, enabled]
+  );
+}
+
+const ratedTrack = {
+  ratingKey: "451",
+  kind: "track" as const,
+  title: "Air",
+  artist: "Andromedik",
+  rating: 10,
+};
+
+beforeEach(async () => {
+  await initializeDatabase(":memory:");
+  mockGetConfigValue.mockReturnValue({ ratingsBackupEnabled: true });
+  mockGetRatedItems.mockResolvedValue([ratedTrack]);
+  mockGetTopArtists.mockResolvedValue([
+    { name: "Andromedik", viewCount: 120, thumb: "", genres: [] },
+  ]);
+});
+afterEach(async () => {
+  vi.clearAllMocks();
+  await closeDatabase();
+});
+
+describe("runSignalIngestionOnce", () => {
+  it("ingests ratings + a snapshot for every enabled token-holding user", async () => {
+    await createUser("alice", "tok-a");
+    await createUser("bob", "tok-b");
+
+    await runSignalIngestionOnce();
+
+    for (const userId of [1, 2]) {
+      expect(await getSignalEvents(userId, "plex_rating")).toHaveLength(1);
+      expect(await getSignalEvents(userId, "snapshot")).toHaveLength(1);
+    }
+  });
+
+  it("skips users without a token and disabled users", async () => {
+    await createUser("local", null);
+    await createUser("disabled", "tok-d", 0);
+
+    await runSignalIngestionOnce();
+
+    expect(mockGetRatedItems).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the backup is disabled", async () => {
+    mockGetConfigValue.mockReturnValue({ ratingsBackupEnabled: false });
+    await createUser("alice", "tok-a");
+
+    await runSignalIngestionOnce();
+
+    expect(mockGetRatedItems).not.toHaveBeenCalled();
+    expect(await getSignalEvents(1, "snapshot")).toHaveLength(0);
+  });
+
+  it("does not write a second snapshot within the interval", async () => {
+    await createUser("alice", "tok-a");
+
+    await runSignalIngestionOnce();
+    await runSignalIngestionOnce();
+
+    expect(await getSignalEvents(1, "snapshot")).toHaveLength(1);
+  });
+
+  it("isolates per-user failures so the sweep continues", async () => {
+    await createUser("broken", "tok-x");
+    await createUser("alice", "tok-a");
+    mockGetRatedItems.mockRejectedValueOnce(new Error("plex down"));
+
+    await runSignalIngestionOnce();
+
+    expect(await getSignalEvents(1, "snapshot")).toHaveLength(0);
+    expect(await getSignalEvents(2, "snapshot")).toHaveLength(1);
+  });
+});

--- a/server/services/profile/signalPoller.ts
+++ b/server/services/profile/signalPoller.ts
@@ -1,0 +1,91 @@
+import { getConfigValue } from "../../config";
+import { getSignalEvents, getSignalIngestionUsers } from "../../db/userProfile";
+import {
+  ingestUserRatings,
+  ingestUserSnapshot,
+  snapshotDue,
+} from "./signalIngestion";
+import { createLogger } from "../../logger";
+
+const log = createLogger("signal-ingestion-poller");
+
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FIRST_RUN_DELAY_MS = 5 * 60 * 1000;
+const SNAPSHOT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+/**
+ * One ingestion sweep over every enabled user with a Plex token: append any
+ * new/changed ratings, and a snapshot if one is due (>= once/day). Per-user
+ * failures (e.g. a managed user whose ratings don't resolve) are logged and
+ * skipped so one account never aborts the sweep.
+ *
+ * NOTE: single-instance assumption — a naive interval double-runs under multiple
+ * replicas. The append-only log tolerates duplicate snapshots but would record
+ * redundant rows.
+ */
+export async function runSignalIngestionOnce(now = Date.now()): Promise<void> {
+  if (running) {
+    log.warn("Signal ingestion already running, skipping this tick");
+    return;
+  }
+  running = true;
+  try {
+    if (!getConfigValue("promotedAlbum").ratingsBackupEnabled) return;
+
+    const users = await getSignalIngestionUsers();
+    let ratingsWritten = 0;
+    let snapshotsWritten = 0;
+
+    for (const user of users) {
+      try {
+        ratingsWritten += await ingestUserRatings(user.userId, user.plexToken);
+        const snapshots = await getSignalEvents(user.userId, "snapshot");
+        if (snapshotDue(snapshots, now, SNAPSHOT_INTERVAL_MS)) {
+          await ingestUserSnapshot(user.userId, user.plexToken);
+          snapshotsWritten += 1;
+        }
+      } catch (error) {
+        log.error(`Signal ingestion failed for user ${user.userId}`, error);
+      }
+    }
+
+    if (ratingsWritten > 0 || snapshotsWritten > 0) {
+      log.info(
+        `Ingested ${ratingsWritten} rating change(s), ${snapshotsWritten} snapshot(s)`
+      );
+    }
+  } finally {
+    running = false;
+  }
+}
+
+export function startSignalIngestionPoller(
+  intervalMs: number = DEFAULT_INTERVAL_MS
+): void {
+  if (timer) return;
+
+  const tick = async () => {
+    try {
+      await runSignalIngestionOnce();
+    } catch (error) {
+      log.error("Signal ingestion tick failed", error);
+    } finally {
+      timer = setTimeout(tick, intervalMs);
+    }
+  };
+
+  timer = setTimeout(tick, FIRST_RUN_DELAY_MS);
+  log.info(
+    `Signal ingestion poller scheduled (interval: ${intervalMs / 1000}s)`
+  );
+}
+
+export function stopSignalIngestionPoller(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -30,4 +30,5 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
   backgroundRegenEnabled: true,
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
+  ratingsBackupEnabled: true,
 };

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -24,6 +24,7 @@ export interface PromotedAlbumSettings {
   backgroundRegenEnabled: boolean;
   backgroundRegenIntervalMinutes: number;
   backgroundRegenActiveWithinMinutes: number;
+  ratingsBackupEnabled: boolean;
 }
 
 export interface PurchaseDecisionSettings {

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -210,6 +210,27 @@ export default function RecommendationsSection({
         </>
       )}
 
+      <div className="flex items-center gap-3">
+        <input
+          type="checkbox"
+          id="ratings-backup-enabled"
+          checked={config.ratingsBackupEnabled}
+          onChange={(e) => update("ratingsBackupEnabled", e.target.checked)}
+          className="h-4 w-4 rounded border-2 border-black"
+        />
+        <label
+          htmlFor="ratings-backup-enabled"
+          className="text-sm font-medium text-gray-900 dark:text-gray-100"
+        >
+          Back up Plex ratings &amp; play counts daily
+        </label>
+      </div>
+      <p className="text-gray-400 dark:text-gray-500 text-xs -mt-2">
+        Once a day, tunearr records each user's Plex star ratings and per-artist
+        play counts into its own database, so your taste data survives a Plex
+        history clear, re-import, or server migration. Single-instance only.
+      </p>
+
       <div>
         <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
           Listening Window

--- a/src/pages/SettingsPage/sections/recommendations/__tests__/RecommendationsSection.test.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/__tests__/RecommendationsSection.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import RecommendationsSection from "../RecommendationsSection";
+import { DEFAULT_PROMOTED_ALBUM } from "@/context/promotedAlbumDefaults";
+
+describe("RecommendationsSection — ratings backup toggle", () => {
+  it("reflects ratingsBackupEnabled and toggles it off", () => {
+    const onChange = vi.fn();
+    render(
+      <RecommendationsSection
+        config={DEFAULT_PROMOTED_ALBUM}
+        onConfigChange={onChange}
+      />
+    );
+
+    const checkbox = screen.getByLabelText(/Back up Plex ratings/i);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PROMOTED_ALBUM,
+      ratingsBackupEnabled: false,
+    });
+  });
+});


### PR DESCRIPTION
Implements **Step 2** of user-profile stabilisation (#172) — ingest Plex star ratings and write daily backup snapshots into the `UserSignalEvent` table that Step 1 (#166) created but never wrote to. Ratings are the one genuinely unrecoverable Plex signal; this gives tunearr its own durable copy so profiles survive a Plex history clear / re-import / server migration.

Design rationale: `docs/user-profile-stabilization-rfc.md`.

## What's here

**Phase 1 — ratings reader** (`server/api/plex/ratings.ts`)
- `getRatedItems(plexToken, types?)` over the existing per-user token path, with a server-side `userRating>=1` filter so the full library is never scanned. Paginates per type until `totalSize`; albums (9) + tracks (10) fetched concurrently.
- Extracted `getMusicSectionKey` → `sections.ts`, shared with `topArtists` (no behaviour change).
- **Live-verified against a real PMS**: filter encoding (`userRating%3E=1`), `totalSize` presence, and both album + track artist mapping all confirmed. (The RFC's guessed `>>=` operator turned out unnecessary.)

**Phase 2 — ingestion writer** (`server/services/profile/signalIngestion.ts`)
- `plex_rating` events written **only on change**, diffed against the replayed latest-rating-per-`ratingKey`.
- `snapshot` events = all-time per-artist play counts (top 200). Snapshots hold play counts only; ratings live in `plex_rating`, so daily rows don't duplicate the rating set.
- Un-rating (clears) deliberately not recorded — a transient empty/200 response would otherwise emit mass false clears. Deferrable behind a non-empty guard.

**Phase 3 — daily poller** (`server/services/profile/signalPoller.ts`)
- Once-daily sweep over **every enabled user with a Plex token** (home servers have few users, so a full sweep is cheap). Appends rating changes each tick; a snapshot when `>= 24h` since the last.
- Per-user failures isolated — a managed/broken account never aborts the sweep.
- Gated by `ratingsBackupEnabled` (default true) with a toggle on the recommendations settings page.

## Tests
- Backend: ingestion diff/replay/snapshot, poller (all-users sweep, token/enabled filtering, disabled gate, daily dedup, per-user error isolation), config validation, reader mapping/pagination/filter.
- Frontend: settings toggle.
- Full suites green (958 server, 774 frontend), typecheck + lint clean.

## Known follow-ups (not blocking — both unit-test-covered)
- Multi-page pagination against a real >100-rated library.
- Managed-account skip behaviour against a genuine managed account (none in the test DB; the per-user `try/catch` already isolates it).

Closes #172.
