### PR TITLE
feat: recommender sources plays + ratings from snapshot series

### DIFF
--- a/server/api/plex/artistPlayCounts.test.ts
+++ b/server/api/plex/artistPlayCounts.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getAllArtistPlayCounts } from "./artistPlayCounts";
+
+vi.mock("./config", () => ({
+  getPlexConfig: vi.fn(() => ({
+    baseUrl: "http://plex:32400",
+    headers: { "X-Plex-Token": "tok", Accept: "application/json" },
+    token: "tok",
+  })),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function okResponse(data: unknown) {
+  return { ok: true, json: () => Promise.resolve(data) };
+}
+
+const musicSection = okResponse({
+  MediaContainer: { Directory: [{ key: "3", type: "artist", title: "Music" }] },
+});
+
+function artistsPage(start: number, count: number, totalSize: number) {
+  return okResponse({
+    MediaContainer: {
+      totalSize,
+      Metadata: Array.from({ length: count }, (_, i) => ({
+        title: `A${start + i}`,
+        viewCount: 5,
+      })),
+    },
+  });
+}
+
+describe("getAllArtistPlayCounts", () => {
+  it("returns played artists and drops zero-play ones", async () => {
+    mockFetch.mockResolvedValueOnce(musicSection).mockResolvedValueOnce(
+      okResponse({
+        MediaContainer: {
+          totalSize: 2,
+          Metadata: [
+            { title: "Radiohead", viewCount: 150 },
+            { title: "Silence", viewCount: 0 },
+          ],
+        },
+      })
+    );
+
+    const result = await getAllArtistPlayCounts("tok");
+
+    expect(result).toEqual([{ name: "Radiohead", viewCount: 150 }]);
+  });
+
+  it("paginates through every page until totalSize", async () => {
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce(artistsPage(0, 200, 450))
+      .mockResolvedValueOnce(artistsPage(200, 200, 450))
+      .mockResolvedValueOnce(artistsPage(400, 50, 450));
+
+    const result = await getAllArtistPlayCounts("tok");
+
+    expect(result).toHaveLength(450);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("stops early once a page returns fewer played artists than the page size", async () => {
+    mockFetch.mockResolvedValueOnce(musicSection).mockResolvedValueOnce(
+      okResponse({
+        MediaContainer: {
+          totalSize: 10000,
+          Metadata: [
+            { title: "Played", viewCount: 3 },
+            { title: "Unplayed", viewCount: 0 },
+          ],
+        },
+      })
+    );
+
+    const result = await getAllArtistPlayCounts("tok");
+
+    expect(result).toEqual([{ name: "Played", viewCount: 3 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on a Plex API error", async () => {
+    mockFetch
+      .mockResolvedValueOnce(musicSection)
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(getAllArtistPlayCounts("tok")).rejects.toThrow(
+      "Plex returned 500"
+    );
+  });
+});

--- a/server/api/plex/artistPlayCounts.ts
+++ b/server/api/plex/artistPlayCounts.ts
@@ -1,0 +1,68 @@
+import { resilientFetch } from "../resilientFetch";
+import { getPlexConfig } from "./config";
+import { getMusicSectionKey } from "./sections";
+import type { PlexArtistsResponse } from "./types";
+
+export type ArtistPlayCount = {
+  name: string;
+  viewCount: number;
+};
+
+const PAGE_SIZE = 200;
+
+const buildPageUrl = (
+  baseUrl: string,
+  sectionKey: string,
+  start: number
+): string =>
+  `${baseUrl}/library/sections/${sectionKey}/all?type=8&sort=viewCount:desc` +
+  `&X-Plex-Container-Start=${start}&X-Plex-Container-Size=${PAGE_SIZE}`;
+
+async function fetchPage(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sectionKey: string,
+  start: number
+): Promise<{ items: ArtistPlayCount[]; totalSize: number }> {
+  const res = await resilientFetch(buildPageUrl(baseUrl, sectionKey, start), {
+    headers,
+  });
+  if (!res.ok) throw new Error(`Plex returned ${res.status}`);
+
+  const data: PlexArtistsResponse & { MediaContainer: { totalSize?: number } } =
+    await res.json();
+  const container = data.MediaContainer;
+  const metadata = container?.Metadata ?? [];
+  const items = metadata
+    .filter((a) => (a.viewCount || 0) > 0)
+    .map((a) => ({ name: a.title, viewCount: a.viewCount || 0 }));
+  return { items, totalSize: container?.totalSize ?? items.length };
+}
+
+/**
+ * Every artist in the library with a play count, paginated to completion. Sorted
+ * by `viewCount:desc`, so once a page yields no played artist the remainder are all
+ * unplayed and we can stop early. Intended for the background snapshot job against a
+ * local PMS, where there is no rate limit on walking the whole library.
+ */
+export async function getAllArtistPlayCounts(
+  plexToken: string
+): Promise<ArtistPlayCount[]> {
+  const { baseUrl, headers } = getPlexConfig(plexToken);
+  const sectionKey = await getMusicSectionKey(baseUrl, headers);
+
+  const all: ArtistPlayCount[] = [];
+  let start = 0;
+  for (;;) {
+    const { items, totalSize } = await fetchPage(
+      baseUrl,
+      headers,
+      sectionKey,
+      start
+    );
+    all.push(...items);
+    start += PAGE_SIZE;
+    if (items.length < PAGE_SIZE || start >= totalSize) break;
+  }
+  return all;
+}

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -239,6 +239,18 @@ describe("promotedAlbum config", () => {
     ).toThrow("ratingsBackupEnabled must be a boolean");
   });
 
+  it("validates playTrendWindowDays is a positive integer", () => {
+    expect(() =>
+      setConfig({ promotedAlbum: { playTrendWindowDays: 0 } as never })
+    ).toThrow("playTrendWindowDays must be a positive integer");
+  });
+
+  it("validates ratingWeight is non-negative", () => {
+    expect(() =>
+      setConfig({ promotedAlbum: { ratingWeight: -1 } as never })
+    ).toThrow("ratingWeight must be a non-negative number");
+  });
+
   it("allows valid promotedAlbum config", () => {
     setConfig({
       promotedAlbum: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -43,6 +43,8 @@ export type PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: number;
   backgroundRegenActiveWithinMinutes: number;
   ratingsBackupEnabled: boolean;
+  playTrendWindowDays: number;
+  ratingWeight: number;
 };
 
 export type IConfig = {
@@ -118,6 +120,8 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 const DEFAULT_CONFIG: IConfig = {
@@ -261,6 +265,10 @@ function validatePromotedAlbumConfig(config: PromotedAlbumConfig) {
   );
   if (typeof config.ratingsBackupEnabled !== "boolean") {
     throw new Error("ratingsBackupEnabled must be a boolean");
+  }
+  validatePositiveInt(config.playTrendWindowDays, "playTrendWindowDays");
+  if (typeof config.ratingWeight !== "number" || config.ratingWeight < 0) {
+    throw new Error("ratingWeight must be a non-negative number");
   }
   if (
     !VALID_LIBRARY_PREFERENCES.includes(

--- a/server/db/userProfile.test.ts
+++ b/server/db/userProfile.test.ts
@@ -36,6 +36,8 @@ const CONFIG_INPUTS = {
   genericTags: ["seen live", "favorites"],
   tagsPerArtist: 5,
   pickedArtistsCount: 3,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 async function createUser(username: string): Promise<number> {

--- a/server/db/userProfile.ts
+++ b/server/db/userProfile.ts
@@ -13,6 +13,8 @@ export type ProfileConfigInputs = {
   genericTags: string[];
   tagsPerArtist: number;
   pickedArtistsCount: number;
+  playTrendWindowDays: number;
+  ratingWeight: number;
 };
 
 /** A partial patch of the anti-repeat exploration memory; only provided fields are replaced. */
@@ -61,6 +63,8 @@ export function computeConfigHash(inputs: ProfileConfigInputs): string {
     genericTags: [...inputs.genericTags].map((t) => t.toLowerCase()).sort(),
     tagsPerArtist: inputs.tagsPerArtist,
     pickedArtistsCount: inputs.pickedArtistsCount,
+    playTrendWindowDays: inputs.playTrendWindowDays,
+    ratingWeight: inputs.ratingWeight,
   });
   return createHash("sha256").update(stable).digest("hex");
 }

--- a/server/promotedAlbum/artistWeights.test.ts
+++ b/server/promotedAlbum/artistWeights.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetAllArtistPlayCounts = vi.fn();
+
+vi.mock("../api/plex/artistPlayCounts", () => ({
+  getAllArtistPlayCounts: (...args: unknown[]) =>
+    mockGetAllArtistPlayCounts(...args),
+}));
+
+import {
+  derivePlayWeights,
+  aggregateArtistRatings,
+  applyRatingMultiplier,
+  loadArtistWeights,
+  type ArtistWeight,
+} from "./artistWeights";
+import { initializeDatabase, closeDatabase, getDataSource } from "../db";
+import { appendSignalEvent, getSignalEvents } from "../db/userProfile";
+import type { UserSignalEvent } from "../db/entity/UserSignalEvent";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-06-28T00:00:00.000Z");
+
+function snapshotEvent(
+  artists: { name: string; playCount: number }[],
+  daysAgo: number
+): UserSignalEvent {
+  return {
+    id: 0,
+    user_id: 1,
+    kind: "snapshot",
+    payload: JSON.stringify({ artists }),
+    recorded_at: new Date(NOW - daysAgo * DAY).toISOString(),
+  } as UserSignalEvent;
+}
+
+function ratingEvent(artist: string, rating: number): UserSignalEvent {
+  return {
+    id: 0,
+    user_id: 1,
+    kind: "plex_rating",
+    payload: JSON.stringify({
+      ratingKey: `${artist}-${rating}`,
+      kind: "track",
+      title: "t",
+      artist,
+      rating,
+    }),
+    recorded_at: "2026-01-01T00:00:00.000Z",
+  } as UserSignalEvent;
+}
+
+describe("derivePlayWeights", () => {
+  it("returns windowed deltas when the series spans the window", () => {
+    const snapshots = [
+      snapshotEvent(
+        [
+          { name: "A", playCount: 10 },
+          { name: "B", playCount: 5 },
+        ],
+        40
+      ),
+      snapshotEvent(
+        [
+          { name: "A", playCount: 30 },
+          { name: "B", playCount: 5 },
+        ],
+        0
+      ),
+    ];
+    const result = derivePlayWeights(snapshots, NOW, 30 * DAY);
+    expect(result).toEqual([{ name: "A", viewCount: 20 }]);
+  });
+
+  it("falls back to latest all-time counts until the window is covered", () => {
+    const snapshots = [
+      snapshotEvent([{ name: "A", playCount: 10 }], 5),
+      snapshotEvent([{ name: "A", playCount: 12 }], 0),
+    ];
+    const result = derivePlayWeights(snapshots, NOW, 30 * DAY);
+    expect(result).toEqual([{ name: "A", viewCount: 12 }]);
+  });
+
+  it("falls back to all-time when nothing was played in the window", () => {
+    const snapshots = [
+      snapshotEvent([{ name: "A", playCount: 10 }], 40),
+      snapshotEvent([{ name: "A", playCount: 10 }], 0),
+    ];
+    const result = derivePlayWeights(snapshots, NOW, 30 * DAY);
+    expect(result).toEqual([{ name: "A", viewCount: 10 }]);
+  });
+
+  it("returns empty for no snapshots", () => {
+    expect(derivePlayWeights([], NOW, 30 * DAY)).toEqual([]);
+  });
+});
+
+describe("aggregateArtistRatings", () => {
+  it("averages ratings per artist from the latest per item", () => {
+    const ratings = aggregateArtistRatings([
+      ratingEvent("A", 10),
+      ratingEvent("A", 6),
+      ratingEvent("B", 8),
+    ]);
+    expect(ratings.get("A")).toBe(8);
+    expect(ratings.get("B")).toBe(8);
+  });
+});
+
+describe("applyRatingMultiplier", () => {
+  it("boosts rated artists and leaves unrated untouched", () => {
+    const plays: ArtistWeight[] = [
+      { name: "A", viewCount: 100 },
+      { name: "B", viewCount: 100 },
+    ];
+    const ratings = new Map([["A", 10]]);
+    const result = applyRatingMultiplier(plays, ratings, 0.5);
+    expect(result[0]).toEqual({ name: "A", viewCount: 150 });
+    expect(result[1]).toEqual({ name: "B", viewCount: 100 });
+  });
+});
+
+describe("loadArtistWeights (with DB)", () => {
+  beforeEach(async () => {
+    await initializeDatabase(":memory:");
+    await getDataSource().query("INSERT INTO users (username) VALUES (?)", [
+      "alice",
+    ]);
+  });
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await closeDatabase();
+  });
+
+  it("ingests a snapshot on demand when the user has none", async () => {
+    mockGetAllArtistPlayCounts.mockResolvedValue([
+      { name: "A", viewCount: 42 },
+    ]);
+
+    const result = await loadArtistWeights(1, "tok", 30 * DAY, 0.5, NOW);
+
+    expect(mockGetAllArtistPlayCounts).toHaveBeenCalledWith("tok");
+    expect(await getSignalEvents(1, "snapshot")).toHaveLength(1);
+    expect(result).toEqual([{ name: "A", viewCount: 42 }]);
+  });
+
+  it("reads existing snapshots + ratings without a live fetch", async () => {
+    await appendSignalEvent(1, "snapshot", {
+      artists: [{ name: "A", playCount: 100 }],
+    });
+    await appendSignalEvent(1, "plex_rating", {
+      ratingKey: "k",
+      kind: "track",
+      title: "t",
+      artist: "A",
+      rating: 10,
+    });
+
+    const result = await loadArtistWeights(1, "tok", 30 * DAY, 0.5, NOW);
+
+    expect(mockGetAllArtistPlayCounts).not.toHaveBeenCalled();
+    expect(result).toEqual([{ name: "A", viewCount: 150 }]);
+  });
+});

--- a/server/promotedAlbum/artistWeights.ts
+++ b/server/promotedAlbum/artistWeights.ts
@@ -1,0 +1,132 @@
+import { getSignalEvents } from "../db/userProfile";
+import {
+  ingestUserSnapshot,
+  latestRatings,
+  type SnapshotPayload,
+} from "../services/profile/signalIngestion";
+import type { UserSignalEvent } from "../db/entity/UserSignalEvent";
+
+/** An artist with the effective weight (windowed plays × rating boost) the recommender ranks by. */
+export type ArtistWeight = {
+  name: string;
+  viewCount: number;
+};
+
+function parseSnapshotCounts(event: UserSignalEvent): Map<string, number> {
+  const counts = new Map<string, number>();
+  try {
+    const payload = JSON.parse(event.payload) as SnapshotPayload;
+    for (const artist of payload.artists ?? []) {
+      counts.set(artist.name, artist.playCount);
+    }
+  } catch {
+    return counts;
+  }
+  return counts;
+}
+
+/** Most recent snapshot recorded at or before the window start, or null if the series is younger. */
+function findBaseline(
+  snapshots: UserSignalEvent[],
+  windowStart: number
+): UserSignalEvent | null {
+  for (let i = snapshots.length - 1; i >= 0; i--) {
+    if (Date.parse(snapshots[i].recorded_at) <= windowStart)
+      return snapshots[i];
+  }
+  return null;
+}
+
+function allTimeWeights(latest: Map<string, number>): ArtistWeight[] {
+  return Array.from(latest, ([name, viewCount]) => ({ name, viewCount }));
+}
+
+/**
+ * Per-artist play weight derived from the snapshot series. When the series spans the
+ * full window, weight = plays within the window (latest cumulative count minus the count
+ * at the window start). Until the series is that deep — or when nothing was played in the
+ * window — weight falls back to the latest cumulative all-time count, so the set is never
+ * empty and a thin history still produces sensible weights.
+ */
+export function derivePlayWeights(
+  snapshots: UserSignalEvent[],
+  now: number,
+  windowMs: number
+): ArtistWeight[] {
+  if (snapshots.length === 0) return [];
+  const latest = parseSnapshotCounts(snapshots[snapshots.length - 1]);
+
+  const baselineEvent = findBaseline(snapshots, now - windowMs);
+  if (!baselineEvent) return allTimeWeights(latest);
+
+  const baseline = parseSnapshotCounts(baselineEvent);
+  const windowed: ArtistWeight[] = [];
+  let total = 0;
+  for (const [name, count] of latest) {
+    const delta = Math.max(0, count - (baseline.get(name) ?? 0));
+    total += delta;
+    if (delta > 0) windowed.push({ name, viewCount: delta });
+  }
+  return total > 0 ? windowed : allTimeWeights(latest);
+}
+
+/** Average rating (0–10) per artist, from the latest rating known for each rated item. */
+export function aggregateArtistRatings(
+  ratingEvents: UserSignalEvent[]
+): Map<string, number> {
+  const totals = new Map<string, { sum: number; count: number }>();
+  for (const payload of latestRatings(ratingEvents).values()) {
+    if (!payload.artist) continue;
+    const entry = totals.get(payload.artist) ?? { sum: 0, count: 0 };
+    entry.sum += payload.rating;
+    entry.count += 1;
+    totals.set(payload.artist, entry);
+  }
+  const averages = new Map<string, number>();
+  for (const [name, { sum, count }] of totals) {
+    averages.set(name, sum / count);
+  }
+  return averages;
+}
+
+/** Boost each artist's play weight by its average rating: `× (1 + ratingWeight × avg/10)`. */
+export function applyRatingMultiplier(
+  plays: ArtistWeight[],
+  ratings: Map<string, number>,
+  ratingWeight: number
+): ArtistWeight[] {
+  return plays.map((play) => {
+    const avg = ratings.get(play.name);
+    if (avg === undefined) return play;
+    return {
+      name: play.name,
+      viewCount: play.viewCount * (1 + ratingWeight * (avg / 10)),
+    };
+  });
+}
+
+/**
+ * The recommender's canonical artist-weight source: windowed play trend from the user's
+ * own snapshot series, boosted by their ratings. Reads everything from `user_signal_events`
+ * — no live Plex query — except the cold-start case (zero snapshots), where one snapshot
+ * is ingested on demand so the first read still goes through our own table.
+ */
+export async function loadArtistWeights(
+  userId: number,
+  plexToken: string,
+  windowMs: number,
+  ratingWeight: number,
+  now: number = Date.now()
+): Promise<ArtistWeight[]> {
+  let snapshots = await getSignalEvents(userId, "snapshot");
+  if (snapshots.length === 0) {
+    await ingestUserSnapshot(userId, plexToken);
+    snapshots = await getSignalEvents(userId, "snapshot");
+  }
+
+  const plays = derivePlayWeights(snapshots, now, windowMs);
+  const ratings = aggregateArtistRatings(
+    await getSignalEvents(userId, "plex_rating")
+  );
+  return applyRatingMultiplier(plays, ratings, ratingWeight);
+}

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { PromotedAlbumConfig } from "../config";
 
+const mockLoadArtistWeights = vi.fn();
 const mockGetTopArtists = vi.fn();
 const mockGetArtistTopTags = vi.fn();
 const mockGetTopAlbumsByTag = vi.fn();
@@ -10,6 +11,10 @@ const mockFetchReleaseGroupsForArtist = vi.fn();
 const mockGetConfigValue = vi.fn();
 const mockGetSimilarArtists = vi.fn();
 const mockGetArtistMbidByName = vi.fn();
+
+vi.mock("./artistWeights", () => ({
+  loadArtistWeights: (...args: unknown[]) => mockLoadArtistWeights(...args),
+}));
 
 vi.mock("../api/plex/topArtists", () => ({
   getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
@@ -112,6 +117,8 @@ const defaultPromotedAlbumConfig: PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 let userId: number;
@@ -121,6 +128,7 @@ beforeEach(async () => {
   clearPromotedAlbumCache();
   vi.spyOn(Math, "random").mockReturnValue(0.1);
   mockGetConfigValue.mockReturnValue(defaultPromotedAlbumConfig);
+  mockGetTopArtists.mockResolvedValue(plexArtists);
   mockGetReleaseGroupIdFromRelease.mockImplementation((mbid: string) =>
     Promise.resolve({ id: `rg-${mbid}`, firstReleaseDate: "1997-06-16" })
   );
@@ -162,7 +170,7 @@ const albumsPage = {
 
 describe("getPromotedAlbum", () => {
   it("returns a promoted album on happy path with correct shape", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({
@@ -184,10 +192,11 @@ describe("getPromotedAlbum", () => {
     });
     expect(wt(result).tag).toBe("alternative");
     expect(result!.inLibrary).toBe(false);
-    expect(mockGetTopArtists).toHaveBeenCalledWith(
+    expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+      expect.any(Number),
       "test-plex-token",
-      10,
-      "6months"
+      expect.any(Number),
+      expect.any(Number)
     );
   });
 
@@ -200,11 +209,11 @@ describe("getPromotedAlbum", () => {
 
     const result = await getPromotedAlbum(tokenlessId);
     expect(result).toBeNull();
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
   });
 
   it("fetches both page 1 and a deep page of tag albums", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -220,14 +229,14 @@ describe("getPromotedAlbum", () => {
   });
 
   it("returns null when Plex has no artists", async () => {
-    mockGetTopArtists.mockResolvedValue([]);
+    mockLoadArtistWeights.mockResolvedValue([]);
 
     const result = await getPromotedAlbum(userId);
     expect(result).toBeNull();
   });
 
   it("returns null when all tags are generic", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue([
       { name: "seen live", count: 100 },
       { name: "favorites", count: 80 },
@@ -238,7 +247,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("handles tag fetch failures gracefully", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockRejectedValue(new Error("API error"));
 
     const result = await getPromotedAlbum(userId);
@@ -246,7 +255,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("filters albums without MBIDs", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue({
       albums: [
@@ -261,7 +270,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("marks inLibrary true when the album is in the Lidarr album list", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockImplementation((path: string) => {
@@ -283,7 +292,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("marks inLibrary false when artist is in library but album is not", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockImplementation((path: string) => {
@@ -302,23 +311,23 @@ describe("getPromotedAlbum", () => {
   });
 
   it("returns the cached result within the result-cache TTL", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
     const first = await getPromotedAlbum(userId);
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
     mockGetTopAlbumsByTag.mockClear();
 
     const second = await getPromotedAlbum(userId);
     expect(second).toEqual(first);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
     expect(mockGetTopAlbumsByTag).not.toHaveBeenCalled();
   });
 
   it("caches results per user — different users get independent results", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -327,33 +336,34 @@ describe("getPromotedAlbum", () => {
     const userB = await createUserWithToken("user-b-token");
 
     await getPromotedAlbum(userA);
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     await getPromotedAlbum(userB);
-    expect(mockGetTopArtists).toHaveBeenCalledWith(
+    expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+      expect.any(Number),
       "user-b-token",
-      10,
-      "6months"
+      expect.any(Number),
+      expect.any(Number)
     );
   });
 
   it("force refresh re-selects an album without re-running the fan-out", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
     await getPromotedAlbum(userId);
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
     mockGetTopAlbumsByTag.mockClear();
 
     await getPromotedAlbum(userId, true);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
     expect(mockGetTopAlbumsByTag).toHaveBeenCalled();
   });
 
   it("falls back gracefully when Lidarr is unavailable", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockRejectedValue(new Error("Connection refused"));
@@ -364,7 +374,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("treats all as not in library when Lidarr returns ok: false", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: false, status: 500, data: {} });
@@ -376,18 +386,18 @@ describe("getPromotedAlbum", () => {
 
   it("re-selects an album after the result cache expires, without re-fanning-out", async () => {
     vi.useFakeTimers();
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
     await getPromotedAlbum(userId);
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
     mockGetTopAlbumsByTag.mockClear();
 
     vi.advanceTimersByTime(31 * 60 * 1000);
     await getPromotedAlbum(userId);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
     expect(mockGetTopAlbumsByTag).toHaveBeenCalled();
 
     vi.useRealTimers();
@@ -395,17 +405,17 @@ describe("getPromotedAlbum", () => {
 
   it("regenerates the profile after the profile TTL expires", async () => {
     vi.useFakeTimers();
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
     await getPromotedAlbum(userId);
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     vi.advanceTimersByTime((1440 + 1) * 60 * 1000);
     await getPromotedAlbum(userId);
-    expect(mockGetTopArtists).toHaveBeenCalled();
+    expect(mockLoadArtistWeights).toHaveBeenCalled();
 
     vi.useRealTimers();
   });
@@ -416,7 +426,7 @@ describe("getPromotedAlbum", () => {
       ...defaultPromotedAlbumConfig,
       cacheDurationMinutes: 5,
     });
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -432,7 +442,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("deduplicates albums from both pages", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
 
     const duplicatedPage = {
@@ -456,7 +466,7 @@ describe("getPromotedAlbum", () => {
   });
 
   it("returns null when no albums can be converted to release-groups", async () => {
-    mockGetTopArtists.mockResolvedValue(plexArtists);
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);
     mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
     mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -468,7 +478,7 @@ describe("getPromotedAlbum", () => {
 
   describe("anti-repeat", () => {
     it("avoids re-showing the most recent album on refresh", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -482,7 +492,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("persists anti-repeat memory across a simulated restart", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -497,7 +507,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("falls back to the full pool when every album was recently shown", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue({
         albums: [albumsPage.albums[0]],
@@ -515,7 +525,7 @@ describe("getPromotedAlbum", () => {
 
   describe("trace", () => {
     it("has correct number of plexArtists entries", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -529,7 +539,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("marks the picked artists", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -540,7 +550,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("chosenTag name matches result tag", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -550,7 +560,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("albumPool counts are accurate", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -565,7 +575,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("selectionReason is preferred_non_library when artist not in library", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -575,7 +585,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("selectionReason is fallback_in_library when all artists are in library", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockImplementation((path: string) => {
@@ -599,7 +609,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("merges same tags from multiple artists with combined weight", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -615,7 +625,7 @@ describe("getPromotedAlbum", () => {
     });
 
     it("picked artists have tagContributions populated", async () => {
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -630,39 +640,41 @@ describe("getPromotedAlbum", () => {
   });
 
   describe("config-driven behavior", () => {
-    it("uses topArtistsCount from config", async () => {
+    it("derives the play-trend window from playTrendWindowDays", async () => {
       mockGetConfigValue.mockReturnValue({
         ...defaultPromotedAlbumConfig,
-        topArtistsCount: 5,
+        playTrendWindowDays: 30,
       });
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       await getPromotedAlbum(userId);
-      expect(mockGetTopArtists).toHaveBeenCalledWith(
+      expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+        expect.any(Number),
         "test-plex-token",
-        5,
-        "6months"
+        30 * 24 * 60 * 60 * 1000,
+        expect.any(Number)
       );
     });
 
-    it("uses topArtistsRange from config", async () => {
+    it("passes ratingWeight from config to the weight source", async () => {
       mockGetConfigValue.mockReturnValue({
         ...defaultPromotedAlbumConfig,
-        topArtistsRange: "4weeks",
+        ratingWeight: 1.0,
       });
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
 
       await getPromotedAlbum(userId);
-      expect(mockGetTopArtists).toHaveBeenCalledWith(
+      expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+        expect.any(Number),
         "test-plex-token",
-        10,
-        "4weeks"
+        expect.any(Number),
+        1.0
       );
     });
 
@@ -671,7 +683,7 @@ describe("getPromotedAlbum", () => {
         ...defaultPromotedAlbumConfig,
         genericTags: ["alternative"],
       });
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -706,7 +718,7 @@ describe("getPromotedAlbum", () => {
         pagination: { page: 1, totalPages: 1 },
       };
 
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(libraryAlbums);
       mockLidarrGet.mockImplementation((p: string) => {
@@ -730,7 +742,7 @@ describe("getPromotedAlbum", () => {
         ...defaultPromotedAlbumConfig,
         libraryPreference: "no_preference",
       });
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -746,7 +758,7 @@ describe("getPromotedAlbum", () => {
         deepPageMin: 5,
         deepPageMax: 5,
       });
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistTopTags.mockResolvedValue(tags);
       mockGetTopAlbumsByTag.mockResolvedValue(albumsPage);
       mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
@@ -811,7 +823,7 @@ describe("getPromotedAlbum", () => {
 
     function setupExplore() {
       mockGetConfigValue.mockReturnValue(exploreConfig);
-      mockGetTopArtists.mockResolvedValue(plexArtists);
+      mockLoadArtistWeights.mockResolvedValue(plexArtists);
       mockGetArtistMbidByName.mockResolvedValue("mbid-seed");
       mockGetSimilarArtists.mockResolvedValue(similarArtists);
       mockGetArtistTopTags.mockImplementation((name: string) =>

--- a/server/promotedAlbum/profileService.test.ts
+++ b/server/promotedAlbum/profileService.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { PromotedAlbumConfig } from "../config";
 
-const mockGetTopArtists = vi.fn();
+const mockLoadArtistWeights = vi.fn();
 const mockGetArtistTopTags = vi.fn();
 const mockGetConfigValue = vi.fn();
 
-vi.mock("../api/plex/topArtists", () => ({
-  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+vi.mock("./artistWeights", () => ({
+  loadArtistWeights: (...args: unknown[]) => mockLoadArtistWeights(...args),
 }));
 
 vi.mock("../api/lastfm/artists", () => ({
@@ -40,6 +40,8 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 const plexArtists = [
@@ -70,7 +72,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   vi.spyOn(Math, "random").mockReturnValue(0.1);
   mockGetConfigValue.mockReturnValue(baseConfig);
-  mockGetTopArtists.mockResolvedValue(plexArtists);
+  mockLoadArtistWeights.mockResolvedValue(plexArtists);
   mockGetArtistTopTags.mockResolvedValue(tags);
   await initializeDatabase(":memory:");
   userId = await createUser("token");
@@ -134,24 +136,24 @@ describe("regenerateProfile", () => {
 describe("loadFreshProfile", () => {
   it("serves a fresh profile from the DB without re-fanning-out", async () => {
     await regenerateProfile(userId, "token");
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
     mockGetArtistTopTags.mockClear();
 
     const profile = await loadFreshProfile(userId, "token", baseConfig);
     expect(profile!.genreVector).toHaveLength(1);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
     expect(mockGetArtistTopTags).not.toHaveBeenCalled();
   });
 
   it("regenerates when the config hash no longer matches", async () => {
     await regenerateProfile(userId, "token");
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     const changedConfig = { ...baseConfig, tagsPerArtist: 2 };
     mockGetConfigValue.mockReturnValue(changedConfig);
 
     await loadFreshProfile(userId, "token", changedConfig);
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
   });
 
   it("regenerates when the stored schema_version is stale", async () => {
@@ -160,15 +162,15 @@ describe("loadFreshProfile", () => {
       "UPDATE user_profiles SET schema_version = 0 WHERE user_id = ?",
       [userId]
     );
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     await loadFreshProfile(userId, "token", baseConfig);
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
   });
 
   it("in-flight guard prevents concurrent double-regeneration", async () => {
     let resolveTop: (v: unknown) => void = () => {};
-    mockGetTopArtists.mockImplementation(
+    mockLoadArtistWeights.mockImplementation(
       () =>
         new Promise((resolve) => {
           resolveTop = resolve;
@@ -178,10 +180,12 @@ describe("loadFreshProfile", () => {
     const p1 = loadFreshProfile(userId, "token", baseConfig);
     const p2 = loadFreshProfile(userId, "token", baseConfig);
 
-    await vi.waitFor(() => expect(mockGetTopArtists).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1)
+    );
     resolveTop(plexArtists);
     await Promise.all([p1, p2]);
 
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/promotedAlbum/profileService.ts
+++ b/server/promotedAlbum/profileService.ts
@@ -1,4 +1,4 @@
-import { getTopArtists } from "../api/plex/topArtists";
+import { loadArtistWeights } from "./artistWeights";
 import { getArtistTopTags } from "../api/lastfm/artists";
 import { getConfigValue } from "../config";
 import type { PromotedAlbumConfig } from "../config";
@@ -103,15 +103,21 @@ export async function regenerateProfile(
 ): Promise<DerivedProfile | null> {
   const config = getConfigValue("promotedAlbum");
 
-  const plexArtists = await getTopArtists(
+  const windowMs = config.playTrendWindowDays * 24 * 60 * 60 * 1000;
+  const weighted = await loadArtistWeights(
+    userId,
     plexToken,
-    config.topArtistsCount,
-    config.topArtistsRange
+    windowMs,
+    config.ratingWeight
   );
-  if (plexArtists.length === 0) return null;
+  if (weighted.length === 0) return null;
+
+  const topArtists = [...weighted]
+    .sort((a, b) => b.viewCount - a.viewCount)
+    .slice(0, config.topArtistsCount);
 
   const pickedArtists = weightedRandomPick(
-    plexArtists,
+    topArtists,
     (a) => a.viewCount,
     config.pickedArtistsCount
   );

--- a/server/promotedArtists/getPromotedArtists.test.ts
+++ b/server/promotedArtists/getPromotedArtists.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { PromotedAlbumConfig } from "../config";
 
-const mockGetTopArtists = vi.fn();
+const mockLoadArtistWeights = vi.fn();
 const mockGetSimilarArtists = vi.fn();
 const mockEnrichArtistsWithImages = vi.fn();
 const mockLidarrGet = vi.fn();
 const mockGetConfigValue = vi.fn();
 
-vi.mock("../api/plex/topArtists", () => ({
-  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+vi.mock("../promotedAlbum/artistWeights", () => ({
+  loadArtistWeights: (...args: unknown[]) => mockLoadArtistWeights(...args),
 }));
 
 vi.mock("../api/lastfm/artists", () => ({
@@ -71,6 +71,8 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 const TOP_ARTISTS = [
@@ -98,7 +100,7 @@ beforeEach(async () => {
   vi.spyOn(Math, "random").mockReturnValue(0);
 
   mockGetConfigValue.mockReturnValue(baseConfig);
-  mockGetTopArtists.mockResolvedValue(TOP_ARTISTS);
+  mockLoadArtistWeights.mockResolvedValue(TOP_ARTISTS);
   mockGetSimilarArtists.mockImplementation((name: string) =>
     Promise.resolve(SIMILAR[name] ?? [])
   );
@@ -125,17 +127,22 @@ describe("getPromotedArtists", () => {
       "INSERT INTO users (user_type, enabled) VALUES ('local', 1) RETURNING id"
     )) as { id: number }[];
     expect(await getPromotedArtists(rows[0].id)).toBeNull();
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
   });
 
   it("returns null when the user has no top artists", async () => {
-    mockGetTopArtists.mockResolvedValue([]);
+    mockLoadArtistWeights.mockResolvedValue([]);
     expect(await getPromotedArtists(userId)).toBeNull();
   });
 
-  it("uses the listening window config to fetch top artists", async () => {
+  it("loads artist weights from the snapshot series for this user", async () => {
     await getPromotedArtists(userId);
-    expect(mockGetTopArtists).toHaveBeenCalledWith("token", 10, "6months");
+    expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+      userId,
+      "token",
+      90 * 24 * 60 * 60 * 1000,
+      0.5
+    );
   });
 
   it("returns similar artists seeded from the top artists", async () => {
@@ -176,10 +183,10 @@ describe("getPromotedArtists", () => {
   it("caches results per user and recomputes on refresh", async () => {
     await getPromotedArtists(userId);
     await getPromotedArtists(userId);
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
 
     await getPromotedArtists(userId, true);
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(2);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(2);
   });
 
   it("persists anti-repeat memory so a refresh avoids re-showing artists", async () => {

--- a/server/promotedArtists/getPromotedArtists.ts
+++ b/server/promotedArtists/getPromotedArtists.ts
@@ -1,4 +1,4 @@
-import { getTopArtists } from "../api/plex/topArtists";
+import { loadArtistWeights } from "../promotedAlbum/artistWeights";
 import { getSimilarArtists } from "../api/lastfm/artists";
 import { enrichArtistsWithImages } from "../services/lastfm";
 import { lidarrGet } from "../api/lidarr/get";
@@ -116,12 +116,18 @@ export async function getPromotedArtists(
   const plexToken = user?.plexToken;
   if (!plexToken) return null;
 
-  const topArtists = await getTopArtists(
+  const windowMs = config.playTrendWindowDays * 24 * 60 * 60 * 1000;
+  const weighted = await loadArtistWeights(
+    userId,
     plexToken,
-    config.topArtistsCount,
-    config.topArtistsRange
+    windowMs,
+    config.ratingWeight
   );
-  if (topArtists.length === 0) return null;
+  if (weighted.length === 0) return null;
+
+  const topArtists = [...weighted]
+    .sort((a, b) => b.viewCount - a.viewCount)
+    .slice(0, config.topArtistsCount);
 
   const seeds = weightedRandomPick(
     topArtists,

--- a/server/services/profile/regenPoller.test.ts
+++ b/server/services/profile/regenPoller.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { PromotedAlbumConfig } from "../../config";
 
-const mockGetTopArtists = vi.fn();
+const mockLoadArtistWeights = vi.fn();
 const mockGetArtistTopTags = vi.fn();
 const mockGetConfigValue = vi.fn();
 
-vi.mock("../../api/plex/topArtists", () => ({
-  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+vi.mock("../../promotedAlbum/artistWeights", () => ({
+  loadArtistWeights: (...args: unknown[]) => mockLoadArtistWeights(...args),
 }));
 
 vi.mock("../../api/lastfm/artists", () => ({
@@ -44,6 +44,8 @@ const baseConfig: PromotedAlbumConfig = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };
 
 const plexArtists = [
@@ -84,7 +86,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   vi.spyOn(Math, "random").mockReturnValue(0.1);
   mockGetConfigValue.mockReturnValue(baseConfig);
-  mockGetTopArtists.mockResolvedValue(plexArtists);
+  mockLoadArtistWeights.mockResolvedValue(plexArtists);
   mockGetArtistTopTags.mockResolvedValue(tags);
   await initializeDatabase(":memory:");
   now = Date.now();
@@ -109,14 +111,15 @@ describe("runProfileRegenOnce", () => {
     await stampProfile(fresh, now, now);
     await stampProfile(staleDormant, now - 2 * DAY_MS, now - 30 * DAY_MS);
 
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
     await runProfileRegenOnce(now);
 
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
-    expect(mockGetTopArtists).toHaveBeenCalledWith(
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledWith(
+      expect.any(Number),
       "stale-active",
-      10,
-      "6months"
+      90 * 24 * 60 * 60 * 1000,
+      0.5
     );
   });
 
@@ -129,18 +132,18 @@ describe("runProfileRegenOnce", () => {
       ...baseConfig,
       backgroundRegenEnabled: false,
     });
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     await runProfileRegenOnce(now);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
   });
 
   it("skips users without a profile row (never used discovery)", async () => {
     await createUser("no-profile");
-    mockGetTopArtists.mockClear();
+    mockLoadArtistWeights.mockClear();
 
     await runProfileRegenOnce(now);
-    expect(mockGetTopArtists).not.toHaveBeenCalled();
+    expect(mockLoadArtistWeights).not.toHaveBeenCalled();
   });
 
   it("does not double-regenerate when a live request holds the in-flight guard", async () => {
@@ -149,8 +152,8 @@ describe("runProfileRegenOnce", () => {
     await stampProfile(userId, now - 2 * DAY_MS, now);
 
     let resolveTop: (v: unknown) => void = () => {};
-    mockGetTopArtists.mockClear();
-    mockGetTopArtists.mockImplementation(
+    mockLoadArtistWeights.mockClear();
+    mockLoadArtistWeights.mockImplementation(
       () =>
         new Promise((resolve) => {
           resolveTop = resolve;
@@ -158,12 +161,14 @@ describe("runProfileRegenOnce", () => {
     );
 
     const live = loadFreshProfile(userId, "stale-active", baseConfig);
-    await vi.waitFor(() => expect(mockGetTopArtists).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1)
+    );
 
     const tick = runProfileRegenOnce(now);
     resolveTop(plexArtists);
     await Promise.all([live, tick]);
 
-    expect(mockGetTopArtists).toHaveBeenCalledTimes(1);
+    expect(mockLoadArtistWeights).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/services/profile/signalIngestion.test.ts
+++ b/server/services/profile/signalIngestion.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockGetRatedItems = vi.fn();
-const mockGetTopArtists = vi.fn();
+const mockGetAllArtistPlayCounts = vi.fn();
 
 vi.mock("../../api/plex/ratings", () => ({
   getRatedItems: (...args: unknown[]) => mockGetRatedItems(...args),
 }));
-vi.mock("../../api/plex/topArtists", () => ({
-  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+vi.mock("../../api/plex/artistPlayCounts", () => ({
+  getAllArtistPlayCounts: (...args: unknown[]) =>
+    mockGetAllArtistPlayCounts(...args),
 }));
 
 import {
@@ -153,10 +154,10 @@ describe("ingestion (with DB)", () => {
     expect(JSON.parse(events[1].payload).rating).toBe(4);
   });
 
-  it("writes a snapshot of per-artist play counts", async () => {
-    mockGetTopArtists.mockResolvedValue([
-      { name: "Andromedik", viewCount: 120, thumb: "", genres: [] },
-      { name: "Durry", viewCount: 30, thumb: "", genres: [] },
+  it("writes a snapshot of per-artist play counts for all played artists", async () => {
+    mockGetAllArtistPlayCounts.mockResolvedValue([
+      { name: "Andromedik", viewCount: 120 },
+      { name: "Durry", viewCount: 30 },
     ]);
 
     await ingestUserSnapshot(1, "tok");
@@ -168,6 +169,6 @@ describe("ingestion (with DB)", () => {
       { name: "Andromedik", playCount: 120 },
       { name: "Durry", playCount: 30 },
     ]);
-    expect(mockGetTopArtists).toHaveBeenCalledWith("tok", 200, "all");
+    expect(mockGetAllArtistPlayCounts).toHaveBeenCalledWith("tok");
   });
 });

--- a/server/services/profile/signalIngestion.ts
+++ b/server/services/profile/signalIngestion.ts
@@ -1,5 +1,5 @@
 import { getRatedItems } from "../../api/plex/ratings";
-import { getTopArtists } from "../../api/plex/topArtists";
+import { getAllArtistPlayCounts } from "../../api/plex/artistPlayCounts";
 import { appendSignalEvent, getSignalEvents } from "../../db/userProfile";
 import type { UserSignalEvent } from "../../db/entity/UserSignalEvent";
 import type { PlexRatedItem } from "../../api/plex/types";
@@ -18,9 +18,6 @@ export type PlexRatingPayload = {
 export type SnapshotPayload = {
   artists: { name: string; playCount: number }[];
 };
-
-/** How many top artists to back up per snapshot (covers the long tail, not just the top few). */
-const SNAPSHOT_ARTIST_COUNT = 200;
 
 /**
  * Latest known rating per `ratingKey`, replayed from the append-only `plex_rating`
@@ -88,14 +85,15 @@ export async function ingestUserRatings(
 }
 
 /**
- * Append a `snapshot` event capturing the user's all-time per-artist play counts —
- * tunearr's own durable copy of the signal Plex can lose on a history clear / re-import.
+ * Append a `snapshot` event capturing the user's cumulative all-time per-artist play
+ * counts for EVERY played artist (not just the top N) — tunearr's own durable copy of
+ * the signal Plex can lose, and the series the recommender diffs to derive play trends.
  */
 export async function ingestUserSnapshot(
   userId: number,
   plexToken: string
 ): Promise<void> {
-  const artists = await getTopArtists(plexToken, SNAPSHOT_ARTIST_COUNT, "all");
+  const artists = await getAllArtistPlayCounts(plexToken);
   const payload: SnapshotPayload = {
     artists: artists.map((a) => ({ name: a.name, playCount: a.viewCount })),
   };

--- a/server/services/profile/signalPoller.test.ts
+++ b/server/services/profile/signalPoller.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockGetConfigValue = vi.fn();
 const mockGetRatedItems = vi.fn();
-const mockGetTopArtists = vi.fn();
+const mockGetAllArtistPlayCounts = vi.fn();
 
 vi.mock("../../config", () => ({
   getConfigValue: (...args: unknown[]) => mockGetConfigValue(...args),
@@ -10,8 +10,9 @@ vi.mock("../../config", () => ({
 vi.mock("../../api/plex/ratings", () => ({
   getRatedItems: (...args: unknown[]) => mockGetRatedItems(...args),
 }));
-vi.mock("../../api/plex/topArtists", () => ({
-  getTopArtists: (...args: unknown[]) => mockGetTopArtists(...args),
+vi.mock("../../api/plex/artistPlayCounts", () => ({
+  getAllArtistPlayCounts: (...args: unknown[]) =>
+    mockGetAllArtistPlayCounts(...args),
 }));
 
 import { runSignalIngestionOnce } from "./signalPoller";
@@ -41,7 +42,7 @@ beforeEach(async () => {
   await initializeDatabase(":memory:");
   mockGetConfigValue.mockReturnValue({ ratingsBackupEnabled: true });
   mockGetRatedItems.mockResolvedValue([ratedTrack]);
-  mockGetTopArtists.mockResolvedValue([
+  mockGetAllArtistPlayCounts.mockResolvedValue([
     { name: "Andromedik", viewCount: 120, thumb: "", genres: [] },
   ]);
 });

--- a/src/context/promotedAlbumDefaults.ts
+++ b/src/context/promotedAlbumDefaults.ts
@@ -31,4 +31,6 @@ export const DEFAULT_PROMOTED_ALBUM: PromotedAlbumSettings = {
   backgroundRegenIntervalMinutes: 60,
   backgroundRegenActiveWithinMinutes: 10080,
   ratingsBackupEnabled: true,
+  playTrendWindowDays: 90,
+  ratingWeight: 0.5,
 };

--- a/src/context/settingsContextDef.ts
+++ b/src/context/settingsContextDef.ts
@@ -25,6 +25,8 @@ export interface PromotedAlbumSettings {
   backgroundRegenIntervalMinutes: number;
   backgroundRegenActiveWithinMinutes: number;
   ratingsBackupEnabled: boolean;
+  playTrendWindowDays: number;
+  ratingWeight: number;
 }
 
 export interface PurchaseDecisionSettings {

--- a/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/RecommendationsSection.tsx
@@ -56,12 +56,20 @@ function NumberField({
   step = 1,
   description,
 }: NumberFieldProps) {
+  const fieldId = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">
+      <label
+        htmlFor={fieldId}
+        className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-1"
+      >
         {label}
       </label>
       <input
+        id={fieldId}
         type="number"
         value={value}
         onChange={(e) => {
@@ -230,6 +238,25 @@ export default function RecommendationsSection({
         play counts into its own database, so your taste data survives a Plex
         history clear, re-import, or server migration. Single-instance only.
       </p>
+
+      <NumberField
+        label="Play Trend Window (days)"
+        value={config.playTrendWindowDays}
+        onChange={(v) => update("playTrendWindowDays", v)}
+        min={1}
+        max={365}
+        step={1}
+        description="Recommendations weight artists by plays within this many recent days, diffed from tunearr's own daily snapshots. Until the snapshot history is this deep, all-time play counts are used."
+      />
+      <NumberField
+        label="Rating Weight"
+        value={config.ratingWeight}
+        onChange={(v) => update("ratingWeight", v)}
+        min={0}
+        max={3}
+        step={0.1}
+        description="How much your Plex star ratings boost an artist's weight: ×(1 + weight × stars/5). 0 ignores ratings; 0.5 gives a 5-star artist +50% weight."
+      />
 
       <div>
         <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">

--- a/src/pages/SettingsPage/sections/recommendations/__tests__/RecommendationsSection.test.tsx
+++ b/src/pages/SettingsPage/sections/recommendations/__tests__/RecommendationsSection.test.tsx
@@ -22,4 +22,30 @@ describe("RecommendationsSection — ratings backup toggle", () => {
       ratingsBackupEnabled: false,
     });
   });
+
+  it("edits the play trend window and rating weight", () => {
+    const onChange = vi.fn();
+    render(
+      <RecommendationsSection
+        config={DEFAULT_PROMOTED_ALBUM}
+        onConfigChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Play Trend Window/i), {
+      target: { value: "30" },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PROMOTED_ALBUM,
+      playTrendWindowDays: 30,
+    });
+
+    fireEvent.change(screen.getByLabelText(/Rating Weight/i), {
+      target: { value: "1" },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PROMOTED_ALBUM,
+      ratingWeight: 1,
+    });
+  });
 });


### PR DESCRIPTION
Builds on Step 2 (#172, merged in #173). Makes tunearr's own append-only signal series the **canonical input** for the recommender's weighted artist/genre finding — so the plays + ratings we collect actually drive the algorithm instead of sitting as dead backup. Plex becomes the ingestion feed, not the live query source.

This evolves the RFC's original "Plex is source of truth" stance; see `docs/user-profile-stabilization-rfc.md` for context.

## What changed

**Plays — windowed trend from our snapshot series, not live Plex.**
`loadArtistWeights` derives a per-artist play weight by diffing daily `kind="snapshot"` rows over a configurable window (`playTrendWindowDays`, default 90): `plays_in_window = viewCount_now − viewCount_(now−window)`. This gives an arbitrary, self-owned trend window that Plex's fixed ranges (4w/6m/12m/all) can't express, and lets rising artists surface. Daily granularity is plenty for taste drift.

**Ratings — wired into the weights.**
Each artist's play weight is multiplied by `1 + ratingWeight × (avgStars/5)` (`ratingWeight` config, default 0.5; 0 disables). Ratings come from the `kind="plex_rating"` series. A 5-star artist gets +50% weight at the default.

**Snapshots now cover every played artist.**
`getAllArtistPlayCounts` paginates *all* `type=8` artists (was top 200). A background job on a local PMS has no rate limit, and a recently-surging artist can sit low in the all-time ranking — capping at 200 would hide exactly the artists trend-detection wants.

**Cold-start / thin-history fallbacks (no parallel live path):**
- Until the series spans the window → use the latest snapshot's all-time counts.
- Nothing played in the window → fall back to all-time (never an empty weight set).
- User has **zero** snapshots → ingest one on demand (a live Plex read we persist), then read it. Every read still goes through `user_signal_events`.

**Wiring:** `regenerateProfile` and `getPromotedArtists` seeds now source from `loadArtistWeights`. **Explore mode stays on live ranged `getTopArtists`** — it's the break-out-of-taste path with different intent. `topArtistsRange` remains for explore; the profile path uses the trend window instead.

**Config:** `playTrendWindowDays` + `ratingWeight` added — validated, included in `config_hash` (so changing them invalidates + regenerates the profile), and exposed on the recommendations settings page. `NumberField` labels are now linked to their inputs (a11y).

## Tests
- New: `artistPlayCounts` (pagination, early-stop, drop-unplayed), `artistWeights` (windowed delta, all-time fallback, rating aggregation/multiplier, cold-start on-demand ingest, no-fetch read path).
- Updated: profile/promoted-album/promoted-artists/regen-poller suites now drive the snapshot-sourced path; config validation; FE settings fields.
- Full suites green (972 server, 782 frontend), typecheck + lint clean.

## Note / possible follow-up
- The "How this was recommended" trace's per-artist `viewCount` now reflects the **effective weight** (windowed plays × rating boost), not raw all-time plays. Internally consistent; the trace label could be clarified later.
- Ratings currently *amplify* artists that also have plays (multiplier). Surfacing a highly-rated-but-barely-played artist would need additive/candidate-injection — deliberately out of scope here.

Refs #172, #144.
