### PR TITLE
feat: album destination page at /album/:mbid (#159)

### DIFF
--- a/server/api/musicbrainz/releaseGroups.test.ts
+++ b/server/api/musicbrainz/releaseGroups.test.ts
@@ -5,6 +5,7 @@ import {
   getReleaseGroupIdFromRelease,
   getReleaseGroupLabel,
   getReleaseGroupDate,
+  getAlbumDetails,
 } from "./releaseGroups";
 
 const mockFetch = vi.fn();
@@ -102,6 +103,62 @@ describe("getReleaseGroupById", () => {
       artistName: "Unknown Artist",
       albumTitle: "Mystery Album",
     });
+  });
+});
+
+describe("getAlbumDetails", () => {
+  it("returns full album metadata including artist MBID and type", async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        id: "rg-123",
+        title: "OK Computer",
+        "primary-type": "Album",
+        "first-release-date": "1997-06-16",
+        "secondary-types": ["Live"],
+        "artist-credit": [
+          { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
+        ],
+      })
+    );
+
+    const result = await getAlbumDetails("rg-123");
+    expect(result).toEqual({
+      mbid: "rg-123",
+      title: "OK Computer",
+      artistName: "Radiohead",
+      artistMbid: "a1",
+      firstReleaseDate: "1997-06-16",
+      primaryType: "Album",
+      secondaryTypes: ["Live"],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://musicbrainz.test/ws/2/release-group/rg-123?inc=artist-credits&fmt=json",
+      { headers: { "User-Agent": "test" } }
+    );
+  });
+
+  it("falls back to defaults when fields are missing", async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({ id: "rg-456", "artist-credit": [] })
+    );
+
+    const result = await getAlbumDetails("rg-456");
+    expect(result).toEqual({
+      mbid: "rg-456",
+      title: "Unknown Album",
+      artistName: "Unknown Artist",
+      artistMbid: null,
+      firstReleaseDate: null,
+      primaryType: null,
+      secondaryTypes: [],
+    });
+  });
+
+  it("returns null when the release group is not found", async () => {
+    mockFetch.mockResolvedValue(errorResponse(404));
+
+    const result = await getAlbumDetails("nonexistent");
+    expect(result).toBeNull();
   });
 });
 

--- a/server/api/musicbrainz/releaseGroups.ts
+++ b/server/api/musicbrainz/releaseGroups.ts
@@ -9,6 +9,16 @@ import type {
   MusicBrainzLabelReleasesResponse,
 } from "./types";
 
