### PR TITLE
feat: delta-encode plays + detect un-ratings (#144)

### DIFF
--- a/docs/user-profile-stabilization-rfc.md
+++ b/docs/user-profile-stabilization-rfc.md
@@ -2,7 +2,7 @@
 
 Status: Steps 1 & 2 implemented; similar-graph persisted. Step 3 (taste page) split out to
 the standalone exploratory [#176](https://github.com/BlieNuckel/tunearr/issues/176); Step 4
-(export/restore) discarded. Remaining under #144: snapshot retention/compaction.
+(export/restore) discarded. Snapshot retention resolved via delta-encoding + un-rating detection.
 Tracking issue: [#144](https://github.com/BlieNuckel/tunearr/issues/144)
 Step 1 issues: [#166](https://github.com/BlieNuckel/tunearr/issues/166) (#167 entities, #168 recommender, #169 scheduler)
 Step 2 issue: [#172](https://github.com/BlieNuckel/tunearr/issues/172)
@@ -261,8 +261,11 @@ The in-memory `userCache`/`recentlyShownByUser` maps fold into `UserProfile`.
    concern and stays a single global setting owned by whoever runs the server.
 3. **Ratings ingestion** — ~~confirm Plex exposes `userRating` per track/album via the existing
    per-user token path; volume/perf of pulling it.~~ **Resolved (June 2026) — yes; see below.**
-4. **Multi-user** — snapshots are per-user; confirm storage growth is acceptable for many users.
-5. **Privacy / retention** — more per-user data on disk; deletion-on-user-removal must cascade.
+4. **Storage growth / retention** — `plex_plays` is the dominant growth driver; bound it without
+   losing fidelity. ~~On a timer; how many to retain / how to compact?~~ **Resolved (June 2026)
+   — delta-encode plays + detect un-ratings; see below.**
+5. **Privacy / retention** — more per-user data on disk; deletion-on-user-removal must cascade
+   (handled: `UserSignalEvent` cascade-deletes with the owning user).
 
 ### Resolved: ratings ingestion (open question 3)
 
@@ -305,6 +308,41 @@ Two caveats to handle during Step 2, neither blocking:
   server-side keyed to the account, so the metadata query returns them regardless. Don't
   assume ratings made on _other_ servers are present.
 
+### Resolved: storage growth / retention (open question 4)
+
+**Verdict: delta-encode plays + detect un-ratings.** The earlier worry was that a daily,
+all-artist, per-user `plex_plays` snapshot grows ~linearly (~9 KB/row → ~3.3 MB/user/year).
+The fix follows from the data's own shape — and is consistent with framing plays and ratings as
+two different kinds of signal. Implemented June 2026 (`signalIngestion.ts`, `artistWeights.ts`,
+`api/plex/ratings.ts`).
+
+- **Plays are accumulated facts; ratings are revocable opinions.** A cumulative play count only
+  ever rises under normal use (you can't un-listen); a decrease or a vanished artist means Plex
+  lost data (history clear, re-import) — exactly what this backup exists to survive. A star, by
+  contrast, can be un-starred. The two get different handling rules.
+- **Plays → monotonic-max delta log.** Each `plex_plays` event now carries only the artists
+  whose cumulative count _increased_ since the last capture; an unchanged day writes nothing.
+  Full state is reconstructed by folding the series last-write-wins (`reconstructPlayCounts`),
+  carrying unchanged artists forward. Stored value = `max(everything seen)`: decreases /
+  disappearances / a transient-empty read are never recorded, which protects the backup against
+  a Plex clear **and** removes the mass-clear ambiguity for free. Expected ~95% reduction
+  (steady state ~1–1.5 MB/user; ~1.5 GB at 1000 users), full daily resolution retained, trend
+  diffing unchanged (it just reconstructs both endpoints from the fold). No migration — old full
+  rows fold correctly as baselines.
+- **Ratings → change log incl. un-stars.** Because the rated read uses a server-side
+  `userRating>=1` filter, an un-starred item simply drops out — indistinguishable from a
+  truncated/glitchy fetch. `detectUnratings` finds previously-rated keys absent from the current
+  set; each candidate is **confirmed** against live Plex (`getItemRating` →
+  `/library/metadata/{key}`) before a `rating: 0` clear is appended. Guards: skip on an empty
+  response, and a candidate cap (`UNRATE_CANDIDATE_CAP = 50`) that skips + logs an implausible
+  mass disappearance (a data event, not user action). `aggregateArtistRatings` excludes
+  `rating <= 0` so a cleared star stops contributing.
+- **Deferred (not needed yet):** periodic full **checkpoints** + pruning of pre-checkpoint
+  deltas. The reconstruction fold is O(total deltas) — a few thousand tiny entries even after
+  years on a home server, and run only during background regen — so this buys nothing for
+  correctness or perf today. It is the natural next step if a very long-lived install ever makes
+  the fold or pre-checkpoint history worth bounding.
+
 ## Out of scope
 
 - Any Plex write-back.
@@ -339,6 +377,7 @@ Discussion now moves to what comes after, in roughly dependency order:
 - **Step 4 — export/restore. Discarded.** No driver; user-facing portability was always out
   of scope (see Out of scope). Not tracked anywhere; revisit only if a concrete need appears.
 
-Open questions 1 (cadence) and 3 (ratings exposure) are resolved; 2 (per-user TTL override)
-is closed as won't-do. The only open decision left under #144 is question 4 (snapshot
-retention/compaction).
+Open questions 1 (cadence), 3 (ratings exposure) and 4 (storage growth / retention) are
+resolved; 2 (per-user TTL override) is closed as won't-do. Question 4's only remaining piece —
+checkpoint + prune — is deferred as not-yet-needed (see "Resolved: storage growth / retention").
+With that, every open question under #144 is settled.

--- a/server/api/plex/ratings.test.ts
+++ b/server/api/plex/ratings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getRatedItems } from "./ratings";
+import { getRatedItems, getItemRating } from "./ratings";
 
 vi.mock("./config", () => ({
   getPlexConfig: vi.fn(() => ({
@@ -167,6 +167,41 @@ describe("getRatedItems", () => {
 
     await expect(getRatedItems("tok", [9])).rejects.toThrow(
       "Plex returned 401"
+    );
+  });
+});
+
+describe("getItemRating", () => {
+  it("returns the rating when present", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse({ MediaContainer: { Metadata: [{ userRating: 6 }] } })
+    );
+
+    expect(await getItemRating("tok", "451")).toBe(6);
+    expect(mockFetch.mock.calls[0][0]).toContain("/library/metadata/451");
+  });
+
+  it("returns null when the item has no userRating", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse({ MediaContainer: { Metadata: [{ title: "Unrated" }] } })
+    );
+
+    expect(await getItemRating("tok", "451")).toBeNull();
+  });
+
+  it("returns null when the item is missing", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse({ MediaContainer: { Metadata: [] } })
+    );
+
+    expect(await getItemRating("tok", "451")).toBeNull();
+  });
+
+  it("throws on a Plex API error", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(getItemRating("tok", "451")).rejects.toThrow(
+      "Plex returned 404"
     );
   });
 });

--- a/server/api/plex/ratings.ts
+++ b/server/api/plex/ratings.ts
@@ -104,3 +104,24 @@ export async function getRatedItems(
   );
   return perType.flat();
 }
