### PR TITLE
feat: right-click / long-press context menu on album cards

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,0 +1,145 @@
+import {
+  ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import type { VirtualElement } from "@floating-ui/react-dom";
+import OptionMenu, { type Option } from "./OptionMenu";
+import useHaptics from "../hooks/useHaptics";
+
+interface ContextMenuProps {
+  options: Option[];
+  title?: string;
+  disabled?: boolean;
+  longPressMs?: number;
+  className?: string;
+  children: ReactNode;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const MOVE_THRESHOLD = 10;
+
+const WRAPPER_STYLE: CSSProperties = {
+  WebkitTouchCallout: "none",
+  WebkitUserSelect: "none",
+  userSelect: "none",
+};
+
+function pointToVirtualElement(point: Point): VirtualElement {
+  return {
+    getBoundingClientRect: () => ({
+      x: point.x,
+      y: point.y,
+      top: point.y,
+      left: point.x,
+      right: point.x,
+      bottom: point.y,
+      width: 0,
+      height: 0,
+      toJSON: () => ({}),
+    }),
+  };
+}
+
+export default function ContextMenu({
+  options,
+  title,
+  disabled = false,
+  longPressMs = 450,
+  className,
+  children,
+}: ContextMenuProps) {
+  const haptics = useHaptics();
+  const [point, setPoint] = useState<Point | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const timerRef = useRef<number | null>(null);
+  const startRef = useRef<Point | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const reference = useMemo(
+    () => (point ? pointToVirtualElement(point) : null),
+    [point]
+  );
+
+  const openAt = useCallback((x: number, y: number) => {
+    setPoint({ x, y });
+    setIsOpen(true);
+  }, []);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const active = !disabled && options.length > 0;
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!active) return;
+    openAt(e.clientX, e.clientY);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (!active) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    startRef.current = { x: touch.clientX, y: touch.clientY };
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      if (!startRef.current) return;
+      haptics.medium();
+      suppressClickRef.current = true;
+      openAt(startRef.current.x, startRef.current.y);
+    }, longPressMs);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch || !startRef.current) return;
+    const dx = Math.abs(touch.clientX - startRef.current.x);
+    const dy = Math.abs(touch.clientY - startRef.current.y);
+    if (dx > MOVE_THRESHOLD || dy > MOVE_THRESHOLD) clearTimer();
+  };
+
+  const handleClickCapture = (e: React.MouseEvent) => {
+    if (suppressClickRef.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      suppressClickRef.current = false;
+    }
+  };
+
+  return (
+    <div
+      className={className}
+      style={WRAPPER_STYLE}
+      onContextMenu={handleContextMenu}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={clearTimer}
+      onTouchCancel={clearTimer}
+      onClickCapture={handleClickCapture}
+    >
+      {children}
+      <OptionMenu
+        options={options}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        reference={reference}
+        title={title}
+        align="left"
+      />
+    </div>
+  );
+}