+export type AlbumDetails = {
+  mbid: string;
+  title: string;
+  artistName: string;
+  artistMbid: string | null;
+  firstReleaseDate: string | null;
+  primaryType: string | null;
+  secondaryTypes: string[];
+};
+
 /** Search for release groups (albums/EPs) by text query */
 export async function searchReleaseGroups(
   query: string
@@ -56,6 +66,31 @@ export async function getReleaseGroupById(
   return {
     artistName: data["artist-credit"]?.[0]?.name ?? "Unknown Artist",
     albumTitle: data.title ?? "Unknown Album",
+  };
+}
+
+/** Fetch album metadata for a release group, including artist MBID and type */
+export async function getAlbumDetails(
+  releaseGroupMbid: string
+): Promise<AlbumDetails | null> {
+  const url = `${MB_BASE}/release-group/${releaseGroupMbid}?inc=artist-credits&fmt=json`;
+  const response = await rateLimitedMbFetch(url, { headers: MB_HEADERS });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data: MusicBrainzReleaseGroup = await response.json();
+  const credit = data["artist-credit"]?.[0];
+
+  return {
+    mbid: data.id,
+    title: data.title ?? "Unknown Album",
+    artistName: credit?.name ?? "Unknown Artist",
+    artistMbid: credit?.artist?.id ?? null,
+    firstReleaseDate: data["first-release-date"] || null,
+    primaryType: data["primary-type"] || null,
+    secondaryTypes: data["secondary-types"] ?? [],
   };
 }
 

--- a/server/routes/musicbrainz.test.ts
+++ b/server/routes/musicbrainz.test.ts
@@ -6,6 +6,7 @@ const mockGetReleaseTracks = vi.fn();
 const mockEnrichTracksWithPreviews = vi.fn();
 const mockGetReleaseGroupLabel = vi.fn();
 const mockGetReleaseGroupDate = vi.fn();
+const mockGetAlbumDetails = vi.fn();
 const mockGetLabelAncestors = vi.fn();
 const mockGetConfigValue = vi.fn();
 const mockEvaluatePurchaseDecision = vi.fn();
@@ -22,6 +23,7 @@ vi.mock("../api/musicbrainz/releaseGroups", () => ({
   getReleaseGroupLabel: (...args: unknown[]) =>
     mockGetReleaseGroupLabel(...args),
   getReleaseGroupDate: (...args: unknown[]) => mockGetReleaseGroupDate(...args),
+  getAlbumDetails: (...args: unknown[]) => mockGetAlbumDetails(...args),
 }));
 
 vi.mock("../api/musicbrainz/artists", () => ({
@@ -298,6 +300,65 @@ describe("GET /tracks/:releaseGroupId", () => {
     await request(app).get("/tracks/rg-456");
 
     expect(mockEnrichTracksWithPreviews).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /album/:mbid", () => {
+  it("returns 404 when the album is not found", async () => {
+    mockGetAlbumDetails.mockResolvedValue(null);
+
+    const res = await request(app).get("/album/missing");
+    expect(res.status).toBe(404);
+    expect(mockFetchReleaseGroupsForArtist).not.toHaveBeenCalled();
+    expect(mockGetReleaseGroupLabel).not.toHaveBeenCalled();
+  });
+
+  it("composes album details, label and more-from-artist", async () => {
+    const album = {
+      mbid: "rg-1",
+      title: "OK Computer",
+      artistName: "Radiohead",
+      artistMbid: "a1",
+      firstReleaseDate: "1997-06-16",
+      primaryType: "Album",
+      secondaryTypes: [],
+    };
+    const label = { name: "Parlophone", mbid: "label-1" };
+    mockGetAlbumDetails.mockResolvedValue(album);
+    mockFetchReleaseGroupsForArtist.mockResolvedValue([
+      { id: "rg-1", title: "OK Computer" },
+      { id: "rg-2", title: "Kid A" },
+    ]);
+    mockGetReleaseGroupLabel.mockResolvedValue(label);
+
+    const res = await request(app).get("/album/rg-1");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      album: { ...album, label },
+      moreFromArtist: [{ id: "rg-2", title: "Kid A" }],
+    });
+    expect(mockGetAlbumDetails).toHaveBeenCalledWith("rg-1");
+    expect(mockFetchReleaseGroupsForArtist).toHaveBeenCalledWith("a1");
+    expect(mockGetReleaseGroupLabel).toHaveBeenCalledWith("rg-1");
+  });
+
+  it("skips more-from-artist when artist MBID is missing", async () => {
+    mockGetAlbumDetails.mockResolvedValue({
+      mbid: "rg-9",
+      title: "Mystery",
+      artistName: "Unknown Artist",
+      artistMbid: null,
+      firstReleaseDate: null,
+      primaryType: null,
+      secondaryTypes: [],
+    });
+    mockGetReleaseGroupLabel.mockResolvedValue(null);
+
+    const res = await request(app).get("/album/rg-9");
+    expect(res.status).toBe(200);
+    expect(res.body.moreFromArtist).toEqual([]);
+    expect(res.body.album.label).toBeNull();
+    expect(mockFetchReleaseGroupsForArtist).not.toHaveBeenCalled();
   });
 });
 

--- a/server/routes/musicbrainz.ts
+++ b/server/routes/musicbrainz.ts
@@ -7,6 +7,7 @@ import {
   getReleaseGroupById,
   getReleaseGroupLabel,
   getReleaseGroupDate,
+  getAlbumDetails,
 } from "../api/musicbrainz/releaseGroups";
 import {
   getArtistById,
@@ -148,6 +149,27 @@ router.get(
     res.json(result);
   }
 );
+
+router.get("/album/:mbid", rateLimiter, async (req: Request, res: Response) => {
+  const { mbid } = req.params;
+  const album = await getAlbumDetails(mbid as string);
+
+  if (!album) {
+    return res.status(404).json({ error: "Album not found" });
+  }
+
+  const [moreFromArtist, label] = await Promise.all([
+    album.artistMbid
+      ? fetchReleaseGroupsForArtist(album.artistMbid)
+      : Promise.resolve([]),
+    getReleaseGroupLabel(mbid as string),
+  ]);
+
+  res.json({
+    album: { ...album, label },
+    moreFromArtist: moreFromArtist.filter((rg) => rg.id !== mbid),
+  });
+});
 
 function sendSSE(res: Response, event: string, data: unknown) {
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import RequireAuth from "./components/RequireAuth";
 import RequireOnboarding from "./components/RequireOnboarding";
 import SearchPage from "./pages/SearchPage/SearchPage";
 import ArtistPage from "./pages/ArtistPage/ArtistPage";
+import AlbumPage from "./pages/AlbumPage/AlbumPage";
 import DiscoverPage from "./pages/DiscoverPage/DiscoverPage";
 import LibraryPage from "./pages/LibraryPage/LibraryPage";
 import SettingsLayout from "./pages/SettingsPage/SettingsLayout";
@@ -30,6 +31,7 @@ function App() {
             <Route path="/" element={<DiscoverPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/artist/:mbid" element={<ArtistPage />} />
+            <Route path="/album/:mbid" element={<AlbumPage />} />
             <Route path="/library/upload" element={<UploadPage />} />
             <Route path="/library" element={<LibraryPage />}>
               <Route

--- a/src/components/AlbumActionModals.tsx
+++ b/src/components/AlbumActionModals.tsx
@@ -1,0 +1,30 @@
+import PurchaseLinksModal from "./PurchaseLinksModal";
+import PurchasePriceModal from "./PurchasePriceModal";
+import type { AlbumActions } from "../hooks/useAlbumActions";
+
+interface AlbumActionModalsProps {
+  actions: AlbumActions;
+}
+
+export default function AlbumActionModals({ actions }: AlbumActionModalsProps) {
+  return (
+    <>
+      <PurchaseLinksModal
+        isOpen={actions.isLinksModalOpen}
+        onClose={actions.closeLinksModal}
+        artistName={actions.artistName}
+        albumTitle={actions.albumTitle}
+        albumMbid={actions.albumMbid}
+        onAddToLibrary={actions.handleAddToLibrary}
+      />
+      <PurchasePriceModal
+        isOpen={actions.isPriceModalOpen}
+        onClose={actions.closePriceModal}
+        artistName={actions.artistName}
+        albumTitle={actions.albumTitle}
+        onConfirm={actions.handleRecordPurchase}
+        saving={actions.recordingPurchase}
+      />
+    </>
+  );
+}

--- a/src/components/ReleaseGroupCard.tsx
+++ b/src/components/ReleaseGroupCard.tsx
@@ -1,203 +1,34 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import MonitorButton from "./MonitorButton";
-import TrackList from "./TrackList";
-import PurchaseLinksModal from "./PurchaseLinksModal";
-import PurchasePriceModal from "./PurchasePriceModal";
-import Spinner from "./Spinner";
-import { CheckIcon, PlusIcon } from "@/components/icons";
 import ImageWithShimmer from "./ImageWithShimmer";
-import OptionSelect from "./OptionSelect";
-import useLidarr from "../hooks/useLidarr";
-import useWanted from "../hooks/useWanted";
-import usePurchase from "../hooks/usePurchase";
-import useReleaseTracks from "../hooks/useReleaseTracks";
-import useAudioPreview from "../hooks/useAudioPreview";
-import useFollowedArtists from "../hooks/useFollowedArtists";
 import useHaptics from "../hooks/useHaptics";
-import { useAuth } from "../context/useAuth";
-import { hasPermission, Permission } from "@shared/permissions";
 import { pastelColorFromId } from "../utils/color";
-import { getMonitorState } from "../utils/monitorState";
-import type { Option } from "./OptionSelect";
-import { MonitorState, ReleaseGroup } from "../types";
-
-const mobileMonitorStyles: Record<MonitorState, string> = {
-  idle: "bg-amber-300 hover:bg-amber-200 text-black",
-  adding: "bg-amber-200 text-amber-700 cursor-wait",
-  success: "bg-emerald-400 text-black cursor-default",
-  already_monitored: "bg-gray-200 text-gray-500 cursor-default",
-  error: "bg-rose-400 text-white",
-};
+import { ReleaseGroup } from "../types";
 
 interface ReleaseGroupCardProps {
   releaseGroup: ReleaseGroup;
-  inLibrary?: boolean;
-  defaultExpanded?: boolean;
-  initialWanted?: boolean;
-  onRemovedFromWanted?: (albumMbid: string) => void | Promise<void>;
 }
 
 export default function ReleaseGroupCard({
   releaseGroup,
-  inLibrary = false,
-  defaultExpanded = false,
-  initialWanted = false,
-  onRemovedFromWanted,
 }: ReleaseGroupCardProps) {
   const navigate = useNavigate();
-  const { user } = useAuth();
-  const canImport =
-    user !== null && hasPermission(user.permissions, Permission.IMPORT);
+  const haptics = useHaptics();
 
-  const [isFlipped, setIsFlipped] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isPurchaseModalOpen, setIsPurchaseModalOpen] = useState(false);
-
-  const artistCredit = releaseGroup["artist-credit"]?.[0]?.artist;
-  const artistName = artistCredit?.name || "Unknown Artist";
-  const artistMbid = artistCredit?.id;
+  const artistName =
+    releaseGroup["artist-credit"]?.[0]?.artist?.name || "Unknown Artist";
   const albumTitle = releaseGroup.title || "";
   const albumMbid = releaseGroup.id;
-  const pastelBg = useMemo(() => pastelColorFromId(albumMbid), [albumMbid]);
   const year = releaseGroup["first-release-date"]?.slice(0, 4) || "";
+  const pastelBg = useMemo(() => pastelColorFromId(albumMbid), [albumMbid]);
   const coverUrl = `https://coverartarchive.org/release-group/${albumMbid}/front-500`;
 
-  const haptics = useHaptics();
-  const { state, errorMsg, requestAlbum } = useLidarr();
-  const {
-    state: wantedState,
-    addToWanted,
-    removeFromWanted,
-  } = useWanted(initialWanted);
-  const { state: purchaseState, record: recordPurchase } = usePurchase();
-  const {
-    media,
-    loading: tracksLoading,
-    error: tracksError,
-    fetchTracks,
-  } = useReleaseTracks();
-  const { toggle, stop, isTrackPlaying } = useAudioPreview();
-  const { isFollowing, follow, unfollow } = useFollowedArtists();
-
-  const expandContentRef = useRef<HTMLDivElement>(null);
-  const [expandHeight, setExpandHeight] = useState(0);
-
-  useEffect(() => {
-    const el = expandContentRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(() => {
-      setExpandHeight(el.offsetHeight);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  const effectiveState = getMonitorState(state, inLibrary);
-  const disabled =
-    effectiveState === "adding" ||
-    effectiveState === "success" ||
-    effectiveState === "already_monitored";
-
-  const loadTracksIfNeeded = () => {
-    if (media.length === 0 && !tracksLoading) {
-      fetchTracks(albumMbid, artistName);
-    }
-  };
-
-  useEffect(() => {
-    if (defaultExpanded) loadTracksIfNeeded();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleMouseEnter = () => {
-    setIsFlipped(true);
-    loadTracksIfNeeded();
-  };
-
-  const handleMouseLeave = () => {
-    setIsFlipped(false);
-    stop();
-  };
-
-  const handleMobileCardClick = () => {
-    haptics.light();
-    if (!isExpanded) loadTracksIfNeeded();
-    if (isExpanded) stop();
-    setIsExpanded(!isExpanded);
-  };
-
-  const handleMonitorClick = () => {
-    haptics.medium();
-    if (!albumTitle) {
-      requestAlbum({ albumMbid });
-      return;
-    }
-
-    if (effectiveState === "idle" || effectiveState === "error") {
-      setIsModalOpen(true);
-    }
-  };
-
-  const handleAddToLibrary = () => {
-    requestAlbum({ albumMbid });
-  };
-
-  const isWanted = wantedState === "wanted";
-  const handleRemoveFromWanted = async () => {
-    if (onRemovedFromWanted) {
-      await onRemovedFromWanted(albumMbid);
-    } else {
-      await removeFromWanted(albumMbid);
-    }
-  };
-  const isPurchased = purchaseState === "purchased";
-  const following = artistMbid ? isFollowing(artistMbid) : false;
-  const cardOptions: Option[] = [
-    isWanted
-      ? { label: "Remove from wanted", onClick: handleRemoveFromWanted }
-      : { label: "Add to wanted", onClick: () => addToWanted(albumMbid) },
-    ...(isPurchased
-      ? []
-      : [
-          {
-            label: "Mark as purchased",
-            onClick: () => setIsPurchaseModalOpen(true),
-          },
-        ]),
-    ...(canImport
-      ? [
-          {
-            label: "Upload files",
-            onClick: () => navigate(`/library/upload?mbid=${albumMbid}`),
-          },
-        ]
-      : []),
-    ...(artistMbid
-      ? [
-          following
-            ? {
-                label: "Unfollow artist",
-                onClick: () => {
-                  void unfollow(artistMbid);
-                },
-              }
-            : {
-                label: "Follow artist",
-                onClick: () => {
-                  void follow(artistMbid, artistName);
-                },
-              },
-        ]
-      : []),
-  ];
-
-  const handleRecordPurchase = (price: number, currency: string) => {
-    recordPurchase(albumMbid, price, currency);
-  };
-
   const [coverError, setCoverError] = useState(false);
+
+  const handleClick = () => {
+    haptics.light();
+    navigate(`/album/${albumMbid}`);
+  };
 
   const coverImage = !coverError ? (
     <div className="absolute inset-0">
@@ -210,172 +41,59 @@ export default function ReleaseGroupCard({
     </div>
   ) : null;
 
-  const monitorIcon =
-    effectiveState === "adding" ? (
-      <Spinner />
-    ) : effectiveState === "success" ||
-      effectiveState === "already_monitored" ? (
-      <CheckIcon className="w-5 h-5" />
-    ) : (
-      <PlusIcon className="w-5 h-5" />
-    );
-
   return (
     <>
-      {/* Mobile: horizontal card with expand */}
-      <div
-        className="sm:hidden bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden"
+      <button
+        type="button"
+        onClick={handleClick}
+        className="sm:hidden w-full flex items-center text-left bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden"
         data-testid="release-group-card-mobile"
       >
         <div
-          className="flex items-center cursor-pointer"
-          onClick={handleMobileCardClick}
+          className="w-24 aspect-square flex-shrink-0 relative"
+          style={{ backgroundColor: pastelBg }}
         >
-          <div
-            className="w-24 aspect-square flex-shrink-0 relative"
-            style={{ backgroundColor: pastelBg }}
-          >
-            {coverImage}
-          </div>
-          <div className="flex-1 min-w-0 px-4 py-3">
-            <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-base truncate">
-              {albumTitle}
-            </h3>
-            <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
-              {artistName}
-            </p>
-            {year && (
-              <p className="text-gray-400 dark:text-gray-500 text-xs">{year}</p>
-            )}
-          </div>
-          <div className="flex items-center gap-1.5 flex-shrink-0 mr-3">
-            <div onClick={(e) => e.stopPropagation()}>
-              <OptionSelect options={cardOptions} title={albumTitle} />
-            </div>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                handleMonitorClick();
-              }}
-              disabled={disabled}
-              className={`w-12 h-12 flex items-center justify-center rounded-lg border-2 border-black shadow-cartoon-sm ${mobileMonitorStyles[effectiveState]}`}
-              data-testid="mobile-monitor-button"
-              aria-label="Request album"
-            >
-              {monitorIcon}
-            </button>
-          </div>
+          {coverImage}
         </div>
-        <div
-          className="overflow-hidden transition-[height] duration-300"
-          data-expanded={isExpanded}
-          style={{
-            height: isExpanded ? expandHeight : 0,
-            transitionTimingFunction: "cubic-bezier(0.34, 1.3, 0.64, 1)",
-          }}
-        >
-          <div ref={expandContentRef}>
-            <div
-              className="border-t-2 border-black p-3 overlay-scrollbar max-h-64 overflow-y-auto"
-              data-testid="mobile-tracklist"
-            >
-              <TrackList
-                media={media}
-                loading={tracksLoading}
-                error={tracksError}
-                onTogglePreview={toggle}
-                isTrackPlaying={isTrackPlaying}
-              />
-            </div>
-          </div>
+        <div className="flex-1 min-w-0 px-4 py-3">
+          <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-base truncate">
+            {albumTitle}
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
+            {artistName}
+          </p>
+          {year && (
+            <p className="text-gray-400 dark:text-gray-500 text-xs">{year}</p>
+          )}
         </div>
-      </div>
+      </button>
 
-      {/* Desktop: flip card on hover */}
-      <div
-        className="hidden sm:block flip-card"
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+      <button
+        type="button"
+        onClick={handleClick}
+        className="hidden sm:block w-full text-left bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden hover:translate-y-[-2px] hover:shadow-cartoon-lg transition-all"
+        data-testid="release-group-card"
       >
-        <div className={`flip-card-inner ${isFlipped ? "flipped" : ""}`}>
-          <div
-            className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden flip-card-face"
-            data-testid="release-group-card"
-          >
-            <div
-              className="aspect-square relative"
-              style={{ backgroundColor: pastelBg }}
-            >
-              {coverImage}
-            </div>
-
-            <div className="p-3 border-t-2 border-black">
-              <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-sm truncate mb-1">
-                {albumTitle}
-              </h3>
-              <p className="text-gray-500 dark:text-gray-400 text-xs truncate">
-                {artistName}
-              </p>
-              {year && (
-                <p className="text-gray-400 dark:text-gray-500 text-xs mt-0.5">
-                  {year}
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div
-            className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black overflow-hidden flex flex-col p-4 flip-card-face flip-card-back shadow-cartoon-md-flip"
-            data-testid="release-group-card-back"
-          >
-            <div className="flex-shrink-0">
-              <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-sm truncate">
-                {albumTitle}
-              </h3>
-              <p className="text-gray-500 dark:text-gray-400 text-xs truncate">
-                {artistName}
-              </p>
-            </div>
-
-            <div className="flex-1 overflow-y-auto mt-3 min-h-0 overlay-scrollbar">
-              <TrackList
-                media={media}
-                loading={tracksLoading}
-                error={tracksError}
-                onTogglePreview={toggle}
-                isTrackPlaying={isTrackPlaying}
-              />
-            </div>
-
-            <div className="flex-shrink-0 mt-2 flex items-center justify-end gap-1.5">
-              <OptionSelect options={cardOptions} title={albumTitle} />
-              <MonitorButton
-                state={effectiveState}
-                onClick={handleMonitorClick}
-                errorMsg={errorMsg ?? undefined}
-              />
-            </div>
-          </div>
+        <div
+          className="aspect-square relative"
+          style={{ backgroundColor: pastelBg }}
+        >
+          {coverImage}
         </div>
-      </div>
-
-      <PurchaseLinksModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        artistName={artistName}
-        albumTitle={albumTitle}
-        albumMbid={albumMbid}
-        onAddToLibrary={handleAddToLibrary}
-      />
-
-      <PurchasePriceModal
-        isOpen={isPurchaseModalOpen}
-        onClose={() => setIsPurchaseModalOpen(false)}
-        artistName={artistName}
-        albumTitle={albumTitle}
-        onConfirm={handleRecordPurchase}
-        saving={purchaseState === "recording"}
-      />
+        <div className="p-3 border-t-2 border-black">
+          <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-sm truncate mb-1">
+            {albumTitle}
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 text-xs truncate">
+            {artistName}
+          </p>
+          {year && (
+            <p className="text-gray-400 dark:text-gray-500 text-xs mt-0.5">
+              {year}
+            </p>
+          )}
+        </div>
+      </button>
     </>
   );
 }

--- a/src/components/WantedCard.tsx
+++ b/src/components/WantedCard.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ImageWithShimmer from "./ImageWithShimmer";
+import MonitorButton from "./MonitorButton";
+import OptionSelect from "./OptionSelect";
+import AlbumActionModals from "./AlbumActionModals";
+import useHaptics from "../hooks/useHaptics";
+import useAlbumActions from "../hooks/useAlbumActions";
+import { pastelColorFromId } from "../utils/color";
+import type { ReleaseGroup } from "../types";
+
+interface WantedCardProps {
+  releaseGroup: ReleaseGroup;
+  inLibrary?: boolean;
+  initialWanted?: boolean;
+  onRemovedFromWanted?: (albumMbid: string) => void | Promise<void>;
+}
+
+export default function WantedCard({
+  releaseGroup,
+  inLibrary = false,
+  initialWanted = false,
+  onRemovedFromWanted,
+}: WantedCardProps) {
+  const navigate = useNavigate();
+  const haptics = useHaptics();
+  const actions = useAlbumActions({
+    releaseGroup,
+    inLibrary,
+    initialWanted,
+    onRemovedFromWanted,
+  });
+
+  const artistName =
+    releaseGroup["artist-credit"]?.[0]?.artist?.name || "Unknown Artist";
+  const albumTitle = releaseGroup.title || "";
+  const albumMbid = releaseGroup.id;
+  const pastelBg = useMemo(() => pastelColorFromId(albumMbid), [albumMbid]);
+  const coverUrl = `https://coverartarchive.org/release-group/${albumMbid}/front-500`;
+
+  const [coverError, setCoverError] = useState(false);
+
+  const handleNavigate = () => {
+    haptics.light();
+    navigate(`/album/${albumMbid}`);
+  };
+
+  return (
+    <>
+      <div
+        className="flex items-center bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden"
+        data-testid="wanted-card"
+      >
+        <button
+          type="button"
+          onClick={handleNavigate}
+          className="flex flex-1 min-w-0 items-center text-left cursor-pointer"
+        >
+          <div
+            className="w-24 aspect-square flex-shrink-0 relative"
+            style={{ backgroundColor: pastelBg }}
+          >
+            {!coverError && (
+              <div className="absolute inset-0">
+                <ImageWithShimmer
+                  src={coverUrl}
+                  alt={`${albumTitle} cover`}
+                  className="w-full h-full object-cover"
+                  onError={() => setCoverError(true)}
+                />
+              </div>
+            )}
+          </div>
+          <div className="flex-1 min-w-0 px-4 py-3">
+            <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-base truncate">
+              {albumTitle}
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
+              {artistName}
+            </p>
+          </div>
+        </button>
+        <div className="flex items-center gap-1.5 flex-shrink-0 mr-3">
+          <OptionSelect options={actions.options} title={albumTitle} />
+          <MonitorButton
+            state={actions.effectiveState}
+            onClick={actions.handleMonitorClick}
+            errorMsg={actions.errorMsg ?? undefined}
+          />
+        </div>
+      </div>
+
+      <AlbumActionModals actions={actions} />
+    </>
+  );
+}

--- a/src/components/__tests__/ReleaseGroupCard.test.tsx
+++ b/src/components/__tests__/ReleaseGroupCard.test.tsx
@@ -1,118 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import ReleaseGroupCard from "../ReleaseGroupCard";
-import { Permission } from "@shared/permissions";
 import type { ReleaseGroup } from "../../types";
 
+const mockNavigate = vi.fn();
+
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => vi.fn(),
-}));
-
-let mockUser: { id: number; permissions: number } | null = {
-  id: 1,
-  permissions: Permission.IMPORT,
-};
-
-vi.mock("../../context/useAuth", () => ({
-  useAuth: () => ({
-    user: mockUser,
-  }),
-}));
-
-Object.defineProperty(window, "matchMedia", {
-  value: vi.fn().mockReturnValue({
-    matches: true,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  }),
-});
-
-const mockRequestAlbum = vi.fn();
-const mockFetchTracks = vi.fn();
-const mockStop = vi.fn();
-const mockAddToWanted = vi.fn();
-const mockRemoveFromWanted = vi.fn();
-const mockFollow = vi.fn();
-const mockUnfollow = vi.fn();
-const mockIsFollowing = vi.fn(() => false);
-
-vi.mock("../../hooks/useLidarr", () => ({
-  default: () => ({
-    state: "idle",
-    errorMsg: null,
-    requestAlbum: mockRequestAlbum,
-  }),
-}));
-
-vi.mock("../../hooks/useWanted", () => ({
-  default: () => ({
-    state: "idle",
-    errorMsg: null,
-    addToWanted: mockAddToWanted,
-    removeFromWanted: mockRemoveFromWanted,
-  }),
-}));
-
-vi.mock("../../hooks/usePurchase", () => ({
-  default: () => ({
-    state: "idle",
-    errorMsg: null,
-    record: vi.fn(),
-    remove: vi.fn(),
-    reset: vi.fn(),
-  }),
-}));
-
-vi.mock("../../hooks/useReleaseTracks", () => ({
-  default: () => ({
-    media: [],
-    loading: false,
-    error: null,
-    fetchTracks: mockFetchTracks,
-  }),
-}));
-
-vi.mock("../../hooks/useAudioPreview", () => ({
-  default: () => ({
-    toggle: vi.fn(),
-    stop: mockStop,
-    isTrackPlaying: () => false,
-  }),
-}));
-
-vi.mock("../../hooks/useFollowedArtists", () => ({
-  default: () => ({
-    items: [],
-    loading: false,
-    error: null,
-    isFollowing: mockIsFollowing,
-    follow: mockFollow,
-    unfollow: mockUnfollow,
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock("../PurchaseLinksModal", () => ({
-  default: ({
-    isOpen,
-    onAddToLibrary,
-  }: {
-    isOpen: boolean;
-    onAddToLibrary: () => void;
-  }) =>
-    isOpen ? (
-      <div data-testid="purchase-modal">
-        <button onClick={onAddToLibrary}>Add to Library</button>
-      </div>
-    ) : null,
-}));
-
-vi.mock("../PurchasePriceModal", () => ({
-  default: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="purchase-price-modal" /> : null,
-}));
-
-vi.mock("../TrackList", () => ({
-  default: () => <div data-testid="track-list" />,
+  useNavigate: () => mockNavigate,
 }));
 
 const makeReleaseGroup = (
@@ -132,8 +25,6 @@ const makeReleaseGroup = (
 describe("ReleaseGroupCard", () => {
   afterEach(() => {
     vi.clearAllMocks();
-    mockIsFollowing.mockReturnValue(false);
-    mockUser = { id: 1, permissions: Permission.IMPORT };
   });
 
   it("renders album title, artist name, and year", () => {
@@ -166,262 +57,24 @@ describe("ReleaseGroupCard", () => {
     expect(screen.queryByText(/^\d{4}$/)).not.toBeInTheDocument();
   });
 
-  describe("hover flip (desktop)", () => {
-    it("renders both faces for 3D flip", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      expect(screen.getByTestId("release-group-card")).toBeInTheDocument();
-      expect(screen.getByTestId("release-group-card-back")).toBeInTheDocument();
-    });
-
-    it("flips card and fetches tracks with artistName on mouse enter", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-      const card = screen
-        .getByTestId("release-group-card")
-        .closest(".flip-card")!;
-
-      fireEvent.mouseEnter(card);
-
-      const inner = screen
-        .getByTestId("release-group-card")
-        .closest(".flip-card-inner")!;
-      expect(inner).toHaveClass("flipped");
-      expect(mockFetchTracks).toHaveBeenCalledWith("abc-123", "Test Artist");
-    });
-
-    it("flips back and stops audio on mouse leave", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-      const card = screen
-        .getByTestId("release-group-card")
-        .closest(".flip-card")!;
-
-      fireEvent.mouseEnter(card);
-      const inner = screen
-        .getByTestId("release-group-card")
-        .closest(".flip-card-inner")!;
-      expect(inner).toHaveClass("flipped");
-
-      fireEvent.mouseLeave(card);
-      expect(inner).not.toHaveClass("flipped");
-      expect(mockStop).toHaveBeenCalled();
-    });
-  });
-
-  describe("mobile layout", () => {
-    it("renders mobile card with title, artist, year, and monitor button", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const mobileCard = screen.getByTestId("release-group-card-mobile");
-      expect(mobileCard).toBeInTheDocument();
-      expect(screen.getByTestId("mobile-monitor-button")).toBeInTheDocument();
-    });
-
-    it("expands to show tracklist when card is clicked", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const expandContainer = screen
-        .getByTestId("mobile-tracklist")
-        .closest("[data-expanded]")!;
-      expect(expandContainer).toHaveAttribute("data-expanded", "false");
-
-      const mobileCard = screen.getByTestId("release-group-card-mobile");
-      fireEvent.click(mobileCard.querySelector(".flex.items-center")!);
-
-      expect(expandContainer).toHaveAttribute("data-expanded", "true");
-      expect(mockFetchTracks).toHaveBeenCalledWith("abc-123", "Test Artist");
-    });
-
-    it("collapses tracklist and stops audio when expanded card is clicked again", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const clickTarget = screen
-        .getByTestId("release-group-card-mobile")
-        .querySelector(".flex.items-center")!;
-      const expandContainer = screen
-        .getByTestId("mobile-tracklist")
-        .closest("[data-expanded]")!;
-
-      fireEvent.click(clickTarget);
-      expect(expandContainer).toHaveAttribute("data-expanded", "true");
-
-      fireEvent.click(clickTarget);
-      expect(expandContainer).toHaveAttribute("data-expanded", "false");
-      expect(mockStop).toHaveBeenCalled();
-    });
-
-    it("opens purchase modal when + button is clicked", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      fireEvent.click(screen.getByTestId("mobile-monitor-button"));
-
-      expect(screen.getByTestId("purchase-modal")).toBeInTheDocument();
-    });
-
-    it("does not expand card when + button is clicked", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      fireEvent.click(screen.getByTestId("mobile-monitor-button"));
-
-      const expandContainer = screen
-        .getByTestId("mobile-tracklist")
-        .closest("[data-expanded]")!;
-      expect(expandContainer).toHaveAttribute("data-expanded", "false");
-    });
-
-    it("fetches tracks on expand but not on collapse", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const clickTarget = screen
-        .getByTestId("release-group-card-mobile")
-        .querySelector(".flex.items-center")!;
-
-      fireEvent.click(clickTarget);
-      expect(mockFetchTracks).toHaveBeenCalledTimes(1);
-
-      fireEvent.click(clickTarget);
-      expect(mockFetchTracks).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does not render a detail overlay", () => {
+  it("navigates to the album page when the card is clicked", () => {
     render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
 
-    expect(screen.queryByTestId("detail-overlay")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("release-group-card"));
+    expect(mockNavigate).toHaveBeenCalledWith("/album/abc-123");
   });
 
-  describe("inLibrary behavior", () => {
-    it("disables add button when inLibrary is true", () => {
-      render(
-        <ReleaseGroupCard releaseGroup={makeReleaseGroup()} inLibrary={true} />
-      );
+  it("navigates from the mobile card too", () => {
+    render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
 
-      const mobileButton = screen.getByTestId("mobile-monitor-button");
-      expect(mobileButton).toBeDisabled();
-    });
-
-    it("shows checkmark icon when inLibrary is true", () => {
-      render(
-        <ReleaseGroupCard releaseGroup={makeReleaseGroup()} inLibrary={true} />
-      );
-
-      const mobileButton = screen.getByTestId("mobile-monitor-button");
-      expect(mobileButton.className).toContain("bg-gray-200");
-      expect(mobileButton.className).toContain("text-gray-500");
-    });
+    fireEvent.click(screen.getByTestId("release-group-card-mobile"));
+    expect(mockNavigate).toHaveBeenCalledWith("/album/abc-123");
   });
 
-  describe("more menu", () => {
-    it("renders more options button on mobile and desktop", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
+  it("does not render action buttons", () => {
+    render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
 
-      const moreButtons = screen.getAllByLabelText("More options");
-      expect(moreButtons.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it("shows 'Add to wanted' option when menu is opened", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.getByText("Add to wanted")).toBeInTheDocument();
-    });
-
-    it("calls addToWanted when 'Add to wanted' is clicked", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-      fireEvent.click(screen.getByText("Add to wanted"));
-
-      expect(mockAddToWanted).toHaveBeenCalledWith("abc-123");
-    });
-
-    it("does not expand card when more menu is clicked on mobile", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const expandContainer = screen
-        .getByTestId("mobile-tracklist")
-        .closest("[data-expanded]")!;
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(expandContainer).toHaveAttribute("data-expanded", "false");
-    });
-
-    it("shows 'Follow artist' option when not following", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.getByText("Follow artist")).toBeInTheDocument();
-    });
-
-    it("calls follow with artistMbid and artistName when clicked", () => {
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-      fireEvent.click(screen.getByText("Follow artist"));
-
-      expect(mockFollow).toHaveBeenCalledWith("a1", "Test Artist");
-    });
-
-    it("shows 'Unfollow artist' option when already following", () => {
-      mockIsFollowing.mockReturnValue(true);
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.getByText("Unfollow artist")).toBeInTheDocument();
-    });
-
-    it("calls unfollow with artistMbid when 'Unfollow artist' clicked", () => {
-      mockIsFollowing.mockReturnValue(true);
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-      fireEvent.click(screen.getByText("Unfollow artist"));
-
-      expect(mockUnfollow).toHaveBeenCalledWith("a1");
-    });
-
-    it("hides follow option when artistMbid is missing", () => {
-      render(
-        <ReleaseGroupCard
-          releaseGroup={makeReleaseGroup({ "artist-credit": [] })}
-        />
-      );
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.queryByText("Follow artist")).not.toBeInTheDocument();
-      expect(screen.queryByText("Unfollow artist")).not.toBeInTheDocument();
-    });
-
-    it("shows 'Upload files' option for a user with IMPORT permission", () => {
-      mockUser = { id: 2, permissions: Permission.IMPORT };
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.getByText("Upload files")).toBeInTheDocument();
-    });
-
-    it("hides 'Upload files' option for a user without IMPORT permission", () => {
-      mockUser = { id: 3, permissions: Permission.REQUEST };
-      render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
-
-      const moreButtons = screen.getAllByLabelText("More options");
-      fireEvent.click(moreButtons[0]);
-
-      expect(screen.queryByText("Upload files")).not.toBeInTheDocument();
-    });
+    expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("track-list")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/WantedCard.test.tsx
+++ b/src/components/__tests__/WantedCard.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import WantedCard from "../WantedCard";
+import { Permission } from "@shared/permissions";
+import type { ReleaseGroup } from "../../types";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({ user: { id: 1, permissions: Permission.ADMIN } }),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  value: vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }),
+});
+
+const mockRequestAlbum = vi.fn();
+const mockAddToWanted = vi.fn();
+const mockRemoveFromWanted = vi.fn();
+
+vi.mock("../../hooks/useLidarr", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    requestAlbum: mockRequestAlbum,
+  }),
+}));
+
+vi.mock("../../hooks/useWanted", () => ({
+  default: () => ({
+    state: "wanted",
+    errorMsg: null,
+    addToWanted: mockAddToWanted,
+    removeFromWanted: mockRemoveFromWanted,
+  }),
+}));
+
+vi.mock("../../hooks/usePurchase", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    record: vi.fn(),
+    remove: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useFollowedArtists", () => ({
+  default: () => ({
+    items: [],
+    loading: false,
+    error: null,
+    isFollowing: () => false,
+    follow: vi.fn(),
+    unfollow: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../PurchaseLinksModal", () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="purchase-modal" /> : null,
+}));
+
+vi.mock("../PurchasePriceModal", () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="purchase-price-modal" /> : null,
+}));
+
+const makeReleaseGroup = (
+  overrides: Partial<ReleaseGroup> = {}
+): ReleaseGroup => ({
+  id: "mbid-1",
+  score: 0,
+  title: "OK Computer",
+  "primary-type": "Album",
+  "first-release-date": "",
+  "artist-credit": [
+    { name: "Radiohead", artist: { id: "a1", name: "Radiohead" } },
+  ],
+  ...overrides,
+});
+
+describe("WantedCard", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("renders album title and artist", () => {
+    render(<WantedCard releaseGroup={makeReleaseGroup()} initialWanted />);
+
+    expect(screen.getByText("OK Computer")).toBeInTheDocument();
+    expect(screen.getByText("Radiohead")).toBeInTheDocument();
+  });
+
+  it("navigates to the album page when the body is clicked", () => {
+    render(<WantedCard releaseGroup={makeReleaseGroup()} initialWanted />);
+
+    fireEvent.click(screen.getByText("OK Computer"));
+    expect(mockNavigate).toHaveBeenCalledWith("/album/mbid-1");
+  });
+
+  it("shows the Monitored button when the album is in library", () => {
+    render(
+      <WantedCard releaseGroup={makeReleaseGroup()} initialWanted inLibrary />
+    );
+
+    expect(screen.getByText("Monitored")).toBeInTheDocument();
+  });
+
+  it("calls onRemovedFromWanted from the options menu", () => {
+    const onRemove = vi.fn();
+    render(
+      <WantedCard
+        releaseGroup={makeReleaseGroup()}
+        initialWanted
+        onRemovedFromWanted={onRemove}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    fireEvent.click(screen.getByText("Remove from wanted"));
+
+    expect(onRemove).toHaveBeenCalledWith("mbid-1");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("opens the purchase links modal when the request button is clicked", () => {
+    render(<WantedCard releaseGroup={makeReleaseGroup()} initialWanted />);
+
+    fireEvent.click(screen.getByText("Request"));
+    expect(screen.getByTestId("purchase-modal")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useReleaseGroupDetails.test.ts
+++ b/src/hooks/__tests__/useReleaseGroupDetails.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import useReleaseGroupDetails from "../useReleaseGroupDetails";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useReleaseGroupDetails", () => {
+  it("does not fetch when no mbid is provided", () => {
+    const { result } = renderHook(() => useReleaseGroupDetails(undefined));
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.album).toBeNull();
+  });
+
+  it("loads album details and more-from-artist", async () => {
+    const payload = {
+      album: {
+        mbid: "rg-1",
+        title: "OK Computer",
+        artistName: "Radiohead",
+        artistMbid: "a1",
+        firstReleaseDate: "1997-06-16",
+        primaryType: "Album",
+        secondaryTypes: [],
+        label: { name: "Parlophone", mbid: "label-1" },
+      },
+      moreFromArtist: [{ id: "rg-2", title: "Kid A" }],
+    };
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), { status: 200 })
+    );
+
+    const { result } = renderHook(() => useReleaseGroupDetails("rg-1"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.album).toEqual(payload.album);
+    expect(result.current.moreFromArtist).toEqual(payload.moreFromArtist);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
+      "/api/musicbrainz/album/rg-1"
+    );
+  });
+
+  it("sets an error when the request fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Album not found" }), {
+        status: 404,
+      })
+    );
+
+    const { result } = renderHook(() => useReleaseGroupDetails("missing"));
+
+    await waitFor(() => expect(result.current.error).toBe("Album not found"));
+    expect(result.current.album).toBeNull();
+    expect(result.current.moreFromArtist).toEqual([]);
+  });
+});