+
+/**
+ * The current user's rating for a single item, or `null` when it carries no `userRating`
+ * (unrated). Reads `/library/metadata/{ratingKey}` directly — no section scan — and is used
+ * to confirm an apparent un-rating before recording it, so an item merely filtered out of
+ * the rated set (or a transient glitch) is never mistaken for a deliberate un-star.
+ */
+export async function getItemRating(
+  plexToken: string,
+  ratingKey: string
+): Promise<number | null> {
+  const { baseUrl, headers } = getPlexConfig(plexToken);
+  const res = await resilientFetch(`${baseUrl}/library/metadata/${ratingKey}`, {
+    headers,
+  });
+  if (!res.ok) throw new Error(`Plex returned ${res.status}`);
+
+  const data: PlexRatedItemsResponse = await res.json();
+  const meta = data.MediaContainer?.Metadata?.[0];
+  return typeof meta?.userRating === "number" ? meta.userRating : null;
+}

--- a/server/promotedAlbum/artistWeights.test.ts
+++ b/server/promotedAlbum/artistWeights.test.ts
@@ -93,7 +93,42 @@ describe("derivePlayWeights", () => {
   it("returns empty for no plays captures", () => {
     expect(derivePlayWeights([], NOW, 30 * DAY)).toEqual([]);
   });
+
+  it("reconstructs latest and baseline across delta rows", () => {
+    const playEvents = [
+      playsEvent(
+        [
+          { name: "A", playCount: 10 },
+          { name: "B", playCount: 5 },
+        ],
+        40
+      ),
+      playsEvent([{ name: "A", playCount: 30 }], 0),
+    ];
+    const result = derivePlayWeights(playEvents, NOW, 30 * DAY);
+    expect(result).toEqual([{ name: "A", viewCount: 20 }]);
+  });
 });
