### PR TITLE
feat: validate import path + autocomplete (#151)

### DIFF
--- a/server/routes/settings.test.ts
+++ b/server/routes/settings.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetConfig = vi.fn();
 const mockSetConfig = vi.fn();
-const mockExistsSync = vi.fn();
+const mockValidateWritableDirectory = vi.fn();
+const mockListDirectorySuggestions = vi.fn();
 const mockClearPromotedAlbumCache = vi.fn();
 const mockTestLidarrConnection = vi.fn();
 const mockTestSlskdConnection = vi.fn();
@@ -12,9 +13,11 @@ vi.mock("../config", () => ({
   setConfig: (...args: unknown[]) => mockSetConfig(...args),
 }));
 
-vi.mock("fs", () => ({
-  default: { existsSync: (p: string) => mockExistsSync(p) },
-  existsSync: (p: string) => mockExistsSync(p),
+vi.mock("../services/pathValidation", () => ({
+  validateWritableDirectory: (...args: unknown[]) =>
+    mockValidateWritableDirectory(...args),
+  listDirectorySuggestions: (...args: unknown[]) =>
+    mockListDirectorySuggestions(...args),
 }));
 
 vi.mock("../promotedAlbum/getPromotedAlbum", () => ({
@@ -95,58 +98,83 @@ describe("PUT /settings", () => {
     });
   });
 
-  it("rejects non-existent import path", async () => {
-    mockExistsSync.mockReturnValue(false);
+  it("rejects an invalid import path", async () => {
+    mockValidateWritableDirectory.mockReturnValue({
+      valid: false,
+      error: 'Path "/bad/path" does not exist.',
+    });
     const res = await request(app)
       .put("/settings")
       .send({ importPath: "/bad/path" });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("/bad/path");
+    expect(mockSetConfig).not.toHaveBeenCalled();
   });
 
-  it("accepts existing import path", async () => {
-    mockExistsSync.mockReturnValue(true);
+  it("accepts a valid import path", async () => {
+    mockValidateWritableDirectory.mockReturnValue({ valid: true });
     const res = await request(app)
       .put("/settings")
       .send({ importPath: "/good/path" });
     expect(res.status).toBe(200);
+    expect(mockValidateWritableDirectory).toHaveBeenCalledWith("/good/path");
   });
 });
 
-describe("POST /settings/validate-import-path", () => {
+describe("POST /settings/validate-path", () => {
   it("returns valid for empty path", async () => {
     const res = await request(app)
-      .post("/settings/validate-import-path")
-      .send({ importPath: "" });
+      .post("/settings/validate-path")
+      .send({ path: "" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ valid: true });
+    expect(mockValidateWritableDirectory).not.toHaveBeenCalled();
+  });
+
+  it("returns valid for missing path", async () => {
+    const res = await request(app).post("/settings/validate-path").send({});
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ valid: true });
   });
 
-  it("returns valid for missing importPath", async () => {
+  it("returns valid for a writable directory", async () => {
+    mockValidateWritableDirectory.mockReturnValue({ valid: true });
     const res = await request(app)
-      .post("/settings/validate-import-path")
-      .send({});
+      .post("/settings/validate-path")
+      .send({ path: "/good/path" });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ valid: true });
+    expect(mockValidateWritableDirectory).toHaveBeenCalledWith("/good/path");
   });
 
-  it("returns valid for existing path", async () => {
-    mockExistsSync.mockReturnValue(true);
+  it("returns 400 with the validation error for an invalid path", async () => {
+    mockValidateWritableDirectory.mockReturnValue({
+      valid: false,
+      error: 'Tunearr does not have write permission for "/bad/path".',
+    });
     const res = await request(app)
-      .post("/settings/validate-import-path")
-      .send({ importPath: "/good/path" });
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ valid: true });
-    expect(mockExistsSync).toHaveBeenCalledWith("/good/path");
-  });
-
-  it("returns 400 for non-existent path", async () => {
-    mockExistsSync.mockReturnValue(false);
-    const res = await request(app)
-      .post("/settings/validate-import-path")
-      .send({ importPath: "/bad/path" });
+      .post("/settings/validate-path")
+      .send({ path: "/bad/path" });
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain("/bad/path");
+    expect(res.body.error).toContain("write permission");
+  });
+});
+
+describe("GET /settings/browse", () => {
+  it("returns directory suggestions", async () => {
+    mockListDirectorySuggestions.mockReturnValue(["/imports", "/images"]);
+    const res = await request(app).get("/settings/browse?path=/im");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ suggestions: ["/imports", "/images"] });
+    expect(mockListDirectorySuggestions).toHaveBeenCalledWith("/im");
+  });
+
+  it("returns empty suggestions when path is missing", async () => {
+    mockListDirectorySuggestions.mockReturnValue([]);
+    const res = await request(app).get("/settings/browse");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ suggestions: [] });
+    expect(mockListDirectorySuggestions).toHaveBeenCalledWith("");
   });
 });
 

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,7 +1,10 @@
 import type { Request, Response } from "express";
 import express from "express";
-import fs from "fs";
 import { getConfig, setConfig } from "../config";
+import {
+  listDirectorySuggestions,
+  validateWritableDirectory,
+} from "../services/pathValidation";
 import { clearPromotedAlbumCache } from "../promotedAlbum/getPromotedAlbum";
 import { clearPromotedArtistsCache } from "../promotedArtists/getPromotedArtists";
 import { testLidarrConnection } from "../services/settings";
@@ -28,10 +31,11 @@ router.get("/", (_req: Request, res: Response) => {
 router.put("/", (req: Request, res: Response) => {
   const partialConfig = req.body;
 
-  if (partialConfig.importPath && !fs.existsSync(partialConfig.importPath)) {
-    return res.status(400).json({
-      error: `Import path "${partialConfig.importPath}" does not exist. Make sure the directory is created or the volume is mounted.`,
-    });
+  if (partialConfig.importPath) {
+    const result = validateWritableDirectory(partialConfig.importPath);
+    if (!result.valid) {
+      return res.status(400).json({ error: result.error });
+    }
   }
 
   setConfig(partialConfig);
@@ -44,20 +48,24 @@ router.put("/", (req: Request, res: Response) => {
   res.json({ success: true });
 });
 
-router.post("/validate-import-path", (req: Request, res: Response) => {
-  const { importPath } = req.body;
+router.post("/validate-path", (req: Request, res: Response) => {
+  const { path: dirPath } = req.body;
 
-  if (!importPath) {
+  if (!dirPath) {
     return res.json({ valid: true });
   }
 
-  if (!fs.existsSync(importPath)) {
-    return res.status(400).json({
-      error: `Import path "${importPath}" does not exist. Make sure the directory is created or the volume is mounted.`,
-    });
+  const result = validateWritableDirectory(dirPath);
+  if (!result.valid) {
+    return res.status(400).json({ error: result.error });
   }
 
   res.json({ valid: true });
+});
+
+router.get("/browse", (req: Request, res: Response) => {
+  const dirPath = typeof req.query.path === "string" ? req.query.path : "";
+  res.json({ suggestions: listDirectorySuggestions(dirPath) });
 });
 
 router.post("/test", async (req: Request, res: Response) => {

--- a/server/services/pathValidation.test.ts
+++ b/server/services/pathValidation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  listDirectorySuggestions,
+  validateWritableDirectory,
+} from "./pathValidation";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "path-validation-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("validateWritableDirectory", () => {
+  it("returns valid for an existing writable directory", () => {
+    expect(validateWritableDirectory(tmpDir)).toEqual({ valid: true });
+  });
+
+  it("returns error for a non-existent path", () => {
+    const result = validateWritableDirectory(path.join(tmpDir, "missing"));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("does not exist");
+  });
+
+  it("returns error when the path is a file", () => {
+    const filePath = path.join(tmpDir, "file.txt");
+    fs.writeFileSync(filePath, "content");
+    const result = validateWritableDirectory(filePath);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("not a directory");
+  });
+
+  it("returns error for a non-writable directory", () => {
+    if (process.getuid?.() === 0) {
+      return;
+    }
+    const readOnlyDir = path.join(tmpDir, "readonly");
+    fs.mkdirSync(readOnlyDir, { mode: 0o555 });
+    const result = validateWritableDirectory(readOnlyDir);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("write permission");
+  });
+});
+
+describe("listDirectorySuggestions", () => {
+  beforeEach(() => {
+    fs.mkdirSync(path.join(tmpDir, "imports"));
+    fs.mkdirSync(path.join(tmpDir, "images"));
+    fs.mkdirSync(path.join(tmpDir, "downloads"));
+    fs.mkdirSync(path.join(tmpDir, ".hidden"));
+    fs.writeFileSync(path.join(tmpDir, "im-a-file.txt"), "content");
+  });
+
+  it("lists all visible directories for a path ending in a separator", () => {
+    const result = listDirectorySuggestions(tmpDir + path.sep);
+    expect(result).toEqual([
+      path.join(tmpDir, "downloads"),
+      path.join(tmpDir, "images"),
+      path.join(tmpDir, "imports"),
+    ]);
+  });
+
+  it("filters directories by the basename prefix", () => {
+    const result = listDirectorySuggestions(path.join(tmpDir, "im"));
+    expect(result).toEqual([
+      path.join(tmpDir, "images"),
+      path.join(tmpDir, "imports"),
+    ]);
+  });
+
+  it("matches prefix case-insensitively", () => {
+    const result = listDirectorySuggestions(path.join(tmpDir, "IM"));
+    expect(result).toEqual([
+      path.join(tmpDir, "images"),
+      path.join(tmpDir, "imports"),
+    ]);
+  });
+
+  it("excludes files from suggestions", () => {
+    const result = listDirectorySuggestions(path.join(tmpDir, "im"));
+    expect(result).not.toContain(path.join(tmpDir, "im-a-file.txt"));
+  });
+
+  it("hides dot directories unless the prefix starts with a dot", () => {
+    expect(listDirectorySuggestions(tmpDir + path.sep)).not.toContain(
+      path.join(tmpDir, ".hidden")
+    );
+    expect(listDirectorySuggestions(path.join(tmpDir, ".h"))).toEqual([
+      path.join(tmpDir, ".hidden"),
+    ]);
+  });
+
+  it("returns empty array for a non-existent base directory", () => {
+    expect(
+      listDirectorySuggestions(path.join(tmpDir, "missing", "sub"))
+    ).toEqual([]);
+  });
+
+  it("returns empty array for empty or relative input", () => {
+    expect(listDirectorySuggestions("")).toEqual([]);
+    expect(listDirectorySuggestions("relative/path")).toEqual([]);
+  });
+});

--- a/server/services/pathValidation.ts
+++ b/server/services/pathValidation.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+
+export interface PathValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+const MAX_SUGGESTIONS = 20;
+
+export function validateWritableDirectory(
+  dirPath: string
+): PathValidationResult {
+  if (!fs.existsSync(dirPath)) {
+    return {
+      valid: false,
+      error: `Path "${dirPath}" does not exist. Make sure the directory is created or the volume is mounted.`,
+    };
+  }
+
+  if (!fs.statSync(dirPath).isDirectory()) {
+    return {
+      valid: false,
+      error: `Path "${dirPath}" is not a directory.`,
+    };
+  }
+
+  try {
+    fs.accessSync(dirPath, fs.constants.W_OK);
+  } catch {
+    return {
+      valid: false,
+      error: `Tunearr does not have write permission for "${dirPath}".`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function listDirectorySuggestions(input: string): string[] {
+  if (!input || !path.isAbsolute(input)) {
+    return [];
+  }
+
+  const endsWithSeparator = input.endsWith(path.sep);
+  const baseDir = endsWithSeparator ? input : path.dirname(input);
+  const prefix = endsWithSeparator ? "" : path.basename(input);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name.toLowerCase().startsWith(prefix.toLowerCase()))
+    .filter((name) => prefix.startsWith(".") || !name.startsWith("."))
+    .sort()
+    .slice(0, MAX_SUGGESTIONS)
+    .map((name) => path.join(baseDir, name));
+}

--- a/src/components/PathInput.tsx
+++ b/src/components/PathInput.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  useFloating,
+  offset,
+  flip,
+  shift,
+  size,
+  autoUpdate,
+} from "@floating-ui/react-dom";
+
+type ValidationState =
+  | { status: "idle" }
+  | { status: "validating" }
+  | { status: "valid" }
+  | { status: "invalid"; error: string };
+
+interface CheckedPath {
+  path: string;
+  validation: ValidationState;
+  suggestions: string[];
+}
+
+interface PathInputProps {
+  value: string;
+  onChange: (path: string) => void;
+  placeholder?: string;
+  className?: string;
+  "data-testid"?: string;
+}
+
+const DEBOUNCE_MS = 400;
+
+async function validatePath(dirPath: string): Promise<ValidationState> {
+  try {
+    const res = await fetch("/api/settings/validate-path", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: dirPath }),
+    });
+    if (res.ok) {
+      return { status: "valid" };
+    }
+    const data = await res.json().catch(() => ({}));
+    return { status: "invalid", error: data.error || "Invalid path" };
+  } catch {
+    return { status: "idle" };
+  }
+}
+
+async function fetchSuggestions(dirPath: string): Promise<string[]> {
+  try {
+    const res = await fetch(
+      `/api/settings/browse?path=${encodeURIComponent(dirPath)}`
+    );
+    if (!res.ok) {
+      return [];
+    }
+    const data = await res.json();
+    return data.suggestions ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export default function PathInput({
+  value,
+  onChange,
+  placeholder,
+  className = "w-full",
+  "data-testid": dataTestId,
+}: PathInputProps) {
+  const [checked, setChecked] = useState<CheckedPath | null>(null);
+  const [open, setOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [referenceEl, setReferenceEl] = useState<HTMLElement | null>(null);
+  const [floatingEl, setFloatingEl] = useState<HTMLElement | null>(null);
+
+  const { floatingStyles } = useFloating({
+    elements: { reference: referenceEl, floating: floatingEl },
+    placement: "bottom-start",
+    transform: false,
+    middleware: [
+      offset(4),
+      flip(),
+      shift({ padding: 8 }),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      const [validation, dirs] = await Promise.all([
+        validatePath(value),
+        fetchSuggestions(value),
+      ]);
+      if (!cancelled) {
+        setChecked({
+          path: value,
+          validation,
+          suggestions: dirs.filter((dir) => dir !== value),
+        });
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [value]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const isCurrent = checked !== null && checked.path === value;
+  const validation: ValidationState = !value
+    ? { status: "idle" }
+    : isCurrent
+      ? checked.validation
+      : { status: "validating" };
+  const suggestions = isCurrent ? checked.suggestions : [];
+
+  const selectSuggestion = (suggestion: string) => {
+    onChange(suggestion);
+    setHighlightIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || suggestions.length === 0) {
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightIndex((prev) => (prev + 1) % suggestions.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightIndex(
+        (prev) => (prev - 1 + suggestions.length) % suggestions.length
+      );
+    } else if (e.key === "Enter" && highlightIndex >= 0) {
+      e.preventDefault();
+      selectSuggestion(suggestions[highlightIndex]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const showDropdown = open && suggestions.length > 0;
+
+  return (
+    <div ref={wrapperRef}>
+      <input
+        ref={setReferenceEl}
+        type="text"
+        value={value}
+        data-testid={dataTestId}
+        onChange={(e) => {
+          setOpen(true);
+          setHighlightIndex(-1);
+          onChange(e.target.value);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className={`${className} px-3 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-200 dark:placeholder-gray-600 focus:outline-none focus:border-amber-400 shadow-cartoon-md`}
+      />
+      {showDropdown && (
+        <div
+          ref={setFloatingEl}
+          style={floatingStyles}
+          className="z-10 bg-white dark:bg-gray-800 rounded-xl border-2 border-black p-2 shadow-cartoon-lg animate-dropdown-in origin-top"
+        >
+          <div className="max-h-64 overflow-y-auto space-y-1">
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={suggestion}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => selectSuggestion(suggestion)}
+                className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                  index === highlightIndex
+                    ? "bg-amber-300 text-black font-bold dark:text-black"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-amber-50 dark:hover:bg-gray-700"
+                }`}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      {validation.status === "validating" && (
+        <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
+          Checking path...
+        </p>
+      )}
+      {validation.status === "valid" && (
+        <p className="text-green-600 dark:text-green-400 text-xs mt-1">
+          Path exists and is writable
+        </p>
+      )}
+      {validation.status === "invalid" && (
+        <p className="text-red-600 dark:text-red-400 text-xs mt-1">
+          {validation.error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+interface RefreshButtonProps {
+  onRefresh: () => void | Promise<void>;
+  loading?: boolean;
+  ariaLabel?: string;
+}
+
+export default function RefreshButton({
+  onRefresh,
+  loading = false,
+  ariaLabel = "Refresh",
+}: RefreshButtonProps) {
+  const [pending, setPending] = useState(false);
+  const busy = loading || pending;
+
+  const handleClick = async () => {
+    setPending(true);
+    try {
+      await onRefresh();
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      className="px-3 py-1.5 text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+      aria-label={ariaLabel}
+    >
+      <svg
+        className={`w-3.5 h-3.5 ${busy ? "animate-spin" : ""}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+      Refresh
+    </button>
+  );
+}

--- a/src/components/__tests__/PathInput.test.tsx
+++ b/src/components/__tests__/PathInput.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import PathInput from "../PathInput";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, ok = true) {
+  return Promise.resolve({ ok, json: () => Promise.resolve(body) });
+}
+
+function mockEndpoints({
+  valid = true,
+  error = "",
+  suggestions = [],
+}: {
+  valid?: boolean;
+  error?: string;
+  suggestions?: string[];
+}) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.startsWith("/api/settings/browse")) {
+      return jsonResponse({ suggestions });
+    }
+    if (valid) {
+      return jsonResponse({ valid: true });
+    }
+    return jsonResponse({ error }, false);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PathInput", () => {
+  it("renders the current value", () => {
+    render(<PathInput value="/imports" onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue("/imports")).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing", () => {
+    const onChange = vi.fn();
+    render(<PathInput value="" onChange={onChange} placeholder="/imports" />);
+    fireEvent.change(screen.getByPlaceholderText("/imports"), {
+      target: { value: "/data" },
+    });
+    expect(onChange).toHaveBeenCalledWith("/data");
+  });
+
+  it("does not validate an empty value", () => {
+    render(<PathInput value="" onChange={vi.fn()} />);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("shows a success message for a valid path", async () => {
+    mockEndpoints({ valid: true });
+    render(<PathInput value="/imports" onChange={vi.fn()} />);
+
+    expect(screen.getByText("Checking path...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Path exists and is writable")
+    ).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/settings/validate-path",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ path: "/imports" }),
+      })
+    );
+  });
+
+  it("shows the error message for an invalid path", async () => {
+    mockEndpoints({ valid: false, error: 'Path "/bad" does not exist.' });
+    render(<PathInput value="/bad" onChange={vi.fn()} />);
+
+    expect(
+      await screen.findByText('Path "/bad" does not exist.')
+    ).toBeInTheDocument();
+  });
+
+  it("shows directory suggestions when focused", async () => {
+    mockEndpoints({ suggestions: ["/imports", "/images"] });
+    render(<PathInput value="/im" onChange={vi.fn()} />);
+
+    fireEvent.focus(screen.getByDisplayValue("/im"));
+    expect(await screen.findByText("/imports")).toBeInTheDocument();
+    expect(screen.getByText("/images")).toBeInTheDocument();
+  });
+
+  it("selects a suggestion on click", async () => {
+    const onChange = vi.fn();
+    mockEndpoints({ suggestions: ["/imports"] });
+    render(<PathInput value="/im" onChange={onChange} />);
+
+    fireEvent.focus(screen.getByDisplayValue("/im"));
+    fireEvent.click(await screen.findByText("/imports"));
+    expect(onChange).toHaveBeenCalledWith("/imports");
+  });
+
+  it("selects a suggestion with keyboard navigation", async () => {
+    const onChange = vi.fn();
+    mockEndpoints({ suggestions: ["/images", "/imports"] });
+    render(<PathInput value="/im" onChange={onChange} />);
+
+    const input = screen.getByDisplayValue("/im");
+    fireEvent.focus(input);
+    await screen.findByText("/images");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("/imports");
+  });
+
+  it("excludes the current value from suggestions", async () => {
+    mockEndpoints({ valid: true, suggestions: ["/imports"] });
+    render(<PathInput value="/imports" onChange={vi.fn()} />);
+
+    fireEvent.focus(screen.getByDisplayValue("/imports"));
+    await waitFor(() =>
+      expect(
+        screen.getByText("Path exists and is writable")
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/RefreshButton.test.tsx
+++ b/src/components/__tests__/RefreshButton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import RefreshButton from "../RefreshButton";
+
+describe("RefreshButton", () => {
+  it("renders with default aria-label", () => {
+    render(<RefreshButton onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+
+  it("renders with custom aria-label", () => {
+    render(<RefreshButton onRefresh={vi.fn()} ariaLabel="Refresh requests" />);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh requests" })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onRefresh when clicked", async () => {
+    const onRefresh = vi.fn();
+    render(<RefreshButton onRefresh={onRefresh} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("is disabled while loading prop is true", () => {
+    render(<RefreshButton onRefresh={vi.fn()} loading />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("is disabled and spinning while an async refresh is pending", async () => {
+    let resolveRefresh: () => void = () => {};
+    const onRefresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    render(<RefreshButton onRefresh={onRefresh} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button"));
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button.querySelector("svg")).toHaveClass("animate-spin");
+
+    resolveRefresh();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeEnabled();
+    });
+    expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+  });
+});

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -70,10 +70,10 @@ export function useOnboarding() {
   const preNextChecks: Partial<Record<StepId, () => Promise<void>>> = {
     import: async () => {
       if (!fields.importPath) return;
-      const res = await fetch("/api/settings/validate-import-path", {
+      const res = await fetch("/api/settings/validate-path", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ importPath: fields.importPath }),
+        body: JSON.stringify({ path: fields.importPath }),
       });
       if (!res.ok) {
         const data = await res.json();

--- a/src/pages/LibraryPage/LibraryPage.tsx
+++ b/src/pages/LibraryPage/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/useAuth";
 import { hasPermission } from "@shared/permissions";
@@ -19,6 +19,9 @@ import PurchaseList from "./components/PurchaseList";
 import SpendingSummary from "./components/SpendingSummary";
 import FollowingList from "./components/FollowingList";
 import Skeleton from "@/components/Skeleton";
+import RefreshButton from "@/components/RefreshButton";
+
+type LibraryTab = "purchases" | "wanted" | "following" | "requests";
 
 function buildLibraryTabs(unseenCount: number): SettingsRoute[] {
   return [
@@ -109,6 +112,7 @@ export default function LibraryPage() {
     loading: wantedLoading,
     error: wantedError,
     removeItem: removeWantedItem,
+    refresh: refreshWanted,
   } = useWantedList();
   const {
     items: purchaseItems,
@@ -116,7 +120,29 @@ export default function LibraryPage() {
     loading: purchasesLoading,
     error: purchasesError,
     removeItem: removePurchaseItem,
+    refresh: refreshPurchases,
   } = usePurchaseList();
+
+  const activeTab: LibraryTab | null = isPurchasesTab
+    ? "purchases"
+    : isWantedTab
+      ? "wanted"
+      : isFollowingTab
+        ? "following"
+        : isRequestsTab
+          ? "requests"
+          : null;
+  const prevTabRef = useRef<LibraryTab | null>(null);
+
+  useEffect(() => {
+    if (activeTab === null || prevTabRef.current === activeTab) return;
+    const isFirstTab = prevTabRef.current === null;
+    prevTabRef.current = activeTab;
+    if (isFirstTab) return;
+    if (activeTab === "requests") void refresh();
+    else if (activeTab === "wanted") void refreshWanted();
+    else if (activeTab === "purchases") void refreshPurchases();
+  }, [activeTab, refresh, refreshWanted, refreshPurchases]);
 
   const handleFilterChange = useCallback((key: string, values: string[]) => {
     setFilters((prev) => ({ ...prev, [key]: values }));
@@ -150,6 +176,55 @@ export default function LibraryPage() {
     [refresh]
   );
 
+  const tabContent = (
+    <>
+      {isPurchasesTab && (
+        <PurchaseList
+          items={purchaseItems}
+          loading={purchasesLoading}
+          error={purchasesError}
+          onRemove={removePurchaseItem}
+        />
+      )}
+
+      {isWantedTab && (
+        <WantedList
+          items={wantedItems}
+          loading={wantedLoading}
+          error={wantedError}
+          onRemove={removeWantedItem}
+        />
+      )}
+
+      {isFollowingTab && <FollowingList />}
+
+      {isRequestsTab && (
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <RequestFilter values={filters} onChange={handleFilterChange} />
+            <RefreshButton onRefresh={refresh} ariaLabel="Refresh requests" />
+          </div>
+
+          <RequestList
+            requests={requests}
+            loading={loading}
+            error={error}
+            emptyMessage={
+              showMine ? "You haven't made any requests yet" : "No requests yet"
+            }
+            showUser={effectiveShowAll}
+            showActions={canManageRequests && effectiveShowAll}
+            showAdminDetails={isAdmin}
+            onApprove={approveRequest}
+            onDecline={declineRequest}
+            onSearch={handleSearch}
+            onUnmonitor={handleUnmonitor}
+          />
+        </div>
+      )}
+    </>
+  );
+
   if (isMobile && isSubTab) {
     return (
       <div className="space-y-6">
@@ -158,51 +233,7 @@ export default function LibraryPage() {
           parentRoute="/library"
           mobileBackLabel="Library"
         >
-          <>
-            {isPurchasesTab && (
-              <PurchaseList
-                items={purchaseItems}
-                loading={purchasesLoading}
-                error={purchasesError}
-                onRemove={removePurchaseItem}
-              />
-            )}
-
-            {isWantedTab && (
-              <WantedList
-                items={wantedItems}
-                loading={wantedLoading}
-                error={wantedError}
-                onRemove={removeWantedItem}
-              />
-            )}
-
-            {isFollowingTab && <FollowingList />}
-
-            {isRequestsTab && (
-              <div className="flex flex-col gap-6">
-                <RequestFilter values={filters} onChange={handleFilterChange} />
-
-                <RequestList
-                  requests={requests}
-                  loading={loading}
-                  error={error}
-                  emptyMessage={
-                    showMine
-                      ? "You haven't made any requests yet"
-                      : "No requests yet"
-                  }
-                  showUser={effectiveShowAll}
-                  showActions={canManageRequests && effectiveShowAll}
-                  showAdminDetails={isAdmin}
-                  onApprove={approveRequest}
-                  onDecline={declineRequest}
-                  onSearch={handleSearch}
-                  onUnmonitor={handleUnmonitor}
-                />
-              </div>
-            )}
-          </>
+          {tabContent}
         </SettingsTabs>
       </div>
     );
@@ -236,51 +267,7 @@ export default function LibraryPage() {
         parentRoute="/library"
         mobileBackLabel="Library"
       >
-        <>
-          {isPurchasesTab && (
-            <PurchaseList
-              items={purchaseItems}
-              loading={purchasesLoading}
-              error={purchasesError}
-              onRemove={removePurchaseItem}
-            />
-          )}
-
-          {isWantedTab && (
-            <WantedList
-              items={wantedItems}
-              loading={wantedLoading}
-              error={wantedError}
-              onRemove={removeWantedItem}
-            />
-          )}
-
-          {isFollowingTab && <FollowingList />}
-
-          {isRequestsTab && (
-            <div className="flex flex-col gap-6">
-              <RequestFilter values={filters} onChange={handleFilterChange} />
-
-              <RequestList
-                requests={requests}
-                loading={loading}
-                error={error}
-                emptyMessage={
-                  showMine
-                    ? "You haven't made any requests yet"
-                    : "No requests yet"
-                }
-                showUser={effectiveShowAll}
-                showActions={canManageRequests && effectiveShowAll}
-                showAdminDetails={isAdmin}
-                onApprove={approveRequest}
-                onDecline={declineRequest}
-                onSearch={handleSearch}
-                onUnmonitor={handleUnmonitor}
-              />
-            </div>
-          )}
-        </>
+        {tabContent}
       </SettingsTabs>
     </div>
   );

--- a/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
+++ b/src/pages/LibraryPage/__tests__/LibraryPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 import LibraryPage from "../LibraryPage";
 import { AuthContext, type AuthContextValue } from "@/context/authContextDef";
 import { Permission } from "@shared/permissions";
@@ -109,6 +109,32 @@ function renderWithAuth(permissions: number, route = "/library/requests") {
       </AuthContext.Provider>
     </MemoryRouter>
   );
+}
+
+function NavigateButton({ to, label }: { to: string; label: string }) {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      {label}
+    </button>
+  );
+}
+
+function renderWithNav(permissions: number, route = "/library/requests") {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthContext.Provider value={makeAuthContext(permissions)}>
+        <NavigateButton to="/library/wanted" label="go-wanted" />
+        <NavigateButton to="/library/requests" label="go-requests" />
+        <LibraryPage />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+function countFetchCalls(url: string): number {
+  return vi.mocked(fetch).mock.calls.filter(([calledUrl]) => calledUrl === url)
+    .length;
 }
 
 async function toggleFilterChip(
@@ -412,5 +438,82 @@ describe("LibraryPage", () => {
     expect(
       screen.queryByText("Supporting artists this month")
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a refresh button on the requests tab", async () => {
+    renderWithAuth(Permission.REQUEST);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh requests" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the requests refresh button on other tabs", () => {
+    renderWithAuth(Permission.REQUEST, "/library/wanted");
+
+    expect(
+      screen.queryByRole("button", { name: "Refresh requests" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("refetches requests when the refresh button is clicked", async () => {
+    renderWithAuth(Permission.ADMIN);
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Refresh requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(2);
+    });
+  });
+
+  it("refetches wanted list when switching to the wanted tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/requests");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-wanted" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(2);
+    });
+  });
+
+  it("refetches requests when switching back to the requests tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/wanted");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(2);
+    });
+  });
+
+  it("does not refetch when re-rendering on the same tab", async () => {
+    renderWithNav(Permission.ADMIN, "/library/requests");
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/requests")).toBe(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "go-requests" }));
+
+    await waitFor(() => {
+      expect(countFetchCalls("/api/wanted")).toBe(1);
+    });
+    expect(countFetchCalls("/api/requests")).toBe(1);
   });
 });

--- a/src/pages/OnboardingPage/steps/ImportStep.tsx
+++ b/src/pages/OnboardingPage/steps/ImportStep.tsx
@@ -1,3 +1,4 @@
+import PathInput from "@/components/PathInput";
 import StepDescription from "../components/StepDescription";
 
 interface ImportStepProps {
@@ -16,13 +17,11 @@ export default function ImportStep({
         <label className="block text-sm font-medium text-gray-600 mb-1">
           Import Path
         </label>
-        <input
-          type="text"
-          data-testid="import-path-input"
+        <PathInput
           value={importPath}
-          onChange={(e) => onImportPathChange(e.target.value)}
+          onChange={onImportPathChange}
           placeholder="/imports"
-          className="w-full px-3 py-2 bg-white border-2 border-black rounded-lg text-gray-900 placeholder-gray-200 focus:outline-none focus:border-amber-400 shadow-cartoon-md"
+          data-testid="import-path-input"
         />
       </div>
       <div className="bg-amber-50 rounded-xl p-4 border-2 border-black shadow-cartoon-sm">

--- a/src/pages/SettingsPage/sections/integrations/ImportSection.tsx
+++ b/src/pages/SettingsPage/sections/integrations/ImportSection.tsx
@@ -1,3 +1,5 @@
+import PathInput from "@/components/PathInput";
+
 interface ImportSectionProps {
   importPath: string;
   onImportPathChange: (path: string) => void;
@@ -16,12 +18,11 @@ export default function ImportSection({
         <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">
           Import Path
         </label>
-        <input
-          type="text"
+        <PathInput
           value={importPath}
-          onChange={(e) => onImportPathChange(e.target.value)}
+          onChange={onImportPathChange}
           placeholder="/imports"
-          className="w-full sm:w-sm px-3 py-2 bg-white dark:bg-gray-800 border-2 border-black rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-200 dark:placeholder-gray-600 focus:outline-none focus:border-amber-400 shadow-cartoon-md"
+          className="w-full sm:w-sm"
         />
         <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">
           Shared volume path accessible by both this app and Lidarr for file

--- a/src/pages/SettingsPage/sections/integrations/__tests__/ImportSection.test.tsx
+++ b/src/pages/SettingsPage/sections/integrations/__tests__/ImportSection.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import ImportSection from "../ImportSection";
 
+const mockFetch = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ valid: true }) })
+);
+vi.stubGlobal("fetch", mockFetch);
+
 describe("ImportSection", () => {
   it("renders the current import path", () => {
     render(

--- a/src/pages/SettingsPage/sections/logs/LogsSection.tsx
+++ b/src/pages/SettingsPage/sections/logs/LogsSection.tsx
@@ -4,6 +4,7 @@ import LogsTable from "./LogsTable";
 import FilterBar from "@/components/FilterBar";
 import Pagination from "@/components/Pagination";
 import Skeleton from "@/components/Skeleton";
+import RefreshButton from "@/components/RefreshButton";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -44,38 +45,17 @@ export default function LogsSection() {
     setPage(1);
   };
 
-  const handleRefresh = () => {
-    refetch();
-  };
-
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
           System Logs
         </h2>
-        <button
-          type="button"
-          onClick={handleRefresh}
-          disabled={loading}
-          className="px-3 py-1.5 text-xs font-bold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-2 border-black rounded-lg shadow-cartoon-sm hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors flex items-center gap-1.5"
-          aria-label="Refresh logs"
-        >
-          <svg
-            className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-            />
-          </svg>
-          Refresh
-        </button>
+        <RefreshButton
+          onRefresh={refetch}
+          loading={loading}
+          ariaLabel="Refresh logs"
+        />
       </div>
 
       <FilterBar


### PR DESCRIPTION
## Summary

Implements #151: path validation in settings.

- **Import path**: validated for existence, directory type, and write permission (Tunearr writes uploads there via multer). Blocks save when invalid.
- **Inline feedback**: new `PathInput` component with debounced (400ms) validation shown under the input, used in both settings (Manual Import) and onboarding (Import step).
- **Autocomplete**: directory suggestions as you type via `GET /api/settings/browse` (dirs only, prefix match, dotdirs hidden unless prefix starts with `.`, capped at 20, admin-only).
- **slskd download path**: intentionally *not* validated. It's Lidarr's view of the shared volume — Tunearr never accesses that path (only relays it in SABnzbd emulation responses), and Lidarr surfaces its own warning when it's wrong. Any Tunearr-side check would be unreliable.

## Changes

- `server/services/pathValidation.ts` — `validateWritableDirectory` + `listDirectorySuggestions`
- `server/routes/settings.ts` — full validation on PUT; `/validate-import-path` replaced by generic `POST /validate-path`; new `GET /browse`
- `src/components/PathInput.tsx` — combobox with inline validation state, suggestion dropdown, keyboard navigation (floating-ui, matches existing `Dropdown` styling)
- Wired into `ImportSection` (settings) and `ImportStep` (onboarding); `useOnboarding` uses the new endpoint

## Testing

- `server/services/pathValidation.test.ts` — real tmp-dir tests for all validation and suggestion cases
- `server/routes/settings.test.ts` — rewritten path sections for new endpoints
- `src/components/__tests__/PathInput.test.tsx` — 9 cases: validation states, suggestions, click + keyboard selection
- Full suites green: 814 frontend + 1015 server tests, typecheck, lint, prettier

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)