--- a/src/hooks/useAlbumActions.ts
+++ b/src/hooks/useAlbumActions.ts
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/useAuth";
+import { hasPermission, Permission } from "@shared/permissions";
+import { getMonitorState } from "../utils/monitorState";
+import useLidarr from "./useLidarr";
+import useWanted from "./useWanted";
+import usePurchase from "./usePurchase";
+import useFollowedArtists from "./useFollowedArtists";
+import useHaptics from "./useHaptics";
+import type { Option } from "../components/OptionSelect";
+import type { MonitorState, ReleaseGroup } from "../types";
+
+interface UseAlbumActionsParams {
+  releaseGroup: ReleaseGroup;
+  inLibrary?: boolean;
+  initialWanted?: boolean;
+  onRemovedFromWanted?: (albumMbid: string) => void | Promise<void>;
+}
+
+export interface AlbumActions {
+  albumMbid: string;
+  albumTitle: string;
+  artistName: string;
+  effectiveState: MonitorState;
+  errorMsg: string | null;
+  disabled: boolean;
+  options: Option[];
+  menuOptions: Option[];
+  isWanted: boolean;
+  wantedPending: boolean;
+  toggleWanted: () => void;
+  handleMonitorClick: () => void;
+  isLinksModalOpen: boolean;
+  closeLinksModal: () => void;
+  isPriceModalOpen: boolean;
+  closePriceModal: () => void;
+  handleAddToLibrary: () => void;
+  handleRecordPurchase: (price: number, currency: string) => void;
+  recordingPurchase: boolean;
+}
+
+export default function useAlbumActions({
+  releaseGroup,
+  inLibrary = false,
+  initialWanted = false,
+  onRemovedFromWanted,
+}: UseAlbumActionsParams): AlbumActions {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const canImport =
+    user !== null && hasPermission(user.permissions, Permission.IMPORT);
+
+  const [isLinksModalOpen, setIsLinksModalOpen] = useState(false);
+  const [isPriceModalOpen, setIsPriceModalOpen] = useState(false);
+
+  const artistCredit = releaseGroup["artist-credit"]?.[0]?.artist;
+  const artistName = artistCredit?.name || "Unknown Artist";
+  const artistMbid = artistCredit?.id;
+  const albumTitle = releaseGroup.title || "";
+  const albumMbid = releaseGroup.id;
+
+  const haptics = useHaptics();
+  const { state, errorMsg, requestAlbum } = useLidarr();
+  const {
+    state: wantedState,
+    addToWanted,
+    removeFromWanted,
+  } = useWanted(initialWanted);
+  const { state: purchaseState, record: recordPurchase } = usePurchase();
+  const { isFollowing, follow, unfollow } = useFollowedArtists();
+
+  const effectiveState = getMonitorState(state, inLibrary);
+  const disabled =
+    effectiveState === "adding" ||
+    effectiveState === "success" ||
+    effectiveState === "already_monitored";
+
+  const handleMonitorClick = () => {
+    haptics.medium();
+    if (!albumTitle) {
+      requestAlbum({ albumMbid });
+      return;
+    }
+    if (effectiveState === "idle" || effectiveState === "error") {
+      setIsLinksModalOpen(true);
+    }
+  };
+
+  const handleRemoveFromWanted = async () => {
+    if (onRemovedFromWanted) {
+      await onRemovedFromWanted(albumMbid);
+    } else {
+      await removeFromWanted(albumMbid);
+    }
+  };
+
+  const isWanted = wantedState === "wanted";
+  const wantedPending = wantedState === "adding" || wantedState === "removing";
+  const isPurchased = purchaseState === "purchased";
+  const following = artistMbid ? isFollowing(artistMbid) : false;
+
+  const toggleWanted = () => {
+    if (isWanted) {
+      void handleRemoveFromWanted();
+    } else {
+      void addToWanted(albumMbid);
+    }
+  };
+
+  const wantedOption: Option = isWanted
+    ? { label: "Remove from wanted", onClick: handleRemoveFromWanted }
+    : { label: "Add to wanted", onClick: () => addToWanted(albumMbid) };
+
+  const menuOptions: Option[] = [
+    ...(isPurchased
+      ? []
+      : [
+          {
+            label: "Mark as purchased",
+            onClick: () => setIsPriceModalOpen(true),
+          },
+        ]),
+    ...(canImport
+      ? [
+          {
+            label: "Upload files",
+            onClick: () => navigate(`/library/upload?mbid=${albumMbid}`),
+          },
+        ]
+      : []),
+    ...(artistMbid
+      ? [
+          following
+            ? {
+                label: "Unfollow artist",
+                onClick: () => {
+                  void unfollow(artistMbid);
+                },
+              }
+            : {
+                label: "Follow artist",
+                onClick: () => {
+                  void follow(artistMbid, artistName);
+                },
+              },
+        ]
+      : []),
+  ];
+
+  const options: Option[] = [wantedOption, ...menuOptions];
+
+  return {
+    albumMbid,
+    albumTitle,
+    artistName,
+    effectiveState,
+    errorMsg,
+    disabled,
+    options,
+    menuOptions,
+    isWanted,
+    wantedPending,
+    toggleWanted,
+    handleMonitorClick,
+    isLinksModalOpen,
+    closeLinksModal: () => setIsLinksModalOpen(false),
+    isPriceModalOpen,
+    closePriceModal: () => setIsPriceModalOpen(false),
+    handleAddToLibrary: () => requestAlbum({ albumMbid }),
+    handleRecordPurchase: (price, currency) =>
+      recordPurchase(albumMbid, price, currency),
+    recordingPurchase: purchaseState === "recording",
+  };
+}