--- a/src/components/OptionMenu.tsx
+++ b/src/components/OptionMenu.tsx
@@ -1,0 +1,151 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  useFloating,
+  offset,
+  flip,
+  shift,
+  autoUpdate,
+  type ReferenceType,
+} from "@floating-ui/react-dom";
+import BottomSheet from "./BottomSheet";
+import useHaptics from "../hooks/useHaptics";
+
+interface Option {
+  label: string;
+  onClick: () => void;
+}
+
+interface OptionMenuProps {
+  options: Option[];
+  isOpen: boolean;
+  onClose: () => void;
+  reference: ReferenceType | null;
+  title?: string;
+  align?: "left" | "right";
+  ignoreRefs?: RefObject<HTMLElement | null>[];
+}
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    () => !window.matchMedia("(min-width: 640px)").matches
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 640px)");
+    const handler = (e: MediaQueryListEvent) => setIsMobile(!e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isMobile;
+}
+
+function useClickOutside(
+  refs: RefObject<HTMLElement | null>[],
+  isOpen: boolean,
+  onClose: () => void
+) {
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const listener = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (refs.some((ref) => ref.current?.contains(target))) return;
+      stableOnClose();
+    };
+    document.addEventListener("mousedown", listener);
+    return () => document.removeEventListener("mousedown", listener);
+  }, [isOpen, refs, stableOnClose]);
+}
+
+function OptionList({
+  options,
+  onClose,
+}: {
+  options: Option[];
+  onClose: () => void;
+}) {
+  const haptics = useHaptics();
+
+  return (
+    <div className="flex flex-col gap-1">
+      {options.map((option) => (
+        <button
+          key={option.label}
+          type="button"
+          onClick={() => {
+            haptics.light();
+            option.onClick();
+            onClose();
+          }}
+          className="w-full text-left px-3 py-2 text-sm text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function OptionMenu({
+  options,
+  isOpen,
+  onClose,
+  reference,
+  title,
+  align = "right",
+  ignoreRefs,
+}: OptionMenuProps) {
+  const isMobile = useIsMobile();
+  const floatingRef = useRef<HTMLDivElement | null>(null);
+  const [floatingEl, setFloatingEl] = useState<HTMLElement | null>(null);
+
+  const setFloating = useCallback((node: HTMLDivElement | null) => {
+    floatingRef.current = node;
+    setFloatingEl(node);
+  }, []);
+
+  const { floatingStyles, placement } = useFloating({
+    elements: { reference, floating: floatingEl },
+    placement: align === "right" ? "bottom-end" : "bottom-start",
+    strategy: "fixed",
+    transform: false,
+    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  useClickOutside(
+    [...(ignoreRefs ?? []), floatingRef],
+    isOpen && !isMobile,
+    onClose
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet isOpen={isOpen} onClose={onClose} title={title}>
+        <OptionList options={options} onClose={onClose} />
+      </BottomSheet>
+    );
+  }
+
+  if (!isOpen) return null;
+
+  const originClass = placement.startsWith("top")
+    ? "origin-bottom"
+    : "origin-top";
+
+  return createPortal(
+    <div
+      ref={setFloating}
+      style={floatingStyles}
+      className={`min-w-48 bg-white dark:bg-gray-800 border-2 border-black rounded-xl shadow-cartoon-lg py-1 z-50 animate-dropdown-in ${originClass}`}
+    >
+      <OptionList options={options} onClose={onClose} />
+    </div>,
+    document.body
+  );
+}
+
+export type { Option };

--- a/src/components/OptionSelect.tsx
+++ b/src/components/OptionSelect.tsx
@@ -1,150 +1,12 @@
-import { RefObject, useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import {
-  useFloating,
-  offset,
-  flip,
-  shift,
-  autoUpdate,
-} from "@floating-ui/react-dom";
+import { useCallback, useRef, useState } from "react";
 import { EllipsisVerticalIcon } from "@/components/icons";
-import BottomSheet from "./BottomSheet";
 import useHaptics from "../hooks/useHaptics";
-
-interface Option {
-  label: string;
-  onClick: () => void;
-}
+import OptionMenu, { type Option } from "./OptionMenu";
 
 interface OptionSelectProps {
   options: Option[];
   title?: string;
   align?: "left" | "right";
-}
-
-function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(
-    () => !window.matchMedia("(min-width: 640px)").matches
-  );
-
-  useEffect(() => {
-    const mql = window.matchMedia("(min-width: 640px)");
-    const handler = (e: MediaQueryListEvent) => setIsMobile(!e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
-  }, []);
-
-  return isMobile;
-}
-
-function useClickOutside(
-  refs: RefObject<HTMLElement | null>[],
-  isOpen: boolean,
-  onClose: () => void
-) {
-  const stableOnClose = useCallback(() => onClose(), [onClose]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const listener = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (refs.some((ref) => ref.current?.contains(target))) return;
-      stableOnClose();
-    };
-    document.addEventListener("mousedown", listener);
-    return () => document.removeEventListener("mousedown", listener);
-  }, [isOpen, refs, stableOnClose]);
-}
-
-function OptionList({
-  options,
-  onClose,
-}: {
-  options: Option[];
-  onClose: () => void;
-}) {
-  const haptics = useHaptics();
-
-  return (
-    <div className="flex flex-col gap-1">
-      {options.map((option) => (
-        <button
-          key={option.label}
-          type="button"
-          onClick={() => {
-            haptics.light();
-            option.onClick();
-            onClose();
-          }}
-          className="w-full text-left px-3 py-2 text-sm text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-        >
-          {option.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function Popup({
-  anchorRef,
-  anchorEl,
-  isOpen,
-  onClose,
-  options,
-  title,
-  align,
-}: {
-  anchorRef: RefObject<HTMLElement | null>;
-  anchorEl: HTMLElement | null;
-  isOpen: boolean;
-  onClose: () => void;
-  options: Option[];
-  title?: string;
-  align: "left" | "right";
-}) {
-  const isMobile = useIsMobile();
-  const floatingRef = useRef<HTMLDivElement | null>(null);
-  const [floatingEl, setFloatingEl] = useState<HTMLElement | null>(null);
-
-  const setFloating = useCallback((node: HTMLDivElement | null) => {
-    floatingRef.current = node;
-    setFloatingEl(node);
-  }, []);
-
-  const { floatingStyles, placement } = useFloating({
-    elements: { reference: anchorEl, floating: floatingEl },
-    placement: align === "right" ? "bottom-end" : "bottom-start",
-    strategy: "fixed",
-    transform: false,
-    middleware: [offset(6), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  });
-  useClickOutside([anchorRef, floatingRef], isOpen && !isMobile, onClose);
-
-  if (isMobile) {
-    return (
-      <BottomSheet isOpen={isOpen} onClose={onClose} title={title}>
-        <OptionList options={options} onClose={onClose} />
-      </BottomSheet>
-    );
-  }
-
-  if (!isOpen) return null;
-
-  const originClass = placement.startsWith("top")
-    ? "origin-bottom"
-    : "origin-top";
-
-  return createPortal(
-    <div
-      ref={setFloating}
-      style={floatingStyles}
-      className={`min-w-48 bg-white dark:bg-gray-800 border-2 border-black rounded-xl shadow-cartoon-lg py-1 z-50 animate-dropdown-in ${originClass}`}
-    >
-      <OptionList options={options} onClose={onClose} />
-    </div>,
-    document.body
-  );
 }
 
 export default function OptionSelect({
@@ -178,14 +40,14 @@ export default function OptionSelect({
       >
         <EllipsisVerticalIcon className="w-5 h-5" />
       </button>
-      <Popup
-        anchorRef={triggerRef}
-        anchorEl={triggerEl}
+      <OptionMenu
+        options={options}
         isOpen={isOpen}
         onClose={close}
-        options={options}
+        reference={triggerEl}
         title={title}
         align={align}
+        ignoreRefs={[triggerRef]}
       />
     </>
   );

--- a/src/components/ReleaseGroupCard.tsx
+++ b/src/components/ReleaseGroupCard.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ImageWithShimmer from "./ImageWithShimmer";
+import ContextMenu from "./ContextMenu";
+import AlbumActionModals from "./AlbumActionModals";
 import useHaptics from "../hooks/useHaptics";
+import useAlbumActions from "../hooks/useAlbumActions";
 import { pastelColorFromId } from "../utils/color";
 import { ReleaseGroup } from "../types";
 
@@ -14,6 +17,7 @@ export default function ReleaseGroupCard({
 }: ReleaseGroupCardProps) {
   const navigate = useNavigate();
   const haptics = useHaptics();
+  const actions = useAlbumActions({ releaseGroup });
 
   const artistName =
     releaseGroup["artist-credit"]?.[0]?.artist?.name || "Unknown Artist";
@@ -42,7 +46,7 @@ export default function ReleaseGroupCard({
   ) : null;
 
   return (
-    <>
+    <ContextMenu options={actions.contextOptions} title={albumTitle}>
       <button
         type="button"
         onClick={handleClick}
@@ -94,6 +98,8 @@ export default function ReleaseGroupCard({
           )}
         </div>
       </button>
-    </>
+
+      <AlbumActionModals actions={actions} />
+    </ContextMenu>
   );
 }

--- a/src/components/__tests__/ContextMenu.test.tsx
+++ b/src/components/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import ContextMenu from "../ContextMenu";
+
+function setMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+}
+
+const makeOptions = () => [{ label: "Add to wanted", onClick: vi.fn() }];
+
+beforeEach(() => {
+  setMatchMedia(true); // desktop: OptionMenu uses the floating popup
+});
+
+describe("ContextMenu — right click", () => {
+  it("opens the menu at the pointer on right-click", () => {
+    render(
+      <ContextMenu options={makeOptions()}>
+        <button>Card</button>
+      </ContextMenu>
+    );
+
+    fireEvent.contextMenu(screen.getByText("Card"));
+    expect(screen.getByText("Add to wanted")).toBeInTheDocument();
+  });
+
+  it("does not open when disabled", () => {
+    render(
+      <ContextMenu options={makeOptions()} disabled>
+        <button>Card</button>
+      </ContextMenu>
+    );
+
+    fireEvent.contextMenu(screen.getByText("Card"));
+    expect(screen.queryByText("Add to wanted")).not.toBeInTheDocument();
+  });
+
+  it("does not open when there are no options", () => {
+    render(
+      <ContextMenu options={[]}>
+        <button>Card</button>
+      </ContextMenu>
+    );
+
+    fireEvent.contextMenu(screen.getByText("Card"));
+    expect(screen.queryByText("Add to wanted")).not.toBeInTheDocument();
+  });
+});
+
+describe("ContextMenu — long press", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("opens the menu after the long-press delay", () => {
+    render(
+      <ContextMenu options={makeOptions()} longPressMs={450}>
+        <button>Card</button>
+      </ContextMenu>
+    );
+    const card = screen.getByText("Card");
+
+    fireEvent.touchStart(card, { touches: [{ clientX: 5, clientY: 5 }] });
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.getByText("Add to wanted")).toBeInTheDocument();
+  });
+
+  it("suppresses the click that follows a long press", () => {
+    const onClick = vi.fn();
+    render(
+      <ContextMenu options={makeOptions()} longPressMs={450}>
+        <button onClick={onClick}>Card</button>
+      </ContextMenu>
+    );
+    const card = screen.getByText("Card");
+
+    fireEvent.touchStart(card, { touches: [{ clientX: 5, clientY: 5 }] });
+    act(() => vi.advanceTimersByTime(450));
+    fireEvent.click(card);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("cancels the long press when the finger moves past the threshold", () => {
+    render(
+      <ContextMenu options={makeOptions()} longPressMs={450}>
+        <button>Card</button>
+      </ContextMenu>
+    );
+    const card = screen.getByText("Card");
+
+    fireEvent.touchStart(card, { touches: [{ clientX: 5, clientY: 5 }] });
+    fireEvent.touchMove(card, { touches: [{ clientX: 50, clientY: 50 }] });
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText("Add to wanted")).not.toBeInTheDocument();
+  });
+
+  it("does not fire when the touch ends before the delay", () => {
+    render(
+      <ContextMenu options={makeOptions()} longPressMs={450}>
+        <button>Card</button>
+      </ContextMenu>
+    );
+    const card = screen.getByText("Card");
+
+    fireEvent.touchStart(card, { touches: [{ clientX: 5, clientY: 5 }] });
+    act(() => vi.advanceTimersByTime(200));
+    fireEvent.touchEnd(card);
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText("Add to wanted")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ReleaseGroupCard.test.tsx
+++ b/src/components/__tests__/ReleaseGroupCard.test.tsx
@@ -1,11 +1,39 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
 import ReleaseGroupCard from "../ReleaseGroupCard";
+import type { Option } from "../OptionMenu";
 import type { ReleaseGroup } from "../../types";
 
 const mockNavigate = vi.fn();
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
+}));
+
+let capturedOptions: Option[] | null = null;
+
+vi.mock("../ContextMenu", () => ({
+  default: ({
+    options,
+    children,
+  }: {
+    options: Option[];
+    children: ReactNode;
+  }) => {
+    capturedOptions = options;
+    return <div data-testid="context-menu">{children}</div>;
+  },
+}));
+
+vi.mock("../AlbumActionModals", () => ({ default: () => null }));
+
+const mockContextOptions: Option[] = [
+  { label: "Add to wanted", onClick: vi.fn() },
+  { label: "Go to artist", onClick: vi.fn() },
+];
+
+vi.mock("../../hooks/useAlbumActions", () => ({
+  default: () => ({ contextOptions: mockContextOptions }),
 }));
 
 const makeReleaseGroup = (
@@ -25,6 +53,7 @@ const makeReleaseGroup = (
 describe("ReleaseGroupCard", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    capturedOptions = null;
   });
 
   it("renders album title, artist name, and year", () => {
@@ -57,7 +86,7 @@ describe("ReleaseGroupCard", () => {
     expect(screen.queryByText(/^\d{4}$/)).not.toBeInTheDocument();
   });
 
-  it("navigates to the album page when the card is clicked", () => {
+  it("navigates to the album page when the desktop card is clicked", () => {
     render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
 
     fireEvent.click(screen.getByTestId("release-group-card"));
@@ -71,10 +100,16 @@ describe("ReleaseGroupCard", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/album/abc-123");
   });
 
-  it("does not render action buttons", () => {
+  it("passes the album's context options to the ContextMenu wrapper", () => {
+    render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
+
+    expect(screen.getByTestId("context-menu")).toBeInTheDocument();
+    expect(capturedOptions).toBe(mockContextOptions);
+  });
+
+  it("does not render inline action buttons", () => {
     render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
 
     expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("track-list")).not.toBeInTheDocument();
   });
 });

--- a/src/hooks/__tests__/useAlbumActions.test.ts
+++ b/src/hooks/__tests__/useAlbumActions.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from "@testing-library/react";
+import useAlbumActions from "../useAlbumActions";
+import { Permission } from "@shared/permissions";
+import type { ReleaseGroup } from "@/types";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+let mockUser: { id: number; permissions: number } | null = {
+  id: 1,
+  permissions: Permission.IMPORT,
+};
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+vi.mock("@/hooks/useLidarr", () => ({
+  default: () => ({ state: "idle", errorMsg: null, requestAlbum: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useWanted", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    addToWanted: vi.fn(),
+    removeFromWanted: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/usePurchase", () => ({
+  default: () => ({
+    state: "idle",
+    errorMsg: null,
+    record: vi.fn(),
+    remove: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useFollowedArtists", () => ({
+  default: () => ({
+    items: [],
+    loading: false,
+    error: null,
+    isFollowing: () => false,
+    follow: vi.fn(),
+    unfollow: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+const makeReleaseGroup = (
+  overrides: Partial<ReleaseGroup> = {}
+): ReleaseGroup => ({
+  id: "abc-123",
+  score: 100,
+  title: "Test Album",
+  "primary-type": "Album",
+  "first-release-date": "2023-05-10",
+  "artist-credit": [
+    { name: "Test Artist", artist: { id: "a1", name: "Test Artist" } },
+  ],
+  ...overrides,
+});
+
+const labels = (options: { label: string }[]) => options.map((o) => o.label);
+
+describe("useAlbumActions contextOptions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockUser = { id: 1, permissions: Permission.IMPORT };
+  });
+
+  it("includes wanted, purchase, upload and go-to-artist", () => {
+    const { result } = renderHook(() =>
+      useAlbumActions({ releaseGroup: makeReleaseGroup() })
+    );
+
+    expect(labels(result.current.contextOptions)).toEqual([
+      "Add to wanted",
+      "Mark as purchased",
+      "Upload files",
+      "Go to artist",
+    ]);
+  });
+
+  it("navigates to the artist from the go-to-artist option", () => {
+    const { result } = renderHook(() =>
+      useAlbumActions({ releaseGroup: makeReleaseGroup() })
+    );
+
+    const goToArtist = result.current.contextOptions.find(
+      (o) => o.label === "Go to artist"
+    );
+    goToArtist?.onClick();
+    expect(mockNavigate).toHaveBeenCalledWith("/artist/a1");
+  });
+
+  it("omits go-to-artist when the release has no artist MBID", () => {
+    const { result } = renderHook(() =>
+      useAlbumActions({
+        releaseGroup: makeReleaseGroup({ "artist-credit": [] }),
+      })
+    );
+
+    expect(labels(result.current.contextOptions)).not.toContain("Go to artist");
+  });
+
+  it("omits upload files without IMPORT permission", () => {
+    mockUser = { id: 2, permissions: Permission.REQUEST };
+    const { result } = renderHook(() =>
+      useAlbumActions({ releaseGroup: makeReleaseGroup() })
+    );
+
+    expect(labels(result.current.contextOptions)).not.toContain("Upload files");
+  });
+});

--- a/src/hooks/useAlbumActions.ts
+++ b/src/hooks/useAlbumActions.ts
@@ -27,6 +27,7 @@ export interface AlbumActions {
   disabled: boolean;
   options: Option[];
   menuOptions: Option[];
+  contextOptions: Option[];
   isWanted: boolean;
   wantedPending: boolean;
   toggleWanted: () => void;
@@ -112,43 +113,53 @@ export default function useAlbumActions({
     ? { label: "Remove from wanted", onClick: handleRemoveFromWanted }
     : { label: "Add to wanted", onClick: () => addToWanted(albumMbid) };
 
+  const markPurchasedOption: Option = {
+    label: "Mark as purchased",
+    onClick: () => setIsPriceModalOpen(true),
+  };
+
+  const uploadOption: Option = {
+    label: "Upload files",
+    onClick: () => navigate(`/library/upload?mbid=${albumMbid}`),
+  };
+
+  const followOption: Option | null = artistMbid
+    ? following
+      ? {
+          label: "Unfollow artist",
+          onClick: () => {
+            void unfollow(artistMbid);
+          },
+        }
+      : {
+          label: "Follow artist",
+          onClick: () => {
+            void follow(artistMbid, artistName);
+          },
+        }
+    : null;
+
+  const goToArtistOption: Option | null = artistMbid
+    ? {
+        label: "Go to artist",
+        onClick: () => navigate(`/artist/${artistMbid}`),
+      }
+    : null;
+
   const menuOptions: Option[] = [
-    ...(isPurchased
-      ? []
-      : [
-          {
-            label: "Mark as purchased",
-            onClick: () => setIsPriceModalOpen(true),
-          },
-        ]),
-    ...(canImport
-      ? [
-          {
-            label: "Upload files",
-            onClick: () => navigate(`/library/upload?mbid=${albumMbid}`),
-          },
-        ]
-      : []),
-    ...(artistMbid
-      ? [
-          following
-            ? {
-                label: "Unfollow artist",
-                onClick: () => {
-                  void unfollow(artistMbid);
-                },
-              }
-            : {
-                label: "Follow artist",
-                onClick: () => {
-                  void follow(artistMbid, artistName);
-                },
-              },
-        ]
-      : []),
+    ...(isPurchased ? [] : [markPurchasedOption]),
+    ...(canImport ? [uploadOption] : []),
+    ...(followOption ? [followOption] : []),
   ];
 
   const options: Option[] = [wantedOption, ...menuOptions];
+
+  const contextOptions: Option[] = [
+    wantedOption,
+    ...(isPurchased ? [] : [markPurchasedOption]),
+    ...(canImport ? [uploadOption] : []),
+    ...(goToArtistOption ? [goToArtistOption] : []),
+  ];
 
   return {
     albumMbid,
@@ -159,6 +170,7 @@ export default function useAlbumActions({
     disabled,
     options,
     menuOptions,
+    contextOptions,
     isWanted,
     wantedPending,
     toggleWanted,


### PR DESCRIPTION
Stacked on #180 — base is `feat/album-destination-page`, so this PR's diff is only the context-menu work. Retarget to `main` (or merge after) once #180 lands.

## What
Adds a generic `ContextMenu` wrapper that opens the options menu via **right-click on desktop** and **long-press on mobile**, reusing the existing dropdown's popup/sheet. First use: quick actions on album cards (add to wanted, mark as purchased, upload files, go to artist) without adding any visible clutter to the tile.

## How
- **`OptionMenu`** — extracted the popup/sheet presentation out of `OptionSelect` (floating-ui portal + `BottomSheet` + click-outside + `OptionList`). `OptionSelect` now just owns its ⋮ button and delegates; behavior unchanged.
- **`ContextMenu`** — `<ContextMenu options title disabled longPressMs>{children}</ContextMenu>`:
  - Desktop: `onContextMenu` → `preventDefault` → opens at the pointer via a floating-ui virtual element.
  - Mobile: `touchstart` starts a 450ms timer (cancelled on >10px move or early release); on fire → `haptics.medium()` + open the `BottomSheet`, and an `onClickCapture` guard swallows the trailing tap so the card doesn't also navigate. iOS callout/selection suppressed.
- **`useAlbumActions`** — adds a "Go to artist" option and a `contextOptions` list, sharing the option builders with the existing menu.
- **`ReleaseGroupCard`** — wraps its tile in `ContextMenu` + renders `AlbumActionModals`, so search / artist / album grids get quick actions. `WantedCard` is unchanged.

## Discoverability
Intentionally no visible affordance (keeps the tile clean, per the album-page design). A hover ⋮ could be a follow-up if we want the actions to be discoverable.

## Tests
New coverage for `ContextMenu` (right-click, long-press open, click suppression, move/early-release cancel, disabled/empty), `useAlbumActions` `contextOptions` + go-to-artist, and the rewired `ReleaseGroupCard`. `OptionSelect` tests pass unchanged. `pnpm typecheck`, `pnpm lint`, `pnpm test` (811), `pnpm test:server` (1008) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)