### PR TITLE
feat: refresh library data on tab change + requests refresh button

### DIFF
--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+interface RefreshButtonProps {
+  onRefresh: () => void | Promise<void>;
+  loading?: boolean;
+  ariaLabel?: string;
+}
+
+export default function RefreshButton({
+  onRefresh,
+  loading = false,
+  ariaLabel = "Refresh",
+}: RefreshButtonProps) {
+  const [pending, setPending] = useState(false);
+  const busy = loading || pending;
+
+  const handleClick = async () => {
+    setPending(true);
+    try {
+      await onRefresh();
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      className="px-3 py-1.5 text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+      aria-label={ariaLabel}
+    >
+      <svg
+        className={`w-3.5 h-3.5 ${busy ? "animate-spin" : ""}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+      Refresh
+    </button>
+  );
+}

--- a/src/components/__tests__/RefreshButton.test.tsx
+++ b/src/components/__tests__/RefreshButton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import RefreshButton from "../RefreshButton";
+
+describe("RefreshButton", () => {
+  it("renders with default aria-label", () => {
+    render(<RefreshButton onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+
+  it("renders with custom aria-label", () => {
+    render(<RefreshButton onRefresh={vi.fn()} ariaLabel="Refresh requests" />);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh requests" })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onRefresh when clicked", async () => {
+    const onRefresh = vi.fn();
+    render(<RefreshButton onRefresh={onRefresh} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("is disabled while loading prop is true", () => {
+    render(<RefreshButton onRefresh={vi.fn()} loading />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("is disabled and spinning while an async refresh is pending", async () => {
+    let resolveRefresh: () => void = () => {};
+    const onRefresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    render(<RefreshButton onRefresh={onRefresh} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button"));
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button.querySelector("svg")).toHaveClass("animate-spin");
+
+    resolveRefresh();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeEnabled();
+    });
+    expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+  });
+});

--- a/src/pages/LibraryPage/LibraryPage.tsx
+++ b/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/useAuth";
 import { hasPermission } from "@shared/permissions";
@@ -19,6 +19,9 @@ import PurchaseList from "./components/PurchaseList";
 import SpendingSummary from "./components/SpendingSummary";
 import FollowingList from "./components/FollowingList";
 import Skeleton from "@/components/Skeleton";
+import RefreshButton from "@/components/RefreshButton";
+
+type LibraryTab = "purchases" | "wanted" | "following" | "requests";
 
 function buildLibraryTabs(unseenCount: number): SettingsRoute[] {
   return [
@@ -109,6 +112,7 @@ export default function LibraryPage() {
     loading: wantedLoading,
     error: wantedError,
     removeItem: removeWantedItem,
+    refresh: refreshWanted,
   } = useWantedList();
   const {
     items: purchaseItems,
@@ -116,7 +120,29 @@ export default function LibraryPage() {
     loading: purchasesLoading,
     error: purchasesError,
     removeItem: removePurchaseItem,
+    refresh: refreshPurchases,
   } = usePurchaseList();
+
+  const activeTab: LibraryTab | null = isPurchasesTab
+    ? "purchases"
+    : isWantedTab
+      ? "wanted"
+      : isFollowingTab
+        ? "following"
+        : isRequestsTab
+          ? "requests"
+          : null;
+  const prevTabRef = useRef<LibraryTab | null>(null);
+
+  useEffect(() => {
+    if (activeTab === null || prevTabRef.current === activeTab) return;
+    const isFirstTab = prevTabRef.current === null;
+    prevTabRef.current = activeTab;
+    if (isFirstTab) return;
+    if (activeTab === "requests") void refresh();
+    else if (activeTab === "wanted") void refreshWanted();
+    else if (activeTab === "purchases") void refreshPurchases();
+  }, [activeTab, refresh, refreshWanted, refreshPurchases]);
 
   const handleFilterChange = useCallback((key: string, values: string[]) => {
     setFilters((prev) => ({ ...prev, [key]: values }));
@@ -150,6 +176,55 @@ export default function LibraryPage() {
     [refresh]
   );
 
+  const tabContent = (
+    <>
+      {isPurchasesTab && (
+        <PurchaseList
+          items={purchaseItems}
+          loading={purchasesLoading}
+          error={purchasesError}
+          onRemove={removePurchaseItem}
+        />
+      )}
+
+      {isWantedTab && (
+        <WantedList
+          items={wantedItems}
+          loading={wantedLoading}
+          error={wantedError}
+          onRemove={removeWantedItem}
+        />
+      )}
+
+      {isFollowingTab && <FollowingList />}
+
+      {isRequestsTab && (
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <RequestFilter values={filters} onChange={handleFilterChange} />
+            <RefreshButton onRefresh={refresh} ariaLabel="Refresh requests" />
+          </div>
+
+          <RequestList
+            requests={requests}
+            loading={loading}
+            error={error}
+            emptyMessage={
+              showMine ? "You haven't made any requests yet" : "No requests yet"
+            }
+            showUser={effectiveShowAll}
+            showActions={canManageRequests && effectiveShowAll}
+            showAdminDetails={isAdmin}
+            onApprove={approveRequest}
+            onDecline={declineRequest}
+            onSearch={handleSearch}
+            onUnmonitor={handleUnmonitor}
+          />
+        </div>
+      )}
+    </>
+  );
+
   if (isMobile && isSubTab) {
     return (
       <div className="space-y-6">
@@ -158,51 +233,7 @@ export default function LibraryPage() {
           parentRoute="/library"
           mobileBackLabel="Library"
         >
-          <>
-            {isPurchasesTab && (
-              <PurchaseList
-                items={purchaseItems}
-                loading={purchasesLoading}
-                error={purchasesError}
-                onRemove={removePurchaseItem}
-              />
-            )}
-
-            {isWantedTab && (
-              <WantedList
-                items={wantedItems}
-                loading={wantedLoading}
-                error={wantedError}
-                onRemove={removeWantedItem}
-              />
-            )}
-
-            {isFollowingTab && <FollowingList />}
-
-            {isRequestsTab && (
-              <div className="flex flex-col gap-6">
-                <RequestFilter values={filters} onChange={handleFilterChange} />
-
-                <RequestList
-                  requests={requests}
-                  loading={loading}
-                  error={error}
-                  emptyMessage={
-                    showMine
-                      ? "You haven't made any requests yet"
-                      : "No requests yet"
-                  }
-                  showUser={effectiveShowAll}
-                  showActions={canManageRequests && effectiveShowAll}
-                  showAdminDetails={isAdmin}
-                  onApprove={approveRequest}
-                  onDecline={declineRequest}
-                  onSearch={handleSearch}
-                  onUnmonitor={handleUnmonitor}
-                />
-              </div>
-            )}
-          </>
+          {tabContent}
         </SettingsTabs>
       </div>
     );
@@ -236,51 +267,7 @@ export default function LibraryPage() {
         parentRoute="/library"
         mobileBackLabel="Library"
       >
-        <>
-          {isPurchasesTab && (
-            <PurchaseList
-              items={purchaseItems}
-              loading={purchasesLoading}
-              error={purchasesError}
-              onRemove={removePurchaseItem}
-            />
-          )}
-
-          {isWantedTab && (
-            <WantedList
-              items={wantedItems}
-              loading={wantedLoading}
-              error={wantedError}
-              onRemove={removeWantedItem}
-            />
-          )}
-
-          {isFollowingTab && <FollowingList />}
-
-          {isRequestsTab && (
-            <div className="flex flex-col gap-6">
-              <RequestFilter values={filters} onChange={handleFilterChange} />
-
-              <RequestList
-                requests={requests}
-                loading={loading}
-                error={error}
-                emptyMessage={
-                  showMine
-                    ? "You haven't made any requests yet"
-                    : "No requests yet"
-                }
-                showUser={effectiveShowAll}
-                showActions={canManageRequests && effectiveShowAll}
-                showAdminDetails={isAdmin}
-                onApprove={approveRequest}
-                onDecline={declineRequest}
-                onSearch={handleSearch}
-                onUnmonitor={handleUnmonitor}
-              />
-            </div>
-          )}
-        </>
+        {tabContent}
       </SettingsTabs>
     </div>
   );

--- a/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
+++ b/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 import LibraryPage from "../LibraryPage";
 import { AuthContext, type AuthContextValue } from "@/context/authContextDef";
 import { Permission } from "@shared/permissions";
@@ -109,6 +109,32 @@ function renderWithAuth(permissions: number, route = "/library/requests") {
       </AuthContext.Provider>
     </MemoryRouter>
   );
+}
+
+function NavigateButton({ to, label }: { to: string; label: string }) {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      {label}
+    </button>
+  );
+}
+
+function renderWithNav(permissions: number, route = "/library/requests") {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthContext.Provider value={makeAuthContext(permissions)}>
+        <NavigateButton to="/library/wanted" label="go-wanted" />
+        <NavigateButton to="/library/requests" label="go-requests" />
+        <LibraryPage />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+function countFetchCalls(url: string): number {
+  return vi.mocked(fetch).mock.calls.filter(([calledUrl]) => calledUrl === url)
+    .length;
 }
 
 async function toggleFilterChip(
@@ -412,5 +438,82 @@ describe("LibraryPage", () => {
     expect(
       screen.queryByText("Supporting artists this month")
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a refresh button on the requests tab", async () => {
+    renderWithAuth(Permission.REQUEST);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh requests" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the requests refresh button on other tabs", () => {
+    renderWithAuth(Permission.REQUEST, "/library/wanted");
+
+    expect(
+      screen.queryByRole("button", { name: "Refresh requests" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("refetches requests when the refresh button is clicked", async () => {
+    renderWithAuth(Permission.ADMIN);
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Refresh requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(2);
+    });
+  });
+
+  it("refetches wanted list when switching to the wanted tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/requests");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-wanted" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(2);
+    });
+  });
+
+  it("refetches requests when switching back to the requests tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/wanted");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(2);
+    });
+  });
+
+  it("does not refetch when re-rendering on the same tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/requests");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(1);
+    });
+    expect(countFetchCalls("/api/requests")).toBe(1);
   });
 });

--- a/src/pages/SettingsPage/sections/logs/LogsSection.tsx
+++ b/src/pages/SettingsPage/sections/logs/LogsSection.tsx
@@ -4,6 +4,7 @@ import LogsTable from "./LogsTable";
 import FilterBar from "@/components/FilterBar";
 import Pagination from "@/components/Pagination";
 import Skeleton from "@/components/Skeleton";
+import RefreshButton from "@/components/RefreshButton";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -44,38 +45,17 @@ export default function LogsSection() {
     setPage(1);
   };
 
-  const handleRefresh = () => {
-    refetch();
-  };
-
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
           System Logs
         </h2>
-        <button
-          type="button"
-          onClick={handleRefresh}
-          disabled={loading}
-          className="px-3 py-1.5 text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors flex items-center gap-1.5"
-          aria-label="Refresh logs"
-        >
-          <svg
-            className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-            />
-          </svg>
-          Refresh
-        </button>
+        <RefreshButton
+          onRefresh={refetch}
+          loading={loading}
+          ariaLabel="Refresh logs"
+        />
       </div>
 
       <FilterBar


### PR DESCRIPTION
Closes #113

## Problem

All Library tab data (requests, wanted, purchases) was fetched once when the page mounted. Switching tabs only swapped conditional JSX, so hooks never re-ran and data went stale. There was also no way to manually refresh the requests list to see download progress.

## Changes

- **Refresh on tab change**: entering a tab now refetches its data via the hooks' existing `refresh` functions (skipped on initial mount, where hooks already fetch). Following tab already refreshed via remount.
- **Refresh button on Requests tab**: same pattern as the logs page, placed next to the filters.
- **Reusable `RefreshButton` component**: extracted from `LogsSection` (now reused there). Manages its own pending state so the spinner works even for hooks that don't toggle `loading` on refetch (`useRequests`).
- **Deduped LibraryPage tab content**: mobile and desktop branches rendered identical tab JSX twice; now a single `tabContent` variable.

## Tests

- New `RefreshButton.test.tsx`: labels, click handling, disabled/spinner states for both `loading` prop and pending async refresh.
- 6 new `LibraryPage` tests: button visible only on requests tab, click triggers refetch, tab switches refetch in both directions, no refetch on same-tab navigation.
- Full suites green: frontend (805), server (1002), typecheck, lint, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)