--- a/src/hooks/useReleaseGroupDetails.ts
+++ b/src/hooks/useReleaseGroupDetails.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import type { AlbumDetails, ReleaseGroup } from "../types";
+
+interface AlbumDetailsResponse {
+  album: AlbumDetails;
+  moreFromArtist: ReleaseGroup[];
+}
+
+export default function useReleaseGroupDetails(mbid: string | undefined) {
+  const [album, setAlbum] = useState<AlbumDetails | null>(null);
+  const [moreFromArtist, setMoreFromArtist] = useState<ReleaseGroup[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!mbid) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/musicbrainz/album/${mbid}`);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to load album");
+        }
+        const data: AlbumDetailsResponse = await res.json();
+        if (cancelled) return;
+        setAlbum(data.album);
+        setMoreFromArtist(data.moreFromArtist || []);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load album");
+        setAlbum(null);
+        setMoreFromArtist([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [mbid]);
+
+  return { album, moreFromArtist, loading, error };
+}

--- a/src/pages/AlbumPage/AlbumPage.tsx
+++ b/src/pages/AlbumPage/AlbumPage.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import useReleaseGroupDetails from "@/hooks/useReleaseGroupDetails";
+import useLibraryAlbums from "@/hooks/useLibraryAlbums";
+import useWantedAlbums from "@/hooks/useWantedAlbums";
+import ReleaseSectionGrid from "@/pages/ArtistPage/components/ReleaseSectionGrid";
+import AlbumHeader from "./components/AlbumHeader";
+import AlbumTracklist from "./components/AlbumTracklist";
+import AlbumPageSkeleton from "./components/AlbumPageSkeleton";
+
+export default function AlbumPage() {
+  const { mbid } = useParams<{ mbid: string }>();
+  const { album, moreFromArtist, loading, error } =
+    useReleaseGroupDetails(mbid);
+  const { isAlbumInLibrary } = useLibraryAlbums();
+  const { isAlbumWanted } = useWantedAlbums();
+
+  const otherReleases = useMemo(
+    () => moreFromArtist.filter((rg) => rg.id !== album?.mbid),
+    [moreFromArtist, album?.mbid]
+  );
+
+  if (loading) return <AlbumPageSkeleton />;
+
+  if (error || !album) {
+    return (
+      <div className="mt-16 flex flex-col items-center text-gray-400 animate-fade-in">
+        <p className="text-lg font-medium text-gray-500">
+          {error ?? "Album not found"}
+        </p>
+        <p className="mt-1 text-center">
+          We couldn&apos;t load this album. Try again from search.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <AlbumHeader
+        album={album}
+        inLibrary={isAlbumInLibrary(album.mbid)}
+        initialWanted={isAlbumWanted(album.mbid)}
+      />
+
+      <AlbumTracklist albumMbid={album.mbid} artistName={album.artistName} />
+
+      {otherReleases.length > 0 && (
+        <ReleaseSectionGrid
+          title="More from this artist"
+          items={otherReleases}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/AlbumPage/__tests__/AlbumPage.test.tsx
+++ b/src/pages/AlbumPage/__tests__/AlbumPage.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import AlbumPage from "../AlbumPage";
+import type { AlbumDetails, ReleaseGroup } from "@/types";
+
+let mockState: {
+  album: AlbumDetails | null;
+  moreFromArtist: ReleaseGroup[];
+  loading: boolean;
+  error: string | null;
+};
+
+vi.mock("@/hooks/useReleaseGroupDetails", () => ({
+  default: () => mockState,
+}));
+
+vi.mock("@/hooks/useLibraryAlbums", () => ({
+  default: () => ({ isAlbumInLibrary: (id: string) => id === "rg-1" }),
+}));
+
+vi.mock("@/hooks/useWantedAlbums", () => ({
+  default: () => ({ isAlbumWanted: (id: string) => id === "rg-1" }),
+}));
+
+vi.mock("../components/AlbumHeader", () => ({
+  default: ({
+    album,
+    inLibrary,
+    initialWanted,
+  }: {
+    album: AlbumDetails;
+    inLibrary?: boolean;
+    initialWanted?: boolean;
+  }) => (
+    <div
+      data-testid="album-header"
+      data-in-library={inLibrary}
+      data-wanted={initialWanted}
+    >
+      {album.title}
+    </div>
+  ),
+}));
+
+vi.mock("../components/AlbumTracklist", () => ({
+  default: ({ albumMbid }: { albumMbid: string }) => (
+    <div data-testid="album-tracklist">{albumMbid}</div>
+  ),
+}));
+
+vi.mock("@/pages/ArtistPage/components/ReleaseSectionGrid", () => ({
+  default: ({ title, items }: { title: string; items: ReleaseGroup[] }) => (
+    <div data-testid="more-from-artist" data-count={items.length}>
+      {title}
+      {items.map((rg) => (
+        <span key={rg.id}>{rg.title}</span>
+      ))}
+    </div>
+  ),
+}));
+
+const makeAlbum = (overrides: Partial<AlbumDetails> = {}): AlbumDetails => ({
+  mbid: "rg-1",
+  title: "OK Computer",
+  artistName: "Radiohead",
+  artistMbid: "a1",
+  firstReleaseDate: "1997-06-16",
+  primaryType: "Album",
+  secondaryTypes: [],
+  label: null,
+  ...overrides,
+});
+
+const makeRg = (id: string, title: string): ReleaseGroup => ({
+  id,
+  score: 0,
+  title,
+  "primary-type": "Album",
+  "first-release-date": "",
+  "artist-credit": [],
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/album/rg-1"]}>
+      <Routes>
+        <Route path="/album/:mbid" element={<AlbumPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  mockState = {
+    album: null,
+    moreFromArtist: [],
+    loading: false,
+    error: null,
+  };
+});
+
+describe("AlbumPage", () => {
+  it("shows a skeleton while loading", () => {
+    mockState.loading = true;
+    renderPage();
+    expect(
+      document.querySelectorAll(".animate-shimmer").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows an error state when the album fails to load", () => {
+    mockState.error = "Album not found";
+    renderPage();
+    expect(screen.getByText("Album not found")).toBeInTheDocument();
+  });
+
+  it("renders the header and tracklist", () => {
+    mockState.album = makeAlbum();
+    renderPage();
+
+    expect(screen.getByTestId("album-header")).toHaveTextContent("OK Computer");
+    expect(screen.getByTestId("album-tracklist")).toHaveTextContent("rg-1");
+  });
+
+  it("passes library and wanted status to the header", () => {
+    mockState.album = makeAlbum();
+    renderPage();
+
+    const header = screen.getByTestId("album-header");
+    expect(header).toHaveAttribute("data-in-library", "true");
+    expect(header).toHaveAttribute("data-wanted", "true");
+  });
+
+  it("renders more-from-artist excluding the current album", () => {
+    mockState.album = makeAlbum();
+    mockState.moreFromArtist = [
+      makeRg("rg-1", "OK Computer"),
+      makeRg("rg-2", "Kid A"),
+    ];
+    renderPage();
+
+    const grid = screen.getByTestId("more-from-artist");
+    expect(grid).toHaveAttribute("data-count", "1");
+    expect(screen.getByText("Kid A")).toBeInTheDocument();
+  });
+
+  it("hides more-from-artist when there are no other releases", () => {
+    mockState.album = makeAlbum();
+    mockState.moreFromArtist = [];
+    renderPage();
+
+    expect(screen.queryByTestId("more-from-artist")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/AlbumPage/components/AlbumActions.tsx
+++ b/src/pages/AlbumPage/components/AlbumActions.tsx
@@ -1,0 +1,51 @@
+import MonitorButton from "@/components/MonitorButton";
+import OptionSelect from "@/components/OptionSelect";
+import AlbumActionModals from "@/components/AlbumActionModals";
+import Spinner from "@/components/Spinner";
+import { HeartIcon } from "@/components/icons";
+import useAlbumActions from "@/hooks/useAlbumActions";
+import type { ReleaseGroup } from "@/types";
+
+interface AlbumActionsProps {
+  releaseGroup: ReleaseGroup;
+  inLibrary?: boolean;
+  initialWanted?: boolean;
+}
+
+export default function AlbumActions({
+  releaseGroup,
+  inLibrary,
+  initialWanted,
+}: AlbumActionsProps) {
+  const actions = useAlbumActions({ releaseGroup, inLibrary, initialWanted });
+
+  return (
+    <div className="flex items-center gap-2">
+      <MonitorButton
+        state={actions.effectiveState}
+        onClick={actions.handleMonitorClick}
+        errorMsg={actions.errorMsg ?? undefined}
+      />
+      <button
+        type="button"
+        onClick={actions.toggleWanted}
+        disabled={actions.wantedPending}
+        aria-label={actions.isWanted ? "Remove from wanted" : "Add to wanted"}
+        aria-pressed={actions.isWanted}
+        className={`w-9 h-9 flex items-center justify-center rounded-lg border-2 border-black shadow-cartoon-sm transition-colors ${
+          actions.isWanted
+            ? "bg-amber-300 text-black hover:bg-amber-200"
+            : "bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+        } ${actions.wantedPending ? "cursor-wait" : ""}`}
+      >
+        {actions.wantedPending ? (
+          <Spinner />
+        ) : (
+          <HeartIcon className="w-5 h-5" />
+        )}
+      </button>
+      <OptionSelect options={actions.menuOptions} title={actions.albumTitle} />
+      <AlbumActionModals actions={actions} />
+    </div>
+  );
+}