+
+function clearedRatingEvent(
+  ratingKey: string,
+  artist: string,
+  rating: number
+): UserSignalEvent {
+  return {
+    id: 0,
+    user_id: 1,
+    kind: "plex_rating",
+    payload: JSON.stringify({
+      ratingKey,
+      kind: "track",
+      title: "t",
+      artist,
+      rating,
+    }),
+    recorded_at: "2026-01-01T00:00:00.000Z",
+  } as UserSignalEvent;
+}
 
 describe("aggregateArtistRatings", () => {
   it("averages ratings per artist from the latest per item", () => {
@@ -103,6 +138,16 @@ describe("aggregateArtistRatings", () => {
       ratingEvent("B", 8),
     ]);
     expect(ratings.get("A")).toBe(8);
+    expect(ratings.get("B")).toBe(8);
+  });
+
+  it("excludes items whose latest rating is 0 (un-rated)", () => {
+    const ratings = aggregateArtistRatings([
+      clearedRatingEvent("a1", "A", 10),
+      clearedRatingEvent("a1", "A", 0),
+      clearedRatingEvent("b1", "B", 8),
+    ]);
+    expect(ratings.has("A")).toBe(false);
     expect(ratings.get("B")).toBe(8);
   });
 });

--- a/server/promotedAlbum/artistWeights.ts
+++ b/server/promotedAlbum/artistWeights.ts
@@ -2,7 +2,7 @@ import { getSignalEvents } from "../db/userProfile";
 import {
   ingestUserPlays,
   latestRatings,
-  type PlexPlaysPayload,
+  reconstructPlayCounts,
 } from "../services/profile/signalIngestion";
 import type { UserSignalEvent } from "../db/entity/UserSignalEvent";
 
@@ -12,41 +12,16 @@ export type ArtistWeight = {
   viewCount: number;
 };
 
