### PR TITLE
feat: in-library indicators on album cards + track availability (#190)

### DIFF
--- a/server/api/lidarr/types.ts
+++ b/server/api/lidarr/types.ts
@@ -19,11 +19,18 @@ export type LidarrArtist = {
   folder: string;
 };
 
+export type LidarrAlbumStatistics = {
+  trackFileCount: number;
+  totalTrackCount: number;
+  percentOfTracks: number;
+};
+
 export type LidarrAlbum = {
   id: number;
   title: string;
   foreignAlbumId: string;
   monitored: boolean;
+  statistics?: LidarrAlbumStatistics;
   artist: {
     id: number;
     artistName: string;

--- a/server/services/lidarr/albums.test.ts
+++ b/server/services/lidarr/albums.test.ts
@@ -31,6 +31,25 @@ describe("getMonitoredAlbums", () => {
     }
   });
 
+  it("passes album statistics through untouched", async () => {
+    const statistics = {
+      trackFileCount: 9,
+      totalTrackCount: 12,
+      percentOfTracks: 75,
+    };
+    mockLidarrGet.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [{ id: 1, title: "OK Computer", monitored: true, statistics }],
+    });
+
+    const result = await getMonitoredAlbums();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data[0].statistics).toEqual(statistics);
+    }
+  });
+
   it("returns error when Lidarr API fails", async () => {
     mockLidarrGet.mockResolvedValue({
       ok: false,

--- a/src/components/ReleaseGroupCard.tsx
+++ b/src/components/ReleaseGroupCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import ImageWithShimmer from "./ImageWithShimmer";
 import ContextMenu from "./ContextMenu";
 import AlbumActionModals from "./AlbumActionModals";
+import { CheckIcon } from "./icons";
 import useHaptics from "../hooks/useHaptics";
 import useAlbumActions from "../hooks/useAlbumActions";
 import { pastelColorFromId } from "../utils/color";
@@ -10,10 +11,12 @@ import { ReleaseGroup } from "../types";
 
 interface ReleaseGroupCardProps {
   releaseGroup: ReleaseGroup;
+  inLibrary?: boolean;
 }
 
 export default function ReleaseGroupCard({
   releaseGroup,
+  inLibrary,
 }: ReleaseGroupCardProps) {
   const navigate = useNavigate();
   const haptics = useHaptics();
@@ -45,6 +48,15 @@ export default function ReleaseGroupCard({
     </div>
   ) : null;
 
+  const inLibraryBadge = inLibrary ? (
+    <span
+      className="absolute bottom-1.5 right-1.5 flex items-center justify-center w-5 h-5 bg-amber-300 text-black rounded-full border-2 border-black shadow-cartoon-sm"
+      aria-label="In Library"
+    >
+      <CheckIcon className="w-3 h-3" />
+    </span>
+  ) : null;
+
   return (
     <ContextMenu options={actions.contextOptions} title={albumTitle}>
       <button
@@ -58,6 +70,7 @@ export default function ReleaseGroupCard({
           style={{ backgroundColor: pastelBg }}
         >
           {coverImage}
+          {inLibraryBadge}
         </div>
         <div className="flex-1 min-w-0 px-4 py-3">
           <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-base truncate">
@@ -83,6 +96,7 @@ export default function ReleaseGroupCard({
           style={{ backgroundColor: pastelBg }}
         >
           {coverImage}
+          {inLibraryBadge}
         </div>
         <div className="p-3 border-t-2 border-black">
           <h3 className="text-gray-900 dark:text-gray-100 font-semibold text-sm truncate mb-1">

--- a/src/components/__tests__/ReleaseGroupCard.test.tsx
+++ b/src/components/__tests__/ReleaseGroupCard.test.tsx
@@ -112,4 +112,16 @@ describe("ReleaseGroupCard", () => {
 
     expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();
   });
+
+  it("shows the In Library badge on both card variants when inLibrary", () => {
+    render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} inLibrary />);
+
+    expect(screen.getAllByLabelText("In Library")).toHaveLength(2);
+  });
+
+  it("hides the In Library badge when not in library", () => {
+    render(<ReleaseGroupCard releaseGroup={makeReleaseGroup()} />);
+
+    expect(screen.queryByLabelText("In Library")).not.toBeInTheDocument();
+  });
 });

--- a/src/hooks/__tests__/useLibraryAlbums.test.ts
+++ b/src/hooks/__tests__/useLibraryAlbums.test.ts
@@ -75,4 +75,109 @@ describe("useLibraryAlbums", () => {
 
     expect(result.current.isAlbumInLibrary("any-mbid")).toBe(false);
   });
+
+  describe("getTrackAvailability", () => {
+    it("returns available and total track counts from statistics", async () => {
+      const albums = [
+        {
+          id: 1,
+          title: "OK Computer",
+          foreignAlbumId: "rg-1",
+          monitored: true,
+          statistics: {
+            trackFileCount: 9,
+            totalTrackCount: 12,
+            percentOfTracks: 75,
+          },
+        },
+      ];
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(albums), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      const { result } = renderHook(() => useLibraryAlbums());
+
+      await waitFor(() => {
+        expect(result.current.isAlbumInLibrary("rg-1")).toBe(true);
+      });
+
+      expect(result.current.getTrackAvailability("rg-1")).toEqual({
+        available: 9,
+        total: 12,
+      });
+    });
+
+    it("returns null when the album has no statistics", async () => {
+      const albums = [
+        { id: 1, title: "Kid A", foreignAlbumId: "rg-2", monitored: true },
+      ];
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(albums), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      const { result } = renderHook(() => useLibraryAlbums());
+
+      await waitFor(() => {
+        expect(result.current.isAlbumInLibrary("rg-2")).toBe(true);
+      });
+
+      expect(result.current.getTrackAvailability("rg-2")).toBeNull();
+    });
+
+    it("returns null when total track count is zero", async () => {
+      const albums = [
+        {
+          id: 1,
+          title: "Empty",
+          foreignAlbumId: "rg-3",
+          monitored: true,
+          statistics: {
+            trackFileCount: 0,
+            totalTrackCount: 0,
+            percentOfTracks: 0,
+          },
+        },
+      ];
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(albums), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      const { result } = renderHook(() => useLibraryAlbums());
+
+      await waitFor(() => {
+        expect(result.current.isAlbumInLibrary("rg-3")).toBe(true);
+      });
+
+      expect(result.current.getTrackAvailability("rg-3")).toBeNull();
+    });
+
+    it("returns null for albums not in the library", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      const { result } = renderHook(() => useLibraryAlbums());
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalled();
+      });
+
+      expect(result.current.getTrackAvailability("rg-unknown")).toBeNull();
+    });
+  });
 });

--- a/src/hooks/useLibraryAlbums.ts
+++ b/src/hooks/useLibraryAlbums.ts
@@ -5,6 +5,16 @@ type LibraryAlbum = {
   title: string;
   foreignAlbumId: string;
   monitored: boolean;
+  statistics?: {
+    trackFileCount: number;
+    totalTrackCount: number;
+    percentOfTracks: number;
+  };
+};
+
+export type TrackAvailability = {
+  available: number;
+  total: number;
 };
 
 export default function useLibraryAlbums() {
@@ -24,13 +34,21 @@ export default function useLibraryAlbums() {
     load();
   }, []);
 
-  const libraryAlbumMbids = useMemo(
-    () => new Set(libraryAlbums.map((a) => a.foreignAlbumId)),
+  const libraryAlbumsByMbid = useMemo(
+    () => new Map(libraryAlbums.map((a) => [a.foreignAlbumId, a])),
     [libraryAlbums]
   );
 
   const isAlbumInLibrary = (albumMbid: string) =>
-    libraryAlbumMbids.has(albumMbid);
+    libraryAlbumsByMbid.has(albumMbid);
 
-  return { isAlbumInLibrary };
+  const getTrackAvailability = (
+    albumMbid: string
+  ): TrackAvailability | null => {
+    const stats = libraryAlbumsByMbid.get(albumMbid)?.statistics;
+    if (!stats || stats.totalTrackCount === 0) return null;
+    return { available: stats.trackFileCount, total: stats.totalTrackCount };
+  };
+
+  return { isAlbumInLibrary, getTrackAvailability };
 }

--- a/src/pages/AlbumPage/AlbumPage.tsx
+++ b/src/pages/AlbumPage/AlbumPage.tsx
@@ -12,7 +12,7 @@ export default function AlbumPage() {
   const { mbid } = useParams<{ mbid: string }>();
   const { album, moreFromArtist, loading, error } =
     useReleaseGroupDetails(mbid);
-  const { isAlbumInLibrary } = useLibraryAlbums();
+  const { isAlbumInLibrary, getTrackAvailability } = useLibraryAlbums();
   const { isAlbumWanted } = useWantedAlbums();
 
   const otherReleases = useMemo(
@@ -41,6 +41,7 @@ export default function AlbumPage() {
         album={album}
         inLibrary={isAlbumInLibrary(album.mbid)}
         initialWanted={isAlbumWanted(album.mbid)}
+        trackAvailability={getTrackAvailability(album.mbid)}
       />
 
       <AlbumTracklist albumMbid={album.mbid} artistName={album.artistName} />
@@ -49,6 +50,7 @@ export default function AlbumPage() {
         <ReleaseSectionGrid
           title="More from this artist"
           items={otherReleases}
+          isAlbumInLibrary={isAlbumInLibrary}
         />
       )}
     </div>

--- a/src/pages/AlbumPage/__tests__/AlbumPage.test.tsx
+++ b/src/pages/AlbumPage/__tests__/AlbumPage.test.tsx
@@ -15,7 +15,11 @@ vi.mock("@/hooks/useReleaseGroupDetails", () => ({
 }));
 
 vi.mock("@/hooks/useLibraryAlbums", () => ({
-  default: () => ({ isAlbumInLibrary: (id: string) => id === "rg-1" }),
+  default: () => ({
+    isAlbumInLibrary: (id: string) => id === "rg-1",
+    getTrackAvailability: (id: string) =>
+      id === "rg-1" ? { available: 9, total: 12 } : null,
+  }),
 }));
 
 vi.mock("@/hooks/useWantedAlbums", () => ({
@@ -27,15 +31,22 @@ vi.mock("../components/AlbumHeader", () => ({
     album,
     inLibrary,
     initialWanted,
+    trackAvailability,
   }: {
     album: AlbumDetails;
     inLibrary?: boolean;
     initialWanted?: boolean;
+    trackAvailability?: { available: number; total: number } | null;
   }) => (
     <div
       data-testid="album-header"
       data-in-library={inLibrary}
       data-wanted={initialWanted}
+      data-track-availability={
+        trackAvailability
+          ? `${trackAvailability.available}/${trackAvailability.total}`
+          : undefined
+      }
     >
       {album.title}
     </div>
@@ -129,6 +140,7 @@ describe("AlbumPage", () => {
     const header = screen.getByTestId("album-header");
     expect(header).toHaveAttribute("data-in-library", "true");
     expect(header).toHaveAttribute("data-wanted", "true");
+    expect(header).toHaveAttribute("data-track-availability", "9/12");
   });
 
   it("renders more-from-artist excluding the current album", () => {

--- a/src/pages/AlbumPage/components/AlbumHeader.tsx
+++ b/src/pages/AlbumPage/components/AlbumHeader.tsx
@@ -3,12 +3,14 @@ import { Link } from "react-router-dom";
 import ImageWithShimmer from "@/components/ImageWithShimmer";
 import { pastelColorFromId } from "@/utils/color";
 import AlbumActions from "./AlbumActions";
+import type { TrackAvailability } from "@/hooks/useLibraryAlbums";
 import type { AlbumDetails, ReleaseGroup } from "@/types";
 
 interface AlbumHeaderProps {
   album: AlbumDetails;
   inLibrary?: boolean;
   initialWanted?: boolean;
+  trackAvailability?: TrackAvailability | null;
 }
 
 function toReleaseGroup(album: AlbumDetails): ReleaseGroup {
@@ -40,6 +42,7 @@ export default function AlbumHeader({
   album,
   inLibrary,
   initialWanted,
+  trackAvailability,
 }: AlbumHeaderProps) {
   const [coverError, setCoverError] = useState(false);
   const pastelBg = useMemo(() => pastelColorFromId(album.mbid), [album.mbid]);
@@ -63,9 +66,16 @@ export default function AlbumHeader({
       </div>
 
       <div className="flex-1 min-w-0">
-        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
-          {album.title}
-        </h1>
+        <div className="flex items-center gap-2 flex-wrap">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+            {album.title}
+          </h1>
+          {inLibrary && trackAvailability && (
+            <span className="text-xs bg-amber-300 text-black px-1.5 py-0.5 rounded-full border-2 border-black font-bold shadow-cartoon-sm whitespace-nowrap">
+              {trackAvailability.available}/{trackAvailability.total} tracks
+            </span>
+          )}
+        </div>
         {album.artistMbid ? (
           <Link
             to={`/artist/${album.artistMbid}`}

--- a/src/pages/AlbumPage/components/__tests__/AlbumHeader.test.tsx
+++ b/src/pages/AlbumPage/components/__tests__/AlbumHeader.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AlbumHeader from "../AlbumHeader";
@@ -24,10 +25,13 @@ const makeAlbum = (overrides: Partial<AlbumDetails> = {}): AlbumDetails => ({
   ...overrides,
 });
 
-function renderHeader(album: AlbumDetails) {
+function renderHeader(
+  album: AlbumDetails,
+  props: Partial<ComponentProps<typeof AlbumHeader>> = {}
+) {
   return render(
     <MemoryRouter>
-      <AlbumHeader album={album} />
+      <AlbumHeader album={album} {...props} />
     </MemoryRouter>
   );
 }
@@ -68,5 +72,29 @@ describe("AlbumHeader", () => {
     expect(screen.getByTestId("album-actions")).toBeInTheDocument();
     expect(receivedReleaseGroup?.id).toBe("rg-1");
     expect(receivedReleaseGroup?.["artist-credit"][0]?.artist.id).toBe("a1");
+  });
+
+  it("shows track availability when the album is in the library", () => {
+    renderHeader(makeAlbum(), {
+      inLibrary: true,
+      trackAvailability: { available: 9, total: 12 },
+    });
+
+    expect(screen.getByText("9/12 tracks")).toBeInTheDocument();
+  });
+
+  it("hides track availability when the album is not in the library", () => {
+    renderHeader(makeAlbum(), {
+      inLibrary: false,
+      trackAvailability: { available: 9, total: 12 },
+    });
+
+    expect(screen.queryByText("9/12 tracks")).not.toBeInTheDocument();
+  });
+
+  it("hides track availability when no statistics are known", () => {
+    renderHeader(makeAlbum(), { inLibrary: true, trackAvailability: null });
+
+    expect(screen.queryByText(/tracks/)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/ArtistPage/ArtistPage.tsx
+++ b/src/pages/ArtistPage/ArtistPage.tsx
@@ -23,11 +23,6 @@ export default function ArtistPage() {
     [releaseGroups, mbid]
   );
 
-  const hasLibraryAlbum = useMemo(
-    () => releaseGroups.some((rg) => isAlbumInLibrary(rg.id)),
-    [releaseGroups, isAlbumInLibrary]
-  );
-
   if (loading) return <ArtistPageSkeleton />;
 
   if (error || !artist) {
@@ -45,7 +40,10 @@ export default function ArtistPage() {
 
   return (
     <div>
-      <ArtistHeader artist={artist} inLibrary={hasLibraryAlbum} />
+      <ArtistHeader
+        artist={artist}
+        inLibrary={isArtistInLibrary(mbid ?? "", artist.name)}
+      />
 
       {sections.length === 0 ? (
         <p className="text-gray-400 dark:text-gray-500 text-sm">
@@ -58,6 +56,7 @@ export default function ArtistPage() {
             title={section.title}
             items={section.items}
             defaultExpanded={index === 0}
+            isAlbumInLibrary={isAlbumInLibrary}
           />
         ))
       )}

--- a/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
+++ b/src/pages/ArtistPage/__tests__/ArtistPage.test.tsx
@@ -21,9 +21,11 @@ vi.mock("@/hooks/useLibraryAlbums", () => ({
   }),
 }));
 
+let mockLibraryArtistMbids: string[];
+
 vi.mock("@/hooks/useLibraryArtists", () => ({
   default: () => ({
-    isArtistInLibrary: (mbid: string) => mbid === "sim-owned",
+    isArtistInLibrary: (mbid: string) => mockLibraryArtistMbids.includes(mbid),
   }),
 }));
 
@@ -34,8 +36,16 @@ vi.mock("@/hooks/useSimilarArtists", () => ({
 }));
 
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({ releaseGroup }: { releaseGroup: ReleaseGroup }) => (
-    <div data-testid={`rg-${releaseGroup.id}`}>{releaseGroup.title}</div>
+  default: ({
+    releaseGroup,
+    inLibrary,
+  }: {
+    releaseGroup: ReleaseGroup;
+    inLibrary?: boolean;
+  }) => (
+    <div data-testid={`rg-${releaseGroup.id}`} data-in-library={inLibrary}>
+      {releaseGroup.title}
+    </div>
   ),
 }));
 
@@ -71,6 +81,7 @@ beforeEach(() => {
     error: null,
   };
   mockSimilar = { artists: [], loading: false };
+  mockLibraryArtistMbids = ["sim-owned"];
 });
 
 describe("ArtistPage", () => {
@@ -119,7 +130,23 @@ describe("ArtistPage", () => {
     expect(screen.getByText("Drill EP")).toBeInTheDocument();
   });
 
-  it("shows the In Library badge when the artist owns an album", () => {
+  it("shows the In Library badge when the artist is in the library", () => {
+    mockState.artist = { mbid: "a1", name: "Radiohead" };
+    mockLibraryArtistMbids = ["a1"];
+    renderPage();
+
+    expect(screen.getByText("In Library")).toBeInTheDocument();
+  });
+
+  it("hides the In Library badge when only an album matches the library", () => {
+    mockState.artist = { mbid: "a1", name: "Radiohead" };
+    mockState.releaseGroups = [makeRg({ id: "in-lib", title: "Owned" })];
+    renderPage();
+
+    expect(screen.queryByText("In Library")).not.toBeInTheDocument();
+  });
+
+  it("marks discography albums that are in the library", () => {
     mockState.artist = { mbid: "a1", name: "Radiohead" };
     mockState.releaseGroups = [
       makeRg({ id: "in-lib", title: "Owned" }),
@@ -127,7 +154,14 @@ describe("ArtistPage", () => {
     ];
     renderPage();
 
-    expect(screen.getByText("In Library")).toBeInTheDocument();
+    expect(screen.getByTestId("rg-in-lib")).toHaveAttribute(
+      "data-in-library",
+      "true"
+    );
+    expect(screen.getByTestId("rg-missing")).toHaveAttribute(
+      "data-in-library",
+      "false"
+    );
   });
 
   it("shows an empty message when the artist has no releases", () => {

--- a/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
+++ b/src/pages/ArtistPage/components/ReleaseSectionGrid.tsx
@@ -9,12 +9,14 @@ interface ReleaseSectionGridProps {
   title: string;
   items: ReleaseGroup[];
   defaultExpanded?: boolean;
+  isAlbumInLibrary?: (albumMbid: string) => boolean;
 }
 
 export default function ReleaseSectionGrid({
   title,
   items,
   defaultExpanded = false,
+  isAlbumInLibrary,
 }: ReleaseSectionGridProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -49,7 +51,10 @@ export default function ReleaseSectionGrid({
                 } as React.CSSProperties
               }
             >
-              <ReleaseGroupCard releaseGroup={rg} />
+              <ReleaseGroupCard
+                releaseGroup={rg}
+                inLibrary={isAlbumInLibrary?.(rg.id)}
+              />
             </div>
           ))}
         </div>

--- a/src/pages/ArtistPage/components/__tests__/ReleaseSectionGrid.test.tsx
+++ b/src/pages/ArtistPage/components/__tests__/ReleaseSectionGrid.test.tsx
@@ -4,8 +4,16 @@ import ReleaseSectionGrid from "../ReleaseSectionGrid";
 import type { ReleaseGroup } from "@/types";
 
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({ releaseGroup }: { releaseGroup: ReleaseGroup }) => (
-    <div data-testid={`rg-${releaseGroup.id}`}>{releaseGroup.title}</div>
+  default: ({
+    releaseGroup,
+    inLibrary,
+  }: {
+    releaseGroup: ReleaseGroup;
+    inLibrary?: boolean;
+  }) => (
+    <div data-testid={`rg-${releaseGroup.id}`} data-in-library={inLibrary}>
+      {releaseGroup.title}
+    </div>
   ),
 }));
 
@@ -63,6 +71,26 @@ describe("ReleaseSectionGrid", () => {
 
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByText("First Album")).not.toBeInTheDocument();
+  });
+
+  it("passes per-album library status to the cards", () => {
+    render(
+      <ReleaseSectionGrid
+        title="Albums"
+        items={items}
+        defaultExpanded
+        isAlbumInLibrary={(mbid) => mbid === "one"}
+      />
+    );
+
+    expect(screen.getByTestId("rg-one")).toHaveAttribute(
+      "data-in-library",
+      "true"
+    );
+    expect(screen.getByTestId("rg-two")).toHaveAttribute(
+      "data-in-library",
+      "false"
+    );
   });
 
   it("rotates the chevron when expanded", async () => {

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -5,6 +5,8 @@ import ReleaseGroupCard from "@/components/ReleaseGroupCard";
 import ArtistCard from "@/pages/DiscoverPage/components/ArtistCard";
 import Skeleton from "@/components/Skeleton";
 import useSearch from "@/hooks/useSearch";
+import useLibraryAlbums from "@/hooks/useLibraryAlbums";
+import useLibraryArtists from "@/hooks/useLibraryArtists";
 
 const DEAL_ROTATIONS = [-4, 3.5, -3, 4.5, -3.5, 3];
 
@@ -63,6 +65,8 @@ function SearchSkeletons() {
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { albums, artists, loading, error, search } = useSearch();
+  const { isAlbumInLibrary } = useLibraryAlbums();
+  const { isArtistInLibrary } = useLibraryArtists();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const query = searchParams.get("q") ?? "";
@@ -117,6 +121,7 @@ export default function SearchPage() {
                     name={artist.name}
                     mbid={artist.mbid}
                     imageUrl={artist.imageUrl}
+                    inLibrary={isArtistInLibrary(artist.mbid, artist.name)}
                   />
                 ))}
               </div>
@@ -138,7 +143,10 @@ export default function SearchPage() {
                       } as React.CSSProperties
                     }
                   >
-                    <ReleaseGroupCard releaseGroup={rg} />
+                    <ReleaseGroupCard
+                      releaseGroup={rg}
+                      inLibrary={isAlbumInLibrary(rg.id)}
+                    />
                   </div>
                 ))}
               </div>

--- a/src/pages/SearchPage/__tests__/SearchPage.test.tsx
+++ b/src/pages/SearchPage/__tests__/SearchPage.test.tsx
@@ -11,6 +11,9 @@ let mockSearchState: {
   search: ReturnType<typeof vi.fn>;
 };
 
+let libraryAlbumMbids: string[] = [];
+let libraryArtistMbids: string[] = [];
+
 vi.mock("@/hooks/useSearch", () => ({
   default: () => mockSearchState,
 }));
@@ -19,15 +22,38 @@ vi.mock("@/hooks/useNavigateToArtist", () => ({
   default: () => ({ go: vi.fn(), resolving: false }),
 }));
 
+vi.mock("@/hooks/useLibraryAlbums", () => ({
+  default: () => ({
+    isAlbumInLibrary: (mbid: string) => libraryAlbumMbids.includes(mbid),
+    getTrackAvailability: () => null,
+  }),
+}));
+
+vi.mock("@/hooks/useLibraryArtists", () => ({
+  default: () => ({
+    isArtistInLibrary: (mbid: string) => libraryArtistMbids.includes(mbid),
+  }),
+}));
+
 vi.mock("@/components/ReleaseGroupCard", () => ({
-  default: ({ releaseGroup }: { releaseGroup: { title: string } }) => (
-    <div data-testid="release-card">{releaseGroup.title}</div>
+  default: ({
+    releaseGroup,
+    inLibrary,
+  }: {
+    releaseGroup: { title: string };
+    inLibrary?: boolean;
+  }) => (
+    <div data-testid="release-card" data-in-library={String(!!inLibrary)}>
+      {releaseGroup.title}
+    </div>
   ),
 }));
 
 vi.mock("@/pages/DiscoverPage/components/ArtistCard", () => ({
-  default: ({ name }: { name: string }) => (
-    <div data-testid="artist-card">{name}</div>
+  default: ({ name, inLibrary }: { name: string; inLibrary?: boolean }) => (
+    <div data-testid="artist-card" data-in-library={String(!!inLibrary)}>
+      {name}
+    </div>
   ),
 }));
 
@@ -61,6 +87,8 @@ beforeEach(() => {
     error: null,
     search: vi.fn(),
   };
+  libraryAlbumMbids = [];
+  libraryArtistMbids = [];
 });
 
 describe("SearchPage", () => {
@@ -114,6 +142,32 @@ describe("SearchPage", () => {
   it("shows the no-results state when a query returns nothing", () => {
     renderSearchPage("nonexistent");
     expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  it("marks only the album results that are in the library", () => {
+    libraryAlbumMbids = ["rg-1"];
+    mockSearchState.albums = [
+      makeAlbum("rg-1", "OK Computer"),
+      makeAlbum("rg-2", "Kid A"),
+    ];
+
+    renderSearchPage("Radiohead");
+
+    const cards = screen.getAllByTestId("release-card");
+    expect(cards.map((c) => c.dataset.inLibrary)).toEqual(["true", "false"]);
+  });
+
+  it("marks only the artist results that are in the library", () => {
+    libraryArtistMbids = ["a1"];
+    mockSearchState.artists = [
+      { mbid: "a1", name: "Radiohead" },
+      { mbid: "a2", name: "Thom Yorke" },
+    ];
+
+    renderSearchPage("Radiohead");
+
+    const cards = screen.getAllByTestId("artist-card");
+    expect(cards.map((c) => c.dataset.inLibrary)).toEqual(["true", "false"]);
   });
 
   it("clears input and focuses it on search:reset event", () => {


### PR DESCRIPTION
Closes #190

## What

- **Album-card checkmarks** — `ReleaseGroupCard` now accepts an optional `inLibrary` prop and renders the same amber checkmark badge used on Discover artist cards (both mobile and desktop variants). Wired through `ReleaseSectionGrid` on the artist page discography and the "More from this artist" section on the album page.
- **Artist header badge source fix** — the artist page "In Library" pill is now driven by `isArtistInLibrary(mbid, name)` (same source as the artist buttons) instead of being derived from monitored albums. An artist monitored in Lidarr with no monitored albums now shows the badge consistently with the Discover cards.
- **Album track availability** — `LidarrAlbum` now captures Lidarr's `statistics` field (already present in the `/album` response, no extra API calls). `useLibraryAlbums` exposes `getTrackAvailability(mbid)`, and the album page header shows a "9/12 tracks" pill next to the title for in-library albums. Hidden when statistics are missing or the total track count is 0.

## Out of scope

Per-song indicators on the tracklist — would require a new `/api/lidarr/tracks` endpoint plus fuzzy matching between the MusicBrainz tracklist and Lidarr's selected release. Left for a follow-up if wanted.

## Testing

- Frontend: 862 tests pass (new coverage for badge rendering, grid pass-through, header availability pill, `getTrackAvailability`)
- Server: 1022 tests pass (statistics passthrough in `getMonitoredAlbums`)
- Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)