--- a/src/pages/AlbumPage/components/AlbumHeader.tsx
+++ b/src/pages/AlbumPage/components/AlbumHeader.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import ImageWithShimmer from "@/components/ImageWithShimmer";
+import { pastelColorFromId } from "@/utils/color";
+import AlbumActions from "./AlbumActions";
+import type { AlbumDetails, ReleaseGroup } from "@/types";
+
+interface AlbumHeaderProps {
+  album: AlbumDetails;
+  inLibrary?: boolean;
+  initialWanted?: boolean;
+}
+
+function toReleaseGroup(album: AlbumDetails): ReleaseGroup {
+  return {
+    id: album.mbid,
+    score: 0,
+    title: album.title,
+    "primary-type": album.primaryType ?? "Album",
+    "first-release-date": album.firstReleaseDate ?? "",
+    "artist-credit": album.artistMbid
+      ? [
+          {
+            name: album.artistName,
+            artist: { id: album.artistMbid, name: album.artistName },
+          },
+        ]
+      : [],
+  };
+}
+
+function buildSubtitle(album: AlbumDetails): string {
+  const year = album.firstReleaseDate?.slice(0, 4);
+  return [album.primaryType, year, album.label?.name]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export default function AlbumHeader({
+  album,
+  inLibrary,
+  initialWanted,
+}: AlbumHeaderProps) {
+  const [coverError, setCoverError] = useState(false);
+  const pastelBg = useMemo(() => pastelColorFromId(album.mbid), [album.mbid]);
+  const coverUrl = `https://coverartarchive.org/release-group/${album.mbid}/front-500`;
+  const subtitle = buildSubtitle(album);
+
+  return (
+    <div className="flex items-start gap-4 mb-8">
+      <div
+        className="w-28 h-28 sm:w-40 sm:h-40 rounded-xl flex-shrink-0 relative overflow-hidden border-2 border-black shadow-cartoon-md"
+        style={{ backgroundColor: pastelBg }}
+      >
+        {!coverError && (
+          <ImageWithShimmer
+            src={coverUrl}
+            alt={`${album.title} cover`}
+            className="w-full h-full object-cover"
+            onError={() => setCoverError(true)}
+          />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+          {album.title}
+        </h1>
+        {album.artistMbid ? (
+          <Link
+            to={`/artist/${album.artistMbid}`}
+            className="text-gray-600 dark:text-gray-300 text-base mt-1 inline-block hover:underline truncate"
+          >
+            {album.artistName}
+          </Link>
+        ) : (
+          <p className="text-gray-600 dark:text-gray-300 text-base mt-1 truncate">
+            {album.artistName}
+          </p>
+        )}
+        {subtitle && (
+          <p className="text-gray-400 dark:text-gray-500 text-sm mt-1 truncate">
+            {subtitle}
+          </p>
+        )}
+        <div className="mt-4">
+          <AlbumActions
+            releaseGroup={toReleaseGroup(album)}
+            inLibrary={inLibrary}
+            initialWanted={initialWanted}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AlbumPage/components/AlbumPageSkeleton.tsx
+++ b/src/pages/AlbumPage/components/AlbumPageSkeleton.tsx
@@ -1,0 +1,23 @@
+import Skeleton from "@/components/Skeleton";
+
+export default function AlbumPageSkeleton() {
+  return (
+    <div>
+      <div className="flex items-start gap-4 mb-8">
+        <Skeleton className="w-28 h-28 sm:w-40 sm:h-40 rounded-xl flex-shrink-0" />
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-8 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-4 w-1/4" />
+          <Skeleton className="h-9 w-40 rounded-lg" />
+        </div>
+      </div>
+      <Skeleton className="h-4 w-24 mb-3" />
+      <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md p-4 space-y-3">
+        {[...Array(6)].map((_, i) => (
+          <Skeleton key={i} className="h-5 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AlbumPage/components/AlbumTracklist.tsx
+++ b/src/pages/AlbumPage/components/AlbumTracklist.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import TrackList from "@/components/TrackList";
+import useReleaseTracks from "@/hooks/useReleaseTracks";
+import useAudioPreview from "@/hooks/useAudioPreview";
+
+interface AlbumTracklistProps {
+  albumMbid: string;
+  artistName: string;
+}
+
+export default function AlbumTracklist({
+  albumMbid,
+  artistName,
+}: AlbumTracklistProps) {
+  const { media, loading, error, fetchTracks } = useReleaseTracks();
+  const { toggle, isTrackPlaying } = useAudioPreview();
+
+  useEffect(() => {
+    void fetchTracks(albumMbid, artistName);
+  }, [albumMbid, artistName, fetchTracks]);
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-gray-500 dark:text-gray-400 text-sm font-semibold uppercase tracking-wide mb-3">
+        Tracklist
+      </h2>
+      <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md p-4">
+        <TrackList
+          media={media}
+          loading={loading}
+          error={error}
+          onTogglePreview={toggle}
+          isTrackPlaying={isTrackPlaying}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/pages/AlbumPage/components/__tests__/AlbumActions.test.tsx
+++ b/src/pages/AlbumPage/components/__tests__/AlbumActions.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AlbumActions from "../AlbumActions";
+import { Permission } from "@shared/permissions";
+import type { ReleaseGroup } from "@/types";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+let mockUser: { id: number; permissions: number } | null = {
+  id: 1,
+  permissions: Permission.IMPORT,
+};
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  value: vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }),
+});
+
+const mockRequestAlbum = vi.fn();
+const mockAddToWanted = vi.fn();
+const mockFollow = vi.fn();
+const mockIsFollowing = vi.fn(() => false);
+
+vi.mock("@/hooks/useLidarr", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    requestAlbum: mockRequestAlbum,
+  }),
+}));
+
+vi.mock("@/hooks/useWanted", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    addToWanted: mockAddToWanted,
+    removeFromWanted: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/usePurchase", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    record: vi.fn(),
+    remove: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useFollowedArtists", () => ({
+  default: () => ({
+    items: [],
+    loading: false,
+    error: null,
+    isFollowing: mockIsFollowing,
+    follow: mockFollow,
+    unfollow: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/PurchaseLinksModal", () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="purchase-modal" /> : null,
+}));
+
+vi.mock("@/components/PurchasePriceModal", () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="purchase-price-modal" /> : null,
+}));
+
+const makeReleaseGroup = (
+  overrides: Partial<ReleaseGroup> = {}
+): ReleaseGroup => ({
+  id: "abc-123",
+  score: 100,
+  title: "Test Album",
+  "primary-type": "Album",
+  "first-release-date": "2023-05-10",
+  "artist-credit": [
+    { name: "Test Artist", artist: { id: "a1", name: "Test Artist" } },
+  ],
+  ...overrides,
+});
+
+describe("AlbumActions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockIsFollowing.mockReturnValue(false);
+    mockUser = { id: 1, permissions: Permission.IMPORT };
+  });
+
+  it("renders the request button and options menu", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    expect(screen.getByText("Request")).toBeInTheDocument();
+    expect(screen.getByLabelText("More options")).toBeInTheDocument();
+  });
+
+  it("opens the purchase links modal when Request is clicked", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByText("Request"));
+    expect(screen.getByTestId("purchase-modal")).toBeInTheDocument();
+  });
+
+  it("adds to wanted from the heart button", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByLabelText("Add to wanted"));
+    expect(mockAddToWanted).toHaveBeenCalledWith("abc-123");
+  });
+
+  it("does not show the wanted toggle in the options menu", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    expect(screen.queryByText("Add to wanted")).not.toBeInTheDocument();
+    expect(screen.queryByText("Remove from wanted")).not.toBeInTheDocument();
+  });
+
+  it("opens the price modal from Mark as purchased", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    fireEvent.click(screen.getByText("Mark as purchased"));
+    expect(screen.getByTestId("purchase-price-modal")).toBeInTheDocument();
+  });
+
+  it("calls follow with artist details from the menu", () => {
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    fireEvent.click(screen.getByText("Follow artist"));
+    expect(mockFollow).toHaveBeenCalledWith("a1", "Test Artist");
+  });
+
+  it("hides the follow option when no artist MBID is present", () => {
+    render(
+      <AlbumActions releaseGroup={makeReleaseGroup({ "artist-credit": [] })} />
+    );
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    expect(screen.queryByText("Follow artist")).not.toBeInTheDocument();
+  });
+
+  it("hides Upload files without IMPORT permission", () => {
+    mockUser = { id: 2, permissions: Permission.REQUEST };
+    render(<AlbumActions releaseGroup={makeReleaseGroup()} />);
+
+    fireEvent.click(screen.getByLabelText("More options"));
+    expect(screen.queryByText("Upload files")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/AlbumPage/components/__tests__/AlbumHeader.test.tsx
+++ b/src/pages/AlbumPage/components/__tests__/AlbumHeader.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AlbumHeader from "../AlbumHeader";
+import type { AlbumDetails, ReleaseGroup } from "@/types";
+
+let receivedReleaseGroup: ReleaseGroup | null = null;
+
+vi.mock("../AlbumActions", () => ({
+  default: ({ releaseGroup }: { releaseGroup: ReleaseGroup }) => {
+    receivedReleaseGroup = releaseGroup;
+    return <div data-testid="album-actions" />;
+  },
+}));
+
+const makeAlbum = (overrides: Partial<AlbumDetails> = {}): AlbumDetails => ({
+  mbid: "rg-1",
+  title: "OK Computer",
+  artistName: "Radiohead",
+  artistMbid: "a1",
+  firstReleaseDate: "1997-06-16",
+  primaryType: "Album",
+  secondaryTypes: [],
+  label: { name: "Parlophone", mbid: "label-1" },
+  ...overrides,
+});
+
+function renderHeader(album: AlbumDetails) {
+  return render(
+    <MemoryRouter>
+      <AlbumHeader album={album} />
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  receivedReleaseGroup = null;
+});
+
+describe("AlbumHeader", () => {
+  it("renders the album title and a subtitle of type, year and label", () => {
+    renderHeader(makeAlbum());
+
+    expect(
+      screen.getByRole("heading", { name: "OK Computer" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Album · 1997 · Parlophone")).toBeInTheDocument();
+  });
+
+  it("links the artist name to the artist page when an MBID is present", () => {
+    renderHeader(makeAlbum());
+
+    const link = screen.getByRole("link", { name: "Radiohead" });
+    expect(link).toHaveAttribute("href", "/artist/a1");
+  });
+
+  it("renders the artist as plain text when no MBID is present", () => {
+    renderHeader(makeAlbum({ artistMbid: null }));
+
+    expect(
+      screen.queryByRole("link", { name: "Radiohead" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Radiohead")).toBeInTheDocument();
+  });
+
+  it("builds the action card from the album details", () => {
+    renderHeader(makeAlbum());
+
+    expect(screen.getByTestId("album-actions")).toBeInTheDocument();
+    expect(receivedReleaseGroup?.id).toBe("rg-1");
+    expect(receivedReleaseGroup?.["artist-credit"][0]?.artist.id).toBe("a1");
+  });
+});

--- a/src/pages/AlbumPage/components/__tests__/AlbumTracklist.test.tsx
+++ b/src/pages/AlbumPage/components/__tests__/AlbumTracklist.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import AlbumTracklist from "../AlbumTracklist";
+
+const mockFetchTracks = vi.fn();
+
+vi.mock("@/hooks/useReleaseTracks", () => ({
+  default: () => ({
+    media: [],
+    loading: false,
+    error: null,
+    fetchTracks: mockFetchTracks,
+  }),
+}));
+
+vi.mock("@/hooks/useAudioPreview", () => ({
+  default: () => ({
+    toggle: vi.fn(),
+    stop: vi.fn(),
+    isTrackPlaying: () => false,
+  }),
+}));
+
+vi.mock("@/components/TrackList", () => ({
+  default: () => <div data-testid="track-list" />,
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("AlbumTracklist", () => {
+  it("fetches tracks for the album on mount", () => {
+    render(<AlbumTracklist albumMbid="rg-1" artistName="Radiohead" />);
+
+    expect(mockFetchTracks).toHaveBeenCalledWith("rg-1", "Radiohead");
+    expect(screen.getByText("Tracklist")).toBeInTheDocument();
+    expect(screen.getByTestId("track-list")).toBeInTheDocument();
+  });
+});

--- a/src/pages/ArtistPage/ArtistPage.tsx
+++ b/src/pages/ArtistPage/ArtistPage.tsx
@@ -3,7 +3,6 @@ import { useParams } from "react-router-dom";
 import useArtistDetails from "@/hooks/useArtistDetails";
 import useLibraryAlbums from "@/hooks/useLibraryAlbums";
 import useLibraryArtists from "@/hooks/useLibraryArtists";
-import useWantedAlbums from "@/hooks/useWantedAlbums";
 import useSimilarArtists from "@/hooks/useSimilarArtists";
 import { groupArtistReleases } from "@/utils/groupArtistReleases";
 import ArtistHeader from "./components/ArtistHeader";
@@ -15,7 +14,6 @@ export default function ArtistPage() {
   const { mbid } = useParams<{ mbid: string }>();
   const { artist, releaseGroups, loading, error } = useArtistDetails(mbid);
   const { isAlbumInLibrary } = useLibraryAlbums();
-  const { isAlbumWanted } = useWantedAlbums();
   const { isArtistInLibrary } = useLibraryArtists();
   const { artists: similarArtists, loading: similarLoading } =
     useSimilarArtists(artist?.name, mbid);
@@ -59,8 +57,6 @@ export default function ArtistPage() {
             key={section.title}
             title={section.title}
             items={section.items}
-            isAlbumInLibrary={isAlbumInLibrary}
-            isAlbumWanted={isAlbumWanted}
           />
         ))
       )}

--- a/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
+++ b/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
@@ -20,12 +20,6 @@ vi.mock("@/hooks/useLibraryAlbums", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useWantedAlbums", () => ({
-  default: () => ({
-    isAlbumWanted: (id: string) => id === "wanted",
-  }),
-}));
-
 vi.mock("@/hooks/useLibraryArtists", () => ({
   default: () => ({
     isArtistInLibrary: (mbid: string) => mbid === "sim-owned",
@@ -39,22 +33,8 @@ vi.mock("@/hooks/useSimilarArtists", () => ({
 }));
 
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({
-    releaseGroup,
-    inLibrary,
-    initialWanted,
-  }: {
-    releaseGroup: ReleaseGroup;
-    inLibrary?: boolean;
-    initialWanted?: boolean;
-  }) => (
-    <div
-      data-testid={`rg-${releaseGroup.id}`}
-      data-in-library={inLibrary}
-      data-wanted={initialWanted}
-    >
-      {releaseGroup.title}
-    </div>
+  default: ({ releaseGroup }: { releaseGroup: ReleaseGroup }) => (
+    <div data-testid={`rg-${releaseGroup.id}`}>{releaseGroup.title}</div>
   ),
 }));
 
@@ -124,7 +104,7 @@ describe("ArtistPage", () => {
     expect(screen.getByText("Drill EP")).toBeInTheDocument();
   });
 
-  it("passes library status through to release cards and header", () => {
+  it("shows the In Library badge when the artist owns an album", () => {
     mockState.artist = { mbid: "a1", name: "Radiohead" };
     mockState.releaseGroups = [
       makeRg({ id: "in-lib", title: "Owned" }),
@@ -132,33 +112,9 @@ describe("ArtistPage", () => {
     ];
     renderPage();
 
-    expect(screen.getByTestId("rg-in-lib")).toHaveAttribute(
-      "data-in-library",
-      "true"
-    );
-    expect(screen.getByTestId("rg-missing")).toHaveAttribute(
-      "data-in-library",
-      "false"
-    );
+    expect(screen.getByTestId("rg-in-lib")).toBeInTheDocument();
+    expect(screen.getByTestId("rg-missing")).toBeInTheDocument();
     expect(screen.getByText("In Library")).toBeInTheDocument();
-  });
-
-  it("passes wanted status through to release cards", () => {
-    mockState.artist = { mbid: "a1", name: "Radiohead" };
-    mockState.releaseGroups = [
-      makeRg({ id: "wanted", title: "On Wanted" }),
-      makeRg({ id: "not-wanted", title: "Not Wanted" }),
-    ];
-    renderPage();
-
-    expect(screen.getByTestId("rg-wanted")).toHaveAttribute(
-      "data-wanted",
-      "true"
-    );
-    expect(screen.getByTestId("rg-not-wanted")).toHaveAttribute(
-      "data-wanted",
-      "false"
-    );
   });
 
   it("shows an empty message when the artist has no releases", () => {

--- a/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
+++ b/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
@@ -6,15 +6,11 @@ const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
 interface ReleaseSectionGridProps {
   title: string;
   items: ReleaseGroup[];
-  isAlbumInLibrary: (albumMbid: string) => boolean;
-  isAlbumWanted: (albumMbid: string) => boolean;
 }
 
 export default function ReleaseSectionGrid({
   title,
   items,
-  isAlbumInLibrary,
-  isAlbumWanted,
 }: ReleaseSectionGridProps) {
   return (
     <section className="mb-8">
@@ -33,11 +29,7 @@ export default function ReleaseSectionGrid({
               } as React.CSSProperties
             }
           >
-            <ReleaseGroupCard
-              releaseGroup={rg}
-              inLibrary={isAlbumInLibrary(rg.id)}
-              initialWanted={isAlbumWanted(rg.id)}
-            />
+            <ReleaseGroupCard releaseGroup={rg} />
           </div>
         ))}
       </div>

--- a/src/pages/LibraryPage/components/WantedList.tsx
+++ b/src/pages/LibraryPage/components/WantedList.tsx
@@ -1,5 +1,5 @@
 import Skeleton from "@/components/Skeleton";
-import ReleaseGroupCard from "@/components/ReleaseGroupCard";
+import WantedCard from "@/components/WantedCard";
 import useLibraryAlbums from "@/hooks/useLibraryAlbums";
 import type { WantedItem, ReleaseGroup } from "@/types";
 
@@ -32,14 +32,14 @@ export default function WantedList({
   const { isAlbumInLibrary } = useLibraryAlbums();
   if (loading) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-4">
         {[...Array(6)].map((_, i) => (
           <div
             key={i}
-            className="bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden"
+            className="flex items-center bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-sm overflow-hidden"
           >
-            <Skeleton className="aspect-square w-full" />
-            <div className="p-3 space-y-2">
+            <Skeleton className="w-24 aspect-square flex-shrink-0 rounded-none" />
+            <div className="flex-1 px-4 py-3 space-y-2">
               <Skeleton className="h-4 w-2/3" />
               <Skeleton className="h-3 w-1/2" />
             </div>
@@ -62,9 +62,9 @@ export default function WantedList({
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3 sm:gap-4">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-4">
       {items.map((item) => (
-        <ReleaseGroupCard
+        <WantedCard
           key={item.albumMbid}
           releaseGroup={toReleaseGroup(item)}
           inLibrary={isAlbumInLibrary(item.albumMbid)}

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -5,8 +5,6 @@ import ReleaseGroupCard from "@/components/ReleaseGroupCard";
 import ArtistCard from "@/pages/DiscoverPage/components/ArtistCard";
 import Skeleton from "@/components/Skeleton";
 import useSearch from "@/hooks/useSearch";
-import useLibraryAlbums from "@/hooks/useLibraryAlbums";
-import useWantedAlbums from "@/hooks/useWantedAlbums";
 
 const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
 
@@ -65,8 +63,6 @@ function SearchSkeletons() {
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { albums, artists, loading, error, search } = useSearch();
-  const { isAlbumInLibrary } = useLibraryAlbums();
-  const { isAlbumWanted } = useWantedAlbums();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const query = searchParams.get("q") ?? "";
@@ -142,11 +138,7 @@ export default function SearchPage() {
                       } as React.CSSProperties
                     }
                   >
-                    <ReleaseGroupCard
-                      releaseGroup={rg}
-                      inLibrary={isAlbumInLibrary(rg.id)}
-                      initialWanted={isAlbumWanted(rg.id)}
-                    />
+                    <ReleaseGroupCard releaseGroup={rg} />
                   </div>
                 ))}
               </div>

--- a/src/pages/SearchPage/__tests__/SearchPage.test.tsx
+++ b/src/pages/SearchPage/__tests__/SearchPage.test.tsx
@@ -15,33 +15,13 @@ vi.mock("@/hooks/useSearch", () => ({
   default: () => mockSearchState,
 }));
 
-vi.mock("@/hooks/useLibraryAlbums", () => ({
-  default: () => ({
-    isAlbumInLibrary: () => false,
-  }),
-}));
-
-vi.mock("@/hooks/useWantedAlbums", () => ({
-  default: () => ({
-    isAlbumWanted: (id: string) => id === "rg-wanted",
-  }),
-}));
-
 vi.mock("@/hooks/useNavigateToArtist", () => ({
   default: () => ({ go: vi.fn(), resolving: false }),
 }));
 
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({
-    releaseGroup,
-    initialWanted,
-  }: {
-    releaseGroup: { title: string };
-    initialWanted?: boolean;
-  }) => (
-    <div data-testid="release-card" data-wanted={initialWanted}>
-      {releaseGroup.title}
-    </div>
+  default: ({ releaseGroup }: { releaseGroup: { title: string } }) => (
+    <div data-testid="release-card">{releaseGroup.title}</div>
   ),
 }));
 
@@ -129,24 +109,6 @@ describe("SearchPage", () => {
 
     expect(screen.queryByText("Artists")).not.toBeInTheDocument();
     expect(screen.getByText("Albums")).toBeInTheDocument();
-  });
-
-  it("seeds initialWanted from the wanted list for matching albums", () => {
-    mockSearchState.albums = [
-      makeAlbum("rg-wanted", "In Rainbows"),
-      makeAlbum("rg-other", "Amnesiac", 90),
-    ];
-
-    renderSearchPage("Radiohead");
-
-    expect(screen.getByText("In Rainbows")).toHaveAttribute(
-      "data-wanted",
-      "true"
-    );
-    expect(screen.getByText("Amnesiac")).toHaveAttribute(
-      "data-wanted",
-      "false"
-    );
   });
 
   it("shows the no-results state when a query returns nothing", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,17 @@ export interface ArtistSearchResult {
   imageUrl?: string;
 }
 
+export interface AlbumDetails {
+  mbid: string;
+  title: string;
+  artistName: string;
+  artistMbid: string | null;
+  firstReleaseDate: string | null;
+  primaryType: string | null;
+  secondaryTypes: string[];
+  label: { name: string; mbid: string } | null;
+}
+
 export interface Track {
   position: number;
   title: string;


### PR DESCRIPTION
Closes #159.

## What
Adds a release-group destination page at `/album/:mbid`, giving albums a real, linkable place to land and explore from (e.g. "more like In Utero"). Mirrors the existing `ArtistPage` pattern.

## Backend
- `getAlbumDetails(mbid)` — one MusicBrainz lookup returning title, artist name + MBID, first-release date, primary/secondary types.
- `GET /api/musicbrainz/album/:mbid` — composes album metadata + primary label + "more from this artist" (current album filtered out); 404s when not found. Tracks reuse the existing `/tracks/:releaseGroupId` endpoint.

## Frontend
- **`AlbumPage`**: header (cover art via CoverArtArchive with pastel fallback, artist link, type · year · label), full tracklist, and a "More from this artist" grid. Similar-albums slot left reserved for Level 3.
- `useReleaseGroupDetails` hook mirroring `useArtistDetails`.
- `useAlbumActions` hook + `AlbumActionModals` — extracts the request / wanted / purchase / follow / upload logic once and shares it.
- The wanted toggle is a **heart icon button** on the album page rather than a menu item; the `⋮` menu keeps purchase / upload / follow.

## Entry-point changes (per issue's open question)
- `ReleaseGroupCard` is now a **pure navigation tile** (cover + title + artist + year); clicking anywhere navigates to `/album/:mbid`. Hover keeps the shadow and lifts the card + grows the shadow, matching `ArtistCard`. All actions now live on the album page.
- `WantedList` uses a new `WantedCard` that keeps the inline request/remove actions the wanted view needs, and also links to the album page.
- `SearchPage`, `ReleaseSectionGrid`, and `ArtistPage` updated to drop the now-unused card props.

## Tests
Full coverage both sides: `getAlbumDetails`, the `/album/:mbid` route, `useReleaseGroupDetails`, `AlbumPage`, `AlbumHeader`, `AlbumActions`, `AlbumTracklist`, `WantedCard`, rewritten `ReleaseGroupCard` tests, and updated `ArtistPage` / `SearchPage` tests. `pnpm typecheck`, `pnpm lint`, `pnpm test` (798), and `pnpm test:server` (1008) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)