-function parsePlayCounts(event: UserSignalEvent): Map<string, number> {
-  const counts = new Map<string, number>();
-  try {
-    const payload = JSON.parse(event.payload) as PlexPlaysPayload;
-    for (const artist of payload.artists ?? []) {
-      counts.set(artist.name, artist.playCount);
-    }
-  } catch {
-    return counts;
-  }
-  return counts;
-}
-
-/** Most recent plays capture recorded at or before the window start, or null if the series is younger. */
-function findBaseline(
-  playEvents: UserSignalEvent[],
-  windowStart: number
-): UserSignalEvent | null {
-  for (let i = playEvents.length - 1; i >= 0; i--) {
-    if (Date.parse(playEvents[i].recorded_at) <= windowStart)
-      return playEvents[i];
-  }
-  return null;
-}
-
 function allTimeWeights(latest: Map<string, number>): ArtistWeight[] {
   return Array.from(latest, ([name, viewCount]) => ({ name, viewCount }));
 }
 
 /**
- * Per-artist play weight derived from the plays series. When the series spans the
- * full window, weight = plays within the window (latest cumulative count minus the count
- * at the window start). Until the series is that deep — or when nothing was played in the
- * window — weight falls back to the latest cumulative all-time count, so the set is never
- * empty and a thin history still produces sensible weights.
+ * Per-artist play weight derived from the plays delta series. When the series spans the
+ * full window, weight = plays within the window (cumulative count now minus the count
+ * reconstructed at the window start). Until the series is that deep — or when nothing was
+ * played in the window — weight falls back to the latest cumulative all-time count, so the
+ * set is never empty and a thin history still produces sensible weights.
  */
 export function derivePlayWeights(
   playEvents: UserSignalEvent[],
@@ -54,12 +29,14 @@ export function derivePlayWeights(
   windowMs: number
 ): ArtistWeight[] {
   if (playEvents.length === 0) return [];
-  const latest = parsePlayCounts(playEvents[playEvents.length - 1]);
+  const latest = reconstructPlayCounts(playEvents, Infinity);
 
-  const baselineEvent = findBaseline(playEvents, now - windowMs);
-  if (!baselineEvent) return allTimeWeights(latest);
+  const windowStart = now - windowMs;
+  if (Date.parse(playEvents[0].recorded_at) > windowStart) {
+    return allTimeWeights(latest);
+  }
 
-  const baseline = parsePlayCounts(baselineEvent);
+  const baseline = reconstructPlayCounts(playEvents, windowStart);
   const windowed: ArtistWeight[] = [];
   let total = 0;
   for (const [name, count] of latest) {
@@ -70,13 +47,17 @@ export function derivePlayWeights(
   return total > 0 ? windowed : allTimeWeights(latest);
 }
 
-/** Average rating (0–10) per artist, from the latest rating known for each rated item. */
+/**
+ * Average rating (0–10) per artist, from the latest rating known for each rated item.
+ * Items whose latest rating is `0` (un-rated) are excluded so a cleared star doesn't
+ * drag an artist's average down.
+ */
 export function aggregateArtistRatings(
   ratingEvents: UserSignalEvent[]
 ): Map<string, number> {
   const totals = new Map<string, { sum: number; count: number }>();
   for (const payload of latestRatings(ratingEvents).values()) {
-    if (!payload.artist) continue;
+    if (!payload.artist || payload.rating <= 0) continue;
     const entry = totals.get(payload.artist) ?? { sum: 0, count: 0 };
     entry.sum += payload.rating;
     entry.count += 1;

--- a/server/services/profile/signalIngestion.test.ts
+++ b/server/services/profile/signalIngestion.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockGetRatedItems = vi.fn();
+const mockGetItemRating = vi.fn();
 const mockGetAllArtistPlayCounts = vi.fn();
 
 vi.mock("../../api/plex/ratings", () => ({
   getRatedItems: (...args: unknown[]) => mockGetRatedItems(...args),
+  getItemRating: (...args: unknown[]) => mockGetItemRating(...args),
 }));
 vi.mock("../../api/plex/artistPlayCounts", () => ({
   getAllArtistPlayCounts: (...args: unknown[]) =>
@@ -14,7 +16,9 @@ vi.mock("../../api/plex/artistPlayCounts", () => ({
 import {
   latestRatings,
   diffRatings,
+  detectUnratings,
   playsDue,
+  reconstructPlayCounts,
   ingestUserRatings,
   ingestUserPlays,
   type PlexRatingPayload,
@@ -43,6 +47,14 @@ const ratedTrack = {
   title: "Air",
   artist: "Andromedik",
   rating: 10,
+};
+
+const ratedAlbum = {
+  ratingKey: "999",
+  kind: "album" as const,
+  title: "Reflections",
+  artist: "Durry",
+  rating: 8,
 };
 
 describe("latestRatings", () => {
@@ -97,6 +109,80 @@ describe("diffRatings", () => {
       ["451", { ...ratedTrack, rating: 10 }],
     ]);
     expect(diffRatings(previous, [])).toEqual([]);
+  });
+});
+
+function playsEvent(
+  artists: { name: string; playCount: number }[],
+  recordedAt: string
+): UserSignalEvent {
+  return {
+    id: 0,
+    user_id: 1,
+    kind: "plex_plays",
+    payload: JSON.stringify({ artists }),
+    recorded_at: recordedAt,
+  } as UserSignalEvent;
+}
+
+describe("reconstructPlayCounts", () => {
+  it("folds deltas last-write-wins and carries unchanged artists forward", () => {
+    const events = [
+      playsEvent(
+        [
+          { name: "A", playCount: 10 },
+          { name: "B", playCount: 5 },
+        ],
+        "2026-01-01T00:00:00.000Z"
+      ),
+      playsEvent([{ name: "A", playCount: 30 }], "2026-02-01T00:00:00.000Z"),
+    ];
+    const counts = reconstructPlayCounts(events, Infinity);
+    expect(counts.get("A")).toBe(30);
+    expect(counts.get("B")).toBe(5);
+  });
+
+  it("ignores events recorded after the cutoff", () => {
+    const events = [
+      playsEvent([{ name: "A", playCount: 10 }], "2026-01-01T00:00:00.000Z"),
+      playsEvent([{ name: "A", playCount: 30 }], "2026-03-01T00:00:00.000Z"),
+    ];
+    const counts = reconstructPlayCounts(
+      events,
+      Date.parse("2026-02-01T00:00:00.000Z")
+    );
+    expect(counts.get("A")).toBe(10);
+  });
+
+  it("skips corrupt rows", () => {
+    const events = [
+      { ...playsEvent([], "2026-01-01T00:00:00.000Z"), payload: "not json" },
+      playsEvent([{ name: "A", playCount: 7 }], "2026-02-01T00:00:00.000Z"),
+    ];
+    const counts = reconstructPlayCounts(events as UserSignalEvent[], Infinity);
+    expect(counts.get("A")).toBe(7);
+    expect(counts.size).toBe(1);
+  });
+});
+
+describe("detectUnratings", () => {
+  it("finds previously-rated keys absent from the current set", () => {
+    const previous = new Map<string, PlexRatingPayload>([
+      ["451", { ...ratedTrack, rating: 10 }],
+      [
+        "999",
+        { ratingKey: "999", kind: "album", title: "X", artist: "Y", rating: 4 },
+      ],
+    ]);
+    const current = [{ ...ratedTrack, rating: 10 }];
+    expect(detectUnratings(previous, current)).toEqual(["999"]);
+  });
+
+  it("ignores keys already cleared (rating 0)", () => {
+    const previous = new Map<string, PlexRatingPayload>([
+      ["451", { ...ratedTrack, rating: 0 }],
+    ]);
+    expect(detectUnratings(previous, [])).toEqual([]);
   });
 });
 
@@ -170,5 +256,124 @@ describe("ingestion (with DB)", () => {
       { name: "Durry", playCount: 30 },
     ]);
     expect(mockGetAllArtistPlayCounts).toHaveBeenCalledWith("tok");
+  });
+
+  it("writes a delta of only the artists whose count increased", async () => {
+    mockGetAllArtistPlayCounts.mockReset();
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([
+      { name: "A", viewCount: 10 },
+      { name: "B", viewCount: 5 },
+    ]);
+    await ingestUserPlays(1, "tok");
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([
+      { name: "A", viewCount: 30 },
+      { name: "B", viewCount: 5 },
+    ]);
+    await ingestUserPlays(1, "tok");
+
+    const events = await getSignalEvents(1, "plex_plays");
+    expect(events).toHaveLength(2);
+    expect((JSON.parse(events[1].payload) as PlexPlaysPayload).artists).toEqual(
+      [{ name: "A", playCount: 30 }]
+    );
+  });
+
+  it("writes nothing when no count increased", async () => {
+    mockGetAllArtistPlayCounts.mockReset();
+    mockGetAllArtistPlayCounts.mockResolvedValue([
+      { name: "A", viewCount: 10 },
+    ]);
+
+    await ingestUserPlays(1, "tok");
+    await ingestUserPlays(1, "tok");
+
+    expect(await getSignalEvents(1, "plex_plays")).toHaveLength(1);
+  });
+
+  it("never records a decrease or a vanished artist (monotonic)", async () => {
+    mockGetAllArtistPlayCounts.mockReset();
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([
+      { name: "A", viewCount: 10 },
+      { name: "B", viewCount: 5 },
+    ]);
+    await ingestUserPlays(1, "tok");
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([
+      { name: "A", viewCount: 8 },
+    ]);
+    await ingestUserPlays(1, "tok");
+
+    expect(await getSignalEvents(1, "plex_plays")).toHaveLength(1);
+  });
+
+  it("treats a transient-empty read as a no-op", async () => {
+    mockGetAllArtistPlayCounts.mockReset();
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([
+      { name: "A", viewCount: 10 },
+    ]);
+    await ingestUserPlays(1, "tok");
+    mockGetAllArtistPlayCounts.mockResolvedValueOnce([]);
+    await ingestUserPlays(1, "tok");
+
+    expect(await getSignalEvents(1, "plex_plays")).toHaveLength(1);
+  });
+
+  it("records a confirmed un-rating as a rating-0 event", async () => {
+    mockGetRatedItems.mockReset();
+    mockGetItemRating.mockReset();
+    mockGetRatedItems.mockResolvedValueOnce([ratedTrack, ratedAlbum]);
+    await ingestUserRatings(1, "tok");
+    mockGetRatedItems.mockResolvedValueOnce([ratedAlbum]);
+    mockGetItemRating.mockResolvedValueOnce(null);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(1);
+
+    const events = await getSignalEvents(1, "plex_rating");
+    expect(events).toHaveLength(3);
+    const last = JSON.parse(events[2].payload) as PlexRatingPayload;
+    expect(last).toMatchObject({ ratingKey: "451", rating: 0 });
+    expect(mockGetItemRating).toHaveBeenCalledWith("tok", "451");
+  });
+
+  it("does not record an un-rating when Plex still reports a rating", async () => {
+    mockGetRatedItems.mockReset();
+    mockGetItemRating.mockReset();
+    mockGetRatedItems.mockResolvedValueOnce([ratedTrack, ratedAlbum]);
+    await ingestUserRatings(1, "tok");
+    mockGetRatedItems.mockResolvedValueOnce([ratedAlbum]);
+    mockGetItemRating.mockResolvedValueOnce(10);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(0);
+    expect(await getSignalEvents(1, "plex_rating")).toHaveLength(2);
+  });
+
+  it("skips un-rating detection when an implausible number disappear", async () => {
+    mockGetRatedItems.mockReset();
+    mockGetItemRating.mockReset();
+    const many = Array.from({ length: 52 }, (_, i) => ({
+      ratingKey: `k${i}`,
+      kind: "track" as const,
+      title: `t${i}`,
+      artist: "Z",
+      rating: 8,
+    }));
+    mockGetRatedItems.mockResolvedValueOnce(many);
+    await ingestUserRatings(1, "tok");
+    mockGetRatedItems.mockResolvedValueOnce([many[0]]);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(0);
+    expect(await getSignalEvents(1, "plex_rating")).toHaveLength(52);
+    expect(mockGetItemRating).not.toHaveBeenCalled();
+  });
+
+  it("does not detect un-ratings from an empty response", async () => {
+    mockGetRatedItems.mockReset();
+    mockGetItemRating.mockReset();
+    mockGetRatedItems.mockResolvedValueOnce([ratedTrack]);
+    await ingestUserRatings(1, "tok");
+    mockGetRatedItems.mockResolvedValueOnce([]);
+
+    expect(await ingestUserRatings(1, "tok")).toBe(0);
+    expect(await getSignalEvents(1, "plex_rating")).toHaveLength(1);
+    expect(mockGetItemRating).not.toHaveBeenCalled();
   });
 });

--- a/server/services/profile/signalIngestion.ts
+++ b/server/services/profile/signalIngestion.ts
@@ -1,6 +1,7 @@
-import { getRatedItems } from "../../api/plex/ratings";
+import { getRatedItems, getItemRating } from "../../api/plex/ratings";
 import { getAllArtistPlayCounts } from "../../api/plex/artistPlayCounts";
 import { appendSignalEvent, getSignalEvents } from "../../db/userProfile";
+import { createLogger } from "../../logger";
 import type { UserSignalEvent } from "../../db/entity/UserSignalEvent";
 import type { PlexRatedItem } from "../../api/plex/types";
 
@@ -10,14 +11,27 @@ export type PlexRatingPayload = {
   kind: PlexRatedItem["kind"];
   title: string;
   artist: string;
-  /** Plex scale 0–10. */
+  /** Plex scale 0–10; `0` is the sentinel for an un-rated (un-starred) item. */
   rating: number;
 };
 
-/** Payload of a `kind = "plex_plays"` event — per-artist play counts at one instant. */
+/**
+ * Payload of a `kind = "plex_plays"` event. Each event is a delta: only the artists
+ * whose cumulative play count *increased* since the previous capture. Reconstruct a
+ * full state by folding the series (see {@link reconstructPlayCounts}).
+ */
 export type PlexPlaysPayload = {
   artists: { name: string; playCount: number }[];
 };
+
+const log = createLogger("signal-ingestion");
+
+/**
+ * Upper bound on per-sweep un-rating candidates. Beyond this, a mass disappearance is
+ * far more likely a Plex data event (history clear, library re-import) than a user
+ * deliberately un-starring; we skip rather than corrupt the backup with bogus clears.
+ */
+const UNRATE_CANDIDATE_CAP = 50;
 
 /**
  * Latest known rating per `ratingKey`, replayed from the append-only `plex_rating`
@@ -42,10 +56,10 @@ export function latestRatings(
 
 /**
  * Change events for the current rated set vs. the latest known ratings: a row for
- * each new or changed rating. Un-rating (an item dropping out of the rated set) is
- * deliberately NOT recorded — a transient empty/200 response would otherwise emit
- * mass "cleared" events and corrupt the backup. Cleared ratings can be handled
- * later behind a non-empty-response guard.
+ * each new or changed rating. Items dropping out of the rated set (un-ratings) are
+ * handled separately by {@link detectUnratings} + {@link recordUnratings}, which
+ * confirm each disappearance against live Plex before recording a clear — so a
+ * transient empty/filtered response can't emit mass bogus clears.
  */
 export function diffRatings(
   previous: Map<string, PlexRatingPayload>,
@@ -68,8 +82,58 @@ export function diffRatings(
 }
 
 /**
- * Read the user's current Plex ratings and append a `plex_rating` event for each
- * one that is new or changed since the last ingestion. Returns the number written.
+ * Rated items that have disappeared from the current set: keys we last knew as rated
+ * (`rating > 0`) and that the current read no longer returns. These are *candidate*
+ * un-ratings — each must still be confirmed against live Plex before being recorded.
+ */
+export function detectUnratings(
+  previous: Map<string, PlexRatingPayload>,
+  current: PlexRatedItem[]
+): string[] {
+  const currentKeys = new Set(current.map((item) => item.ratingKey));
+  const candidates: string[] = [];
+  for (const [ratingKey, payload] of previous) {
+    if (payload.rating > 0 && !currentKeys.has(ratingKey)) {
+      candidates.push(ratingKey);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Confirm each candidate un-rating against live Plex and append a `rating = 0` clear
+ * for the genuinely-unrated ones. A per-item read guards against the `userRating>=1`
+ * filter quirk (an un-starred item simply vanishes, indistinguishable from a glitch);
+ * a failed confirm skips that candidate rather than recording a false clear.
+ */
+async function recordUnratings(
+  userId: number,
+  plexToken: string,
+  previous: Map<string, PlexRatingPayload>,
+  candidates: string[]
+): Promise<number> {
+  let written = 0;
+  for (const ratingKey of candidates) {
+    let liveRating: number | null;
+    try {
+      liveRating = await getItemRating(plexToken, ratingKey);
+    } catch {
+      continue;
+    }
+    if (liveRating !== null && liveRating > 0) continue;
+    const prior = previous.get(ratingKey);
+    if (!prior) continue;
+    await appendSignalEvent(userId, "plex_rating", { ...prior, rating: 0 });
+    written += 1;
+  }
+  return written;
+}
+
+/**
+ * Read the user's current Plex ratings and append a `plex_rating` event for each one
+ * that is new, changed, or newly un-rated since the last ingestion. Un-ratings are
+ * confirmed per-item and skipped wholesale when an implausible number disappear at
+ * once (a Plex data event, not user action). Returns the number of events written.
  */
 export async function ingestUserRatings(
   userId: number,
@@ -81,21 +145,69 @@ export async function ingestUserRatings(
   for (const change of changes) {
     await appendSignalEvent(userId, "plex_rating", change);
   }
-  return changes.length;
+
+  let removals = 0;
+  if (current.length > 0) {
+    const candidates = detectUnratings(previous, current);
+    if (candidates.length > UNRATE_CANDIDATE_CAP) {
+      log.warn(
+        `Skipping ${candidates.length} un-rating candidate(s) for user ${userId} — ` +
+          "exceeds cap, likely a Plex data event rather than user action"
+      );
+    } else {
+      removals = await recordUnratings(userId, plexToken, previous, candidates);
+    }
+  }
+  return changes.length + removals;
 }
 
 /**
- * Append a `plex_plays` event capturing the user's cumulative all-time per-artist play
- * counts for EVERY played artist (not just the top N) — tunearr's own durable copy of
- * the signal Plex can lose, and the series the recommender diffs to derive play trends.
+ * Cumulative per-artist play count reconstructed from the delta series, considering only
+ * events recorded at or before `cutoffMs`. Folds last-write-wins per artist; unchanged
+ * artists are absent from later deltas and carry their prior value forward. Events arrive
+ * oldest-first, so we stop as soon as one is past the cutoff.
+ */
+export function reconstructPlayCounts(
+  events: UserSignalEvent[],
+  cutoffMs: number
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    if (Date.parse(event.recorded_at) > cutoffMs) break;
+    try {
+      const payload = JSON.parse(event.payload) as PlexPlaysPayload;
+      for (const artist of payload.artists ?? []) {
+        counts.set(artist.name, artist.playCount);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Append a `plex_plays` delta capturing only the artists whose cumulative play count
+ * *increased* since the last capture — tunearr's own durable copy of the signal Plex can
+ * lose, and the series the recommender diffs to derive play trends. Counts are treated as
+ * monotonic: a decrease or a vanished artist (Plex history clear / re-import) is never
+ * recorded, so the stored value is the max ever seen and a transient-empty read is a no-op.
+ * When nothing increased, no event is written.
  */
 export async function ingestUserPlays(
   userId: number,
   plexToken: string
 ): Promise<void> {
-  const artists = await getAllArtistPlayCounts(plexToken);
+  const live = await getAllArtistPlayCounts(plexToken);
+  const stored = reconstructPlayCounts(
+    await getSignalEvents(userId, "plex_plays"),
+    Infinity
+  );
+  const changed = live.filter((a) => a.viewCount > (stored.get(a.name) ?? 0));
+  if (changed.length === 0) return;
+
   const payload: PlexPlaysPayload = {
-    artists: artists.map((a) => ({ name: a.name, playCount: a.viewCount })),
+    artists: changed.map((a) => ({ name: a.name, playCount: a.viewCount })),
   };
   await appendSignalEvent(userId, "plex_plays", payload);
 }


### PR DESCRIPTION
Resolves RFC open question 4 (snapshot retention/compaction). Bounds the dominant storage cost in `user_signal_events` without losing fidelity, and ingests the one rating change that was previously dropped.

## Plays → monotonic-max delta log
- Each `plex_plays` event now carries **only** the artists whose cumulative count increased since the last capture; an unchanged day writes nothing.
- Full state is reconstructed by folding the series (`reconstructPlayCounts`), carrying unchanged artists forward.
- Counts are treated as monotonic: a **decrease, a vanished artist, or a transient-empty read is never recorded**. This protects the backup against a Plex history clear (the data this backup exists to survive) and removes the mass-clear ambiguity for free.
- Expected **~95% storage reduction**, full daily resolution retained, trend diffing unchanged. **No migration** — old full rows fold correctly as baselines.

## Ratings → change log incl. un-stars
- The `userRating>=1` filter makes an un-starred item simply drop out, indistinguishable from a truncated fetch. `detectUnratings` finds the dropped keys; each is **confirmed against live Plex** (`getItemRating` → `/library/metadata/{key}`) before a `rating: 0` clear is appended.
- Guards: skip on an empty response, and a candidate cap (`UNRATE_CANDIDATE_CAP = 50`) that skips + logs an implausible mass disappearance (a Plex data event, not user action).
- `aggregateArtistRatings` excludes `rating <= 0` so a cleared star stops contributing.

## Rationale
Plays are accumulated facts (can only be lost, not revoked); ratings are revocable opinions. The two get different handling rules, which is what makes the delta encoding both correct and cheap.

## Deferred
Periodic full **checkpoints** + pruning of pre-checkpoint deltas — the reconstruction fold is O(total deltas), a few thousand tiny entries even after years on a home server, run only during background regen, so it buys nothing yet.

## Tests
Server suite green (1002) incl. new coverage for `reconstructPlayCounts`, `detectUnratings`, `getItemRating`, the plays delta/monotonic/no-op cases, and un-star detection (confirm, cap, empty-guard). Frontend suite green (782). Typecheck + lint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)