### PR TITLE
feat: definition-driven bento grid for the Discover page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,9 @@ Full-stack TypeScript app: React 19 frontend + Express 5 backend. Vite proxies `
 
 **Frontend (`/src`):** React with React Router DOM, Tailwind CSS v4 for styling. Path aliases: `@/*` maps to `./src/*`, `@shared/*` maps to `./shared/*`. Pages live under `src/pages/` with co-located sub-components:
 
-- `/` — DiscoverPage (similar artists from Plex/Last.fm)
+- `/` — DiscoverPage (promoted album + promoted artists recommendations)
 - `/search` — SearchPage (MusicBrainz album search)
-- `/explore` — ExplorationPage
-- `/library` — LibraryPage (subroutes: `/library/wanted`, `/library/requests`)
+- `/library` — LibraryPage (subroutes: `/library/purchases`, `/library/wanted`, `/library/requests`, `/library/following`)
 - `/library/upload` — UploadPage (manual import)
 - `/settings` — SettingsLayout (subroutes: general, integrations, recommendations, users, logs, notifications with email/webhook sub-pages)
 - `/onboarding` — OnboardingPage (first-run setup)
@@ -46,13 +45,13 @@ Shared components in `src/components/`. Frontend uses plain `fetch()` to relativ
 **Backend (`/server`):** Express with four layers:
 
 - **Service layer** (`/server/api/`) — each external API has a `<name>/` directory (e.g., `lidarr/`, `lastfm/`, `musicbrainz/`, `plex/`, `deezer/`, `apple/`, `slskd/`) containing `types.ts`, usually `config.ts`, and function files. Service configs read from `getConfig()` lazily at request time (no restart needed after settings change).
-- **Route layer** (`/server/routes/`) — maps Express routes to service functions. Routes mount at `/api/settings`, `/api/lidarr`, `/api/musicbrainz`, `/api/lastfm`, `/api/plex`, `/api/promoted-album`, `/api/torznab`, `/api/sabnzbd`, `/api/auth`, `/api/users`, `/api/requests`, `/api/wanted`, `/api/exploration`, `/api/logs`. The Lidarr router is an aggregator that mounts sub-routers (add, albums, artists, history, import, queue, search, wanted, qualityProfile, rootPath, metadataProfile, autoSetup).
+- **Route layer** (`/server/routes/`) — maps Express routes to service functions. Routes mount at `/api/settings`, `/api/lidarr`, `/api/musicbrainz`, `/api/lastfm`, `/api/plex`, `/api/promoted-album`, `/api/promoted-artists`, `/api/torznab`, `/api/sabnzbd`, `/api/auth`, `/api/users`, `/api/requests`, `/api/purchases`, `/api/wanted`, `/api/followed`, `/api/logs`. The Lidarr router is an aggregator that mounts sub-routers (add, albums, artists, history, import, queue, search, wanted, qualityProfile, rootPath, metadataProfile, autoSetup).
 - **Middleware** (`/server/middleware/`) — `errorHandler.ts` (global Express error handler), `rateLimiter.ts` (MusicBrainz 1 req/sec), `requireAuth.ts` (session cookie authentication), `requirePermission.ts` (bitfield permission checks), `ApiError.ts` (typed error class with HTTP status).
 - **Auth layer** (`/server/auth/`) — session management (`sessions.ts`), password hashing (`password.ts`), user CRUD (`users.ts`). Sessions stored in SQLite alongside users.
 
-**Database (`/server/db/`):** SQLite via better-sqlite3 + TypeORM. Entities in `/server/db/entity/`: `User`, `Session`, `Request`, `Config`, `WantedItem`. Migrations in `/server/db/migration/` run automatically on startup (`migrationsRun: true`). WAL mode enabled. Access the singleton DataSource via `getDataSource()` after `initializeDatabase()`.
+**Database (`/server/db/`):** SQLite via better-sqlite3 + TypeORM. Entities in `/server/db/entity/`: `User`, `Session`, `Request`, `Config`, `WantedItem`, `FollowedArtist`, `SeenRelease`, `Purchase`, `UserProfile`, `UserSignalEvent`. Migrations in `/server/db/migration/` run automatically on startup (`migrationsRun: true`). WAL mode enabled. Access the singleton DataSource via `getDataSource()` after `initializeDatabase()`.
 
-**Auth & permissions:** Bitfield-based permission system in `shared/permissions.ts` (shared between frontend and backend). Permissions: `ADMIN`, `MANAGE_USERS`, `MANAGE_REQUESTS`, `REQUEST`, `AUTO_APPROVE`, `REQUEST_VIEW`. `ADMIN` bypasses all checks. Auth uses HTTP-only session cookies (`tunearr_session`). Some routes (torznab, sabnzbd, logs, exploration, auth) are public; most require `requireAuth` middleware. Each user's Plex OAuth token is stored on the `User` entity (`plex_token` column) and used for per-user Plex media server queries. The server config only stores `plexUrl` (shared), not the token. `AuthUser` includes `hasPlexToken` (sent to frontend) and `plexToken` (server-side only). The `/api/auth/store-plex-token` endpoint updates a user's stored Plex token.
+**Auth & permissions:** Bitfield-based permission system in `shared/permissions.ts` (shared between frontend and backend). Permissions: `ADMIN`, `MANAGE_USERS`, `MANAGE_REQUESTS`, `REQUEST`, `AUTO_APPROVE`, `REQUEST_VIEW`. `ADMIN` bypasses all checks. Auth uses HTTP-only session cookies (`tunearr_session`). Some routes (torznab, sabnzbd, logs, auth) are public; most require `requireAuth` middleware. Each user's Plex OAuth token is stored on the `User` entity (`plex_token` column) and used for per-user Plex media server queries. The server config only stores `plexUrl` (shared), not the token. `AuthUser` includes `hasPlexToken` (sent to frontend) and `plexToken` (server-side only). The `/api/auth/store-plex-token` endpoint updates a user's stored Plex token.
 
 **Soulseek integration via torznab/SABnzbd emulation (`/server/api/slskd/`):** The app integrates Soulseek (via an external slskd daemon) into Lidarr's standard indexer+download-client workflow by emulating two services:
 

--- a/src/components/ImageWithShimmer.tsx
+++ b/src/components/ImageWithShimmer.tsx
@@ -4,6 +4,8 @@ interface ImageWithShimmerProps {
   src: string;
   alt: string;
   className?: string;
+  /** Extra classes for the wrapper div, e.g. to make it fill its parent */
+  wrapperClassName?: string;
   onError?: () => void;
 }
 
@@ -11,6 +13,7 @@ export default function ImageWithShimmer({
   src,
   alt,
   className = "",
+  wrapperClassName = "",
   onError,
 }: ImageWithShimmerProps) {
   const [isLoading, setIsLoading] = useState(true);
@@ -31,7 +34,7 @@ export default function ImageWithShimmer({
   }
 
   return (
-    <div className="relative">
+    <div className={`relative ${wrapperClassName}`}>
       {isLoading && (
         <div
           className={`absolute inset-0 bg-gray-200 dark:bg-gray-700 animate-shimmer ${className}`}

--- a/src/pages/DiscoverPage/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage/DiscoverPage.tsx
@@ -1,42 +1,14 @@
-import usePromotedAlbum from "@/hooks/usePromotedAlbum";
-import usePromotedArtists from "@/hooks/usePromotedArtists";
-import PromotedAlbum from "./components/PromotedAlbum";
-import PromotedArtists from "./components/PromotedArtists";
+import DiscoverGrid from "./components/DiscoverGrid";
+import { SECTION_DEFINITIONS } from "./sections";
 
 export default function DiscoverPage() {
-  const {
-    promotedAlbum,
-    loading: promotedLoading,
-    refresh: refreshPromotedAlbum,
-  } = usePromotedAlbum();
-
-  const {
-    promotedArtists,
-    loading: artistsLoading,
-    refresh: refreshArtists,
-  } = usePromotedArtists();
-
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
         Discover
       </h1>
 
-      {(promotedAlbum || promotedLoading) && (
-        <PromotedAlbum
-          data={promotedAlbum}
-          loading={promotedLoading}
-          onRefresh={refreshPromotedAlbum}
-        />
-      )}
-
-      {(promotedArtists || artistsLoading) && (
-        <PromotedArtists
-          data={promotedArtists}
-          loading={artistsLoading}
-          onRefresh={refreshArtists}
-        />
-      )}
+      <DiscoverGrid definitions={SECTION_DEFINITIONS} />
     </div>
   );
 }

--- a/src/pages/DiscoverPage/__tests__/layout.test.ts
+++ b/src/pages/DiscoverPage/__tests__/layout.test.ts
@@ -1,0 +1,89 @@
+import { resolveLayout, sectionSlotClasses } from "../layout";
+import type { SectionDefinition } from "../types";
+
+function makeDefinition(
+  overrides: Partial<SectionDefinition> = {}
+): SectionDefinition {
+  return {
+    id: "spotlight",
+    span: { cols: 6, rows: 1 },
+    desktopOrder: 1,
+    mobileOrder: 1,
+    whenEmpty: "hide",
+    Component: () => null,
+    ...overrides,
+  };
+}
+
+describe("resolveLayout", () => {
+  it("sorts sections by desktopOrder", () => {
+    const first = makeDefinition({ id: "artists", desktopOrder: 2 });
+    const second = makeDefinition({ id: "spotlight", desktopOrder: 1 });
+
+    const resolved = resolveLayout([first, second], {});
+
+    expect(resolved.map((r) => r.definition.id)).toEqual([
+      "spotlight",
+      "artists",
+    ]);
+  });
+
+  it("treats unreported sections as loading and keeps them visible", () => {
+    const resolved = resolveLayout([makeDefinition()], {});
+    expect(resolved[0].hidden).toBe(false);
+  });
+
+  it("hides an empty section when whenEmpty is hide", () => {
+    const resolved = resolveLayout([makeDefinition()], { spotlight: "empty" });
+    expect(resolved[0].hidden).toBe(true);
+  });
+
+  it("hides an errored section when whenEmpty is hide", () => {
+    const resolved = resolveLayout([makeDefinition()], { spotlight: "error" });
+    expect(resolved[0].hidden).toBe(true);
+  });
+
+  it("keeps an empty section visible when whenEmpty is keep", () => {
+    const resolved = resolveLayout([makeDefinition({ whenEmpty: "keep" })], {
+      spotlight: "empty",
+    });
+    expect(resolved[0].hidden).toBe(false);
+  });
+
+  it("keeps ready sections visible", () => {
+    const resolved = resolveLayout([makeDefinition()], { spotlight: "ready" });
+    expect(resolved[0].hidden).toBe(false);
+  });
+
+  it("does not mutate the definitions array", () => {
+    const definitions = [
+      makeDefinition({ id: "artists", desktopOrder: 2 }),
+      makeDefinition({ id: "spotlight", desktopOrder: 1 }),
+    ];
+
+    resolveLayout(definitions, {});
+
+    expect(definitions[0].id).toBe("artists");
+  });
+});
+
+describe("sectionSlotClasses", () => {
+  it("returns only the hidden class for hidden sections", () => {
+    expect(sectionSlotClasses(makeDefinition(), true)).toBe("hidden");
+  });
+
+  it("maps column and row spans to grid classes", () => {
+    const classes = sectionSlotClasses(
+      makeDefinition({ span: { cols: 4, rows: 2 } }),
+      false
+    );
+
+    expect(classes).toContain("lg:col-span-4");
+    expect(classes).toContain("lg:row-span-2");
+  });
+
+  it("includes the mobile order class", () => {
+    const classes = sectionSlotClasses(makeDefinition(), false);
+    expect(classes).toContain("max-lg:[order:var(--order-mobile)]");
+  });
+});

--- a/src/pages/DiscoverPage/__tests__/useReportSectionStatus.test.ts
+++ b/src/pages/DiscoverPage/__tests__/useReportSectionStatus.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react";
+import useReportSectionStatus, {
+  deriveSectionStatus,
+} from "../useReportSectionStatus";
+import type { SectionDataState } from "../useReportSectionStatus";
+
+describe("deriveSectionStatus", () => {
+  it("returns loading while loading, even if empty", () => {
+    expect(
+      deriveSectionStatus({ loading: true, error: false, empty: true })
+    ).toBe("loading");
+  });
+
+  it("returns error over empty once loading finishes", () => {
+    expect(
+      deriveSectionStatus({ loading: false, error: true, empty: true })
+    ).toBe("error");
+  });
+
+  it("returns empty when loaded without data", () => {
+    expect(
+      deriveSectionStatus({ loading: false, error: false, empty: true })
+    ).toBe("empty");
+  });
+
+  it("returns ready when loaded with data", () => {
+    expect(
+      deriveSectionStatus({ loading: false, error: false, empty: false })
+    ).toBe("ready");
+  });
+});
+
+describe("useReportSectionStatus", () => {
+  it("reports the derived status on mount", () => {
+    const onStatusChange = vi.fn();
+
+    renderHook(() =>
+      useReportSectionStatus(onStatusChange, {
+        loading: true,
+        error: false,
+        empty: true,
+      })
+    );
+
+    expect(onStatusChange).toHaveBeenCalledTimes(1);
+    expect(onStatusChange).toHaveBeenCalledWith("loading");
+  });
+
+  it("reports again when the derived status changes", () => {
+    const onStatusChange = vi.fn();
+
+    const { rerender } = renderHook(
+      (state: SectionDataState) =>
+        useReportSectionStatus(onStatusChange, state),
+      { initialProps: { loading: true, error: false, empty: true } }
+    );
+    rerender({ loading: false, error: false, empty: false });
+
+    expect(onStatusChange).toHaveBeenNthCalledWith(1, "loading");
+    expect(onStatusChange).toHaveBeenNthCalledWith(2, "ready");
+  });
+
+  it("does not re-report when flags change but the status does not", () => {
+    const onStatusChange = vi.fn();
+
+    const { rerender } = renderHook(
+      (state: SectionDataState) =>
+        useReportSectionStatus(onStatusChange, state),
+      { initialProps: { loading: false, error: false, empty: false } }
+    );
+    rerender({ loading: false, error: false, empty: false });
+
+    expect(onStatusChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/DiscoverPage/components/DiscoverGrid.tsx
+++ b/src/pages/DiscoverPage/components/DiscoverGrid.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+import { resolveLayout } from "../layout";
+import SectionSlot from "./SectionSlot";
+import type {
+  SectionDefinition,
+  SectionId,
+  SectionStatus,
+  SectionStatusMap,
+} from "../types";
+
+interface DiscoverGridProps {
+  definitions: readonly SectionDefinition[];
+}
+
+export default function DiscoverGrid({ definitions }: DiscoverGridProps) {
+  const [statuses, setStatuses] = useState<SectionStatusMap>({});
+
+  const handleStatusChange = useCallback(
+    (id: SectionId, status: SectionStatus) => {
+      setStatuses((prev) =>
+        prev[id] === status ? prev : { ...prev, [id]: status }
+      );
+    },
+    []
+  );
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-6 gap-6">
+      {resolveLayout(definitions, statuses).map(({ definition, hidden }) => (
+        <SectionSlot
+          key={definition.id}
+          definition={definition}
+          hidden={hidden}
+          onStatusChange={handleStatusChange}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { PromotedAlbumData } from "@/hooks/usePromotedAlbum";
 import MonitorButton from "@/components/MonitorButton";
@@ -6,7 +6,8 @@ import OptionSelect from "@/components/OptionSelect";
 import useHaptics from "@/hooks/useHaptics";
 import PurchaseLinksModal from "@/components/PurchaseLinksModal";
 import RecommendationTraceModal from "./RecommendationTraceModal";
-import { ChevronDownIcon, MusicalNoteIcon } from "@/components/icons";
+import TracksPreviewModal from "./TracksPreviewModal";
+import { MusicalNoteIcon } from "@/components/icons";
 import SectionHeader from "./SectionHeader";
 import ShuffleButton from "./ShuffleButton";
 import useLidarr from "@/hooks/useLidarr";
@@ -15,7 +16,6 @@ import useReleaseTracks from "@/hooks/useReleaseTracks";
 import useAudioPreview from "@/hooks/useAudioPreview";
 import ImageWithShimmer from "@/components/ImageWithShimmer";
 import Skeleton from "@/components/Skeleton";
-import TrackList from "@/components/TrackList";
 import { pastelColorFromId } from "@/utils/color";
 import { getMonitorState } from "@/utils/monitorState";
 import type { Option } from "@/components/OptionSelect";
@@ -37,8 +37,6 @@ export default function PromotedAlbum({
   const [isAnimating, setIsAnimating] = useState(false);
   const [isTracksOpen, setIsTracksOpen] = useState(false);
   const [fetchedMbid, setFetchedMbid] = useState<string | null>(null);
-  const [expandHeight, setExpandHeight] = useState(0);
-  const expandContentRef = useRef<HTMLDivElement>(null);
 
   const haptics = useHaptics();
   const { state, errorMsg, requestAlbum, reset: resetLidarr } = useLidarr();
@@ -60,16 +58,6 @@ export default function PromotedAlbum({
   const album = data?.album;
   const inLibrary = data?.inLibrary ?? false;
   const pastelBg = album ? pastelColorFromId(album.mbid) : "hsl(200, 70%, 85%)";
-
-  useEffect(() => {
-    const el = expandContentRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(() => {
-      setExpandHeight(el.offsetHeight);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
 
   const isWanted = wantedState === "wanted";
   const wantedOptions: Option[] = [
@@ -114,23 +102,22 @@ export default function PromotedAlbum({
     }, 300);
   };
 
-  const handleTracksToggle = () => {
-    if (
-      !isTracksOpen &&
-      album &&
-      fetchedMbid !== album.mbid &&
-      !tracksLoading
-    ) {
+  const handleTracksOpen = () => {
+    if (album && fetchedMbid !== album.mbid && !tracksLoading) {
       fetchTracks(album.mbid, album.artistName);
       setFetchedMbid(album.mbid);
     }
-    if (isTracksOpen) stop();
-    setIsTracksOpen(!isTracksOpen);
+    setIsTracksOpen(true);
+  };
+
+  const handleTracksClose = () => {
+    stop();
+    setIsTracksOpen(false);
   };
 
   return (
     <>
-      <div>
+      <div className="h-full flex flex-col">
         <SectionHeader
           title="Recommended for you"
           action={
@@ -144,15 +131,15 @@ export default function PromotedAlbum({
         />
 
         <div
-          className={`bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden transition-all duration-300 ${
+          className={`flex-1 bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden flex flex-col transition-all duration-300 ${
             isAnimating
               ? "opacity-0 -translate-x-4 scale-95"
               : "opacity-100 translate-x-0 scale-100"
           }`}
         >
-          <div className="flex flex-col sm:flex-row">
+          <div className="flex-1 flex flex-col sm:flex-row">
             <div
-              className="w-full sm:w-48 aspect-square sm:aspect-auto sm:h-48 flex-shrink-0 overflow-hidden"
+              className="w-full sm:w-48 aspect-square sm:aspect-auto sm:min-h-48 flex-shrink-0 overflow-hidden"
               style={{ backgroundColor: pastelBg }}
             >
               {loading ? (
@@ -216,19 +203,12 @@ export default function PromotedAlbum({
 
                   <div className="mt-3 flex items-center justify-between">
                     <button
-                      onClick={handleTracksToggle}
+                      onClick={handleTracksOpen}
                       className="flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
-                      aria-label={
-                        isTracksOpen ? "Hide tracks" : "Preview tracks"
-                      }
+                      aria-label="Preview tracks"
                     >
                       <MusicalNoteIcon className="w-3.5 h-3.5" />
-                      <span>{isTracksOpen ? "Hide tracks" : "Preview"}</span>
-                      <ChevronDownIcon
-                        className={`w-3.5 h-3.5 transition-transform duration-200 ${
-                          isTracksOpen ? "rotate-180" : ""
-                        }`}
-                      />
+                      <span>Preview</span>
                     </button>
                     <div className="flex items-center gap-1.5">
                       <OptionSelect
@@ -246,29 +226,22 @@ export default function PromotedAlbum({
               ) : null}
             </div>
           </div>
-
-          <div
-            className="overflow-hidden transition-[height] duration-300"
-            style={{
-              height: isTracksOpen ? expandHeight : 0,
-              transitionTimingFunction: "cubic-bezier(0.34, 1.3, 0.64, 1)",
-            }}
-            data-testid="tracks-expand"
-          >
-            <div ref={expandContentRef}>
-              <div className="border-t-2 border-black px-4 py-3 overlay-scrollbar max-h-64 overflow-y-auto">
-                <TrackList
-                  media={media}
-                  loading={tracksLoading}
-                  error={tracksError}
-                  onTogglePreview={toggle}
-                  isTrackPlaying={isTrackPlaying}
-                />
-              </div>
-            </div>
-          </div>
         </div>
       </div>
+
+      {album && (
+        <TracksPreviewModal
+          isOpen={isTracksOpen}
+          onClose={handleTracksClose}
+          albumName={album.name}
+          artistName={album.artistName}
+          media={media}
+          loading={tracksLoading}
+          error={tracksError}
+          onTogglePreview={toggle}
+          isTrackPlaying={isTrackPlaying}
+        />
+      )}
 
       {album && (
         <PurchaseLinksModal

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -131,7 +131,7 @@ export default function PromotedAlbum({
         />
 
         <div
-          className={`flex-1 bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden flex flex-col transition-all duration-300 ${
+          className={`relative flex-1 lg:min-h-80 bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden flex flex-col transition-all duration-300 ${
             isAnimating
               ? "opacity-0 -translate-x-4 scale-95"
               : "opacity-100 translate-x-0 scale-100"
@@ -139,7 +139,7 @@ export default function PromotedAlbum({
         >
           <div className="flex-1 flex flex-col sm:flex-row">
             <div
-              className="w-full sm:w-48 aspect-square sm:aspect-auto sm:min-h-48 flex-shrink-0 overflow-hidden"
+              className="w-full sm:w-48 lg:w-auto aspect-square sm:aspect-auto sm:h-48 lg:h-auto flex-shrink-0 overflow-hidden lg:absolute lg:inset-0"
               style={{ backgroundColor: pastelBg }}
             >
               {loading ? (
@@ -151,13 +151,15 @@ export default function PromotedAlbum({
                     src={album.coverUrl}
                     alt={`${album.name} cover`}
                     className="w-full h-full object-cover"
+                    wrapperClassName="w-full h-full"
                     onError={() => setCoverError(true)}
                   />
                 )
               )}
+              <div className="hidden lg:block absolute inset-0 bg-gradient-to-t from-black/80 via-black/35 to-transparent pointer-events-none" />
             </div>
 
-            <div className="flex-1 p-4 flex flex-col justify-between min-w-0">
+            <div className="flex-1 p-4 flex flex-col justify-between min-w-0 lg:relative lg:justify-end lg:p-5">
               {loading ? (
                 <div className="space-y-3">
                   <Skeleton className="h-6 w-3/4" />
@@ -167,10 +169,10 @@ export default function PromotedAlbum({
               ) : album ? (
                 <>
                   <div>
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 truncate">
+                    <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 truncate lg:text-xl lg:text-white">
                       {album.name}
                     </h3>
-                    <p className="text-gray-500 dark:text-gray-400 text-sm truncate">
+                    <p className="text-gray-500 dark:text-gray-400 text-sm truncate lg:text-gray-300">
                       <Link
                         to={`/search?q=${encodeURIComponent(album.artistName)}`}
                         className="hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
@@ -204,7 +206,7 @@ export default function PromotedAlbum({
                   <div className="mt-3 flex items-center justify-between">
                     <button
                       onClick={handleTracksOpen}
-                      className="flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
+                      className="flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-amber-600 dark:hover:text-amber-400 lg:text-gray-300 lg:hover:text-amber-400 transition-colors"
                       aria-label="Preview tracks"
                     >
                       <MusicalNoteIcon className="w-3.5 h-3.5" />

--- a/src/pages/DiscoverPage/components/PromotedAlbum.tsx
+++ b/src/pages/DiscoverPage/components/PromotedAlbum.tsx
@@ -6,11 +6,9 @@ import OptionSelect from "@/components/OptionSelect";
 import useHaptics from "@/hooks/useHaptics";
 import PurchaseLinksModal from "@/components/PurchaseLinksModal";
 import RecommendationTraceModal from "./RecommendationTraceModal";
-import {
-  RefreshIcon,
-  ChevronDownIcon,
-  MusicalNoteIcon,
-} from "@/components/icons";
+import { ChevronDownIcon, MusicalNoteIcon } from "@/components/icons";
+import SectionHeader from "./SectionHeader";
+import ShuffleButton from "./ShuffleButton";
 import useLidarr from "@/hooks/useLidarr";
 import useWanted from "@/hooks/useWanted";
 import useReleaseTracks from "@/hooks/useReleaseTracks";
@@ -132,23 +130,18 @@ export default function PromotedAlbum({
 
   return (
     <>
-      <div className="mb-6">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-            Recommended for you
-          </h2>
-          <button
-            onClick={handleRefresh}
-            disabled={isAnimating || loading}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 text-xs font-bold bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Shuffle recommendation"
-          >
-            <RefreshIcon
-              className={`w-4 h-4 ${isAnimating || loading ? "animate-spin" : ""}`}
+      <div>
+        <SectionHeader
+          title="Recommended for you"
+          action={
+            <ShuffleButton
+              onClick={handleRefresh}
+              disabled={isAnimating || loading}
+              spinning={isAnimating || loading}
+              ariaLabel="Shuffle recommendation"
             />
-            <span className="hidden sm:inline">Shuffle</span>
-          </button>
-        </div>
+          }
+        />
 
         <div
           className={`bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md overflow-hidden transition-all duration-300 ${

--- a/src/pages/DiscoverPage/components/PromotedArtists.tsx
+++ b/src/pages/DiscoverPage/components/PromotedArtists.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import type { PromotedArtistsData } from "@/hooks/usePromotedArtists";
 import ArtistCard from "./ArtistCard";
 import Skeleton from "@/components/Skeleton";
-import { RefreshIcon } from "@/components/icons";
+import SectionHeader from "./SectionHeader";
+import ShuffleButton from "./ShuffleButton";
 
 interface PromotedArtistsProps {
   data: PromotedArtistsData | null;
@@ -41,23 +42,18 @@ export default function PromotedArtists({
   if (!loading && artists.length === 0) return null;
 
   return (
-    <div className="mb-6">
-      <div className="flex items-center justify-between mb-2">
-        <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-          Artists you might like
-        </h2>
-        <button
-          onClick={handleRefresh}
-          disabled={isAnimating || loading}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 text-xs font-bold bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label="Shuffle recommended artists"
-        >
-          <RefreshIcon
-            className={`w-4 h-4 ${isAnimating || loading ? "animate-spin" : ""}`}
+    <div>
+      <SectionHeader
+        title="Artists you might like"
+        action={
+          <ShuffleButton
+            onClick={handleRefresh}
+            disabled={isAnimating || loading}
+            spinning={isAnimating || loading}
+            ariaLabel="Shuffle recommended artists"
           />
-          <span className="hidden sm:inline">Shuffle</span>
-        </button>
-      </div>
+        }
+      />
 
       {seeds.length > 0 && !loading && (
         <p className="text-xs text-gray-400 mb-3">

--- a/src/pages/DiscoverPage/components/PromotedArtists.tsx
+++ b/src/pages/DiscoverPage/components/PromotedArtists.tsx
@@ -11,8 +11,9 @@ interface PromotedArtistsProps {
   onRefresh: () => void;
 }
 
-const GRID_CLASSES =
-  "grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-8 gap-3 sm:gap-4";
+const SKELETON_COUNT = 6;
+
+const GRID_CLASSES = "grid grid-cols-3 lg:grid-cols-2 gap-3 sm:gap-4";
 
 function formatSeeds(seeds: string[]): string {
   if (seeds.length === 1) return seeds[0];
@@ -42,7 +43,7 @@ export default function PromotedArtists({
   if (!loading && artists.length === 0) return null;
 
   return (
-    <div>
+    <div className="h-full flex flex-col">
       <SectionHeader
         title="Artists you might like"
         action={
@@ -55,34 +56,36 @@ export default function PromotedArtists({
         }
       />
 
-      {seeds.length > 0 && !loading && (
-        <p className="text-xs text-gray-400 mb-3">
-          Because you listen to {formatSeeds(seeds)}
-        </p>
-      )}
+      <div className="flex-1 bg-white dark:bg-gray-800 rounded-xl border-2 border-black shadow-cartoon-md p-4 flex flex-col">
+        <div
+          className={`${GRID_CLASSES} flex-1 content-start transition-all duration-300 ${
+            isAnimating ? "opacity-0 scale-95" : "opacity-100 scale-100"
+          }`}
+        >
+          {loading
+            ? [...Array(SKELETON_COUNT)].map((_, i) => (
+                <div key={i} className="flex flex-col items-center">
+                  <Skeleton className="w-full aspect-square rounded-full" />
+                  <Skeleton className="mt-2 h-3 w-3/4" />
+                </div>
+              ))
+            : artists.map((artist) => (
+                <ArtistCard
+                  key={`${artist.name}-${artist.mbid}`}
+                  name={artist.name}
+                  mbid={artist.mbid || undefined}
+                  imageUrl={artist.imageUrl || undefined}
+                  match={artist.match}
+                  inLibrary={artist.inLibrary}
+                />
+              ))}
+        </div>
 
-      <div
-        className={`${GRID_CLASSES} transition-all duration-300 ${
-          isAnimating ? "opacity-0 scale-95" : "opacity-100 scale-100"
-        }`}
-      >
-        {loading
-          ? [...Array(8)].map((_, i) => (
-              <div key={i} className="flex flex-col items-center">
-                <Skeleton className="w-full aspect-square rounded-full" />
-                <Skeleton className="mt-2 h-3 w-3/4" />
-              </div>
-            ))
-          : artists.map((artist) => (
-              <ArtistCard
-                key={`${artist.name}-${artist.mbid}`}
-                name={artist.name}
-                mbid={artist.mbid || undefined}
-                imageUrl={artist.imageUrl || undefined}
-                match={artist.match}
-                inLibrary={artist.inLibrary}
-              />
-            ))}
+        {seeds.length > 0 && !loading && (
+          <p className="text-xs text-gray-400 mt-3">
+            Because you listen to {formatSeeds(seeds)}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/pages/DiscoverPage/components/SectionHeader.tsx
+++ b/src/pages/DiscoverPage/components/SectionHeader.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+interface SectionHeaderProps {
+  title: string;
+  action?: ReactNode;
+}
+
+export default function SectionHeader({ title, action }: SectionHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-2">
+      <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+        {title}
+      </h2>
+      {action}
+    </div>
+  );
+}

--- a/src/pages/DiscoverPage/components/SectionSlot.tsx
+++ b/src/pages/DiscoverPage/components/SectionSlot.tsx
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import type { CSSProperties } from "react";
+import { sectionSlotClasses } from "../layout";
+import type { SectionDefinition, SectionId, SectionStatus } from "../types";
+
+interface SectionSlotProps {
+  definition: SectionDefinition;
+  hidden: boolean;
+  onStatusChange: (id: SectionId, status: SectionStatus) => void;
+}
+
+export default function SectionSlot({
+  definition,
+  hidden,
+  onStatusChange,
+}: SectionSlotProps) {
+  const { id, mobileOrder, Component } = definition;
+
+  const handleStatusChange = useCallback(
+    (status: SectionStatus) => onStatusChange(id, status),
+    [id, onStatusChange]
+  );
+
+  return (
+    <section
+      data-testid={`discover-section-${id}`}
+      className={sectionSlotClasses(definition, hidden)}
+      style={{ "--order-mobile": mobileOrder } as CSSProperties}
+    >
+      <Component onStatusChange={handleStatusChange} />
+    </section>
+  );
+}

--- a/src/pages/DiscoverPage/components/ShuffleButton.tsx
+++ b/src/pages/DiscoverPage/components/ShuffleButton.tsx
@@ -1,0 +1,27 @@
+import { RefreshIcon } from "@/components/icons";
+
+interface ShuffleButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+  spinning: boolean;
+  ariaLabel: string;
+}
+
+export default function ShuffleButton({
+  onClick,
+  disabled,
+  spinning,
+  ariaLabel,
+}: ShuffleButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center gap-1.5 px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 text-xs font-bold bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg border-2 border-black shadow-cartoon-sm hover:translate-y-[-1px] hover:shadow-cartoon-md active:translate-y-[1px] active:shadow-cartoon-pressed transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+      aria-label={ariaLabel}
+    >
+      <RefreshIcon className={`w-4 h-4 ${spinning ? "animate-spin" : ""}`} />
+      <span className="hidden sm:inline">Shuffle</span>
+    </button>
+  );
+}

--- a/src/pages/DiscoverPage/components/TracksPreviewModal.tsx
+++ b/src/pages/DiscoverPage/components/TracksPreviewModal.tsx
@@ -1,0 +1,49 @@
+import Modal from "@/components/Modal";
+import TrackList from "@/components/TrackList";
+import type { Medium } from "@/types";
+
+interface TracksPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  albumName: string;
+  artistName: string;
+  media: Medium[];
+  loading: boolean;
+  error: string | null;
+  onTogglePreview: (url: string) => void;
+  isTrackPlaying: (url: string) => boolean;
+}
+
+export default function TracksPreviewModal({
+  isOpen,
+  onClose,
+  albumName,
+  artistName,
+  media,
+  loading,
+  error,
+  onTogglePreview,
+  isTrackPlaying,
+}: TracksPreviewModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} panelClassName="w-full max-w-lg">
+      <div>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {albumName}
+        </h2>
+        <p className="text-gray-500 dark:text-gray-400 text-sm mb-4">
+          {artistName}
+        </p>
+        <div className="overlay-scrollbar max-h-96 overflow-y-auto">
+          <TrackList
+            media={media}
+            loading={loading}
+            error={error}
+            onTogglePreview={onTogglePreview}
+            isTrackPlaying={isTrackPlaying}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/DiscoverPage/components/__tests__/DiscoverGrid.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/DiscoverGrid.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import DiscoverGrid from "../DiscoverGrid";
+import type {
+  SectionComponentProps,
+  SectionDefinition,
+  SectionStatus,
+} from "../../types";
+
+function makeStatusSection(status: SectionStatus, label: string) {
+  return function StatusSection({ onStatusChange }: SectionComponentProps) {
+    useEffect(() => {
+      onStatusChange(status);
+    }, [onStatusChange]);
+    return <div>{label}</div>;
+  };
+}
+
+function makeDefinition(
+  overrides: Partial<SectionDefinition> = {}
+): SectionDefinition {
+  return {
+    id: "spotlight",
+    span: { cols: 6, rows: 1 },
+    desktopOrder: 1,
+    mobileOrder: 1,
+    whenEmpty: "hide",
+    Component: makeStatusSection("ready", "spotlight content"),
+    ...overrides,
+  };
+}
+
+describe("DiscoverGrid", () => {
+  it("renders every section's content", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition(),
+          makeDefinition({
+            id: "artists",
+            desktopOrder: 2,
+            Component: makeStatusSection("ready", "artists content"),
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("spotlight content")).toBeInTheDocument();
+    expect(screen.getByText("artists content")).toBeInTheDocument();
+  });
+
+  it("orders slots in the DOM by desktopOrder", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({
+            id: "artists",
+            desktopOrder: 2,
+            Component: makeStatusSection("ready", "artists content"),
+          }),
+          makeDefinition({ id: "spotlight", desktopOrder: 1 }),
+        ]}
+      />
+    );
+
+    const slots = screen.getAllByTestId(/discover-section-/);
+    expect(slots.map((el) => el.dataset.testid)).toEqual([
+      "discover-section-spotlight",
+      "discover-section-artists",
+    ]);
+  });
+
+  it("hides a slot when its section reports empty and whenEmpty is hide", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({
+            Component: makeStatusSection("empty", "spotlight content"),
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("discover-section-spotlight")).toHaveClass(
+      "hidden"
+    );
+  });
+
+  it("hides a slot when its section reports error and whenEmpty is hide", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({
+            Component: makeStatusSection("error", "spotlight content"),
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("discover-section-spotlight")).toHaveClass(
+      "hidden"
+    );
+  });
+
+  it("keeps an empty section visible when whenEmpty is keep", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({
+            whenEmpty: "keep",
+            Component: makeStatusSection("empty", "spotlight content"),
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("discover-section-spotlight")).not.toHaveClass(
+      "hidden"
+    );
+  });
+
+  it("keeps hidden sections mounted so their hooks stay alive", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({
+            Component: makeStatusSection("empty", "spotlight content"),
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("spotlight content")).toBeInTheDocument();
+  });
+
+  it("applies span classes and the mobile order variable to each slot", () => {
+    render(
+      <DiscoverGrid
+        definitions={[
+          makeDefinition({ span: { cols: 4, rows: 2 }, mobileOrder: 3 }),
+        ]}
+      />
+    );
+
+    const slot = screen.getByTestId("discover-section-spotlight");
+    expect(slot).toHaveClass("lg:col-span-4");
+    expect(slot).toHaveClass("lg:row-span-2");
+    expect(slot.style.getPropertyValue("--order-mobile")).toBe("3");
+  });
+});

--- a/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/PromotedAlbum.test.tsx
@@ -120,8 +120,13 @@ vi.mock("../RecommendationTraceModal", () => ({
     ) : null,
 }));
 
-vi.mock("@/components/TrackList", () => ({
-  default: () => <div data-testid="track-list" />,
+vi.mock("../TracksPreviewModal", () => ({
+  default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="tracks-modal">
+        <button onClick={onClose}>Close Tracks</button>
+      </div>
+    ) : null,
 }));
 
 const albumData: PromotedAlbumData = {
@@ -599,12 +604,12 @@ describe("PromotedAlbum", () => {
       fireEvent.click(screen.getByLabelText("Preview tracks"));
       expect(mockFetchTracks).toHaveBeenCalledTimes(1);
 
-      fireEvent.click(screen.getByLabelText("Hide tracks"));
+      fireEvent.click(screen.getByText("Close Tracks"));
       fireEvent.click(screen.getByLabelText("Preview tracks"));
       expect(mockFetchTracks).toHaveBeenCalledTimes(1);
     });
 
-    it("shows track list after clicking preview", () => {
+    it("opens the tracks modal after clicking preview", () => {
       renderWithRouter(
         <PromotedAlbum
           data={albumData}
@@ -612,11 +617,12 @@ describe("PromotedAlbum", () => {
           onRefresh={mockRefresh}
         />
       );
+      expect(screen.queryByTestId("tracks-modal")).not.toBeInTheDocument();
       fireEvent.click(screen.getByLabelText("Preview tracks"));
-      expect(screen.getByTestId("track-list")).toBeInTheDocument();
+      expect(screen.getByTestId("tracks-modal")).toBeInTheDocument();
     });
 
-    it("toggles label to Hide tracks when open", () => {
+    it("stops audio when closing the tracks modal", () => {
       renderWithRouter(
         <PromotedAlbum
           data={albumData}
@@ -625,24 +631,12 @@ describe("PromotedAlbum", () => {
         />
       );
       fireEvent.click(screen.getByLabelText("Preview tracks"));
-      expect(screen.getByLabelText("Hide tracks")).toBeInTheDocument();
-      expect(screen.getByText("Hide tracks")).toBeInTheDocument();
-    });
-
-    it("stops audio when closing track list", () => {
-      renderWithRouter(
-        <PromotedAlbum
-          data={albumData}
-          loading={false}
-          onRefresh={mockRefresh}
-        />
-      );
-      fireEvent.click(screen.getByLabelText("Preview tracks"));
-      fireEvent.click(screen.getByLabelText("Hide tracks"));
+      fireEvent.click(screen.getByText("Close Tracks"));
       expect(mockStop).toHaveBeenCalled();
+      expect(screen.queryByTestId("tracks-modal")).not.toBeInTheDocument();
     });
 
-    it("stops audio and closes track list on shuffle", () => {
+    it("stops audio and closes the tracks modal on shuffle", () => {
       vi.useFakeTimers();
       renderWithRouter(
         <PromotedAlbum
@@ -652,11 +646,11 @@ describe("PromotedAlbum", () => {
         />
       );
       fireEvent.click(screen.getByLabelText("Preview tracks"));
-      expect(screen.getByText("Hide tracks")).toBeInTheDocument();
+      expect(screen.getByTestId("tracks-modal")).toBeInTheDocument();
 
       fireEvent.click(screen.getByLabelText("Shuffle recommendation"));
       expect(mockStop).toHaveBeenCalled();
-      expect(screen.queryByText("Hide tracks")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("tracks-modal")).not.toBeInTheDocument();
 
       vi.useRealTimers();
     });

--- a/src/pages/DiscoverPage/components/__tests__/SectionHeader.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SectionHeader from "../SectionHeader";
+import ShuffleButton from "../ShuffleButton";
+
+describe("SectionHeader", () => {
+  it("renders the title as a heading", () => {
+    render(<SectionHeader title="New releases" />);
+    expect(
+      screen.getByRole("heading", { name: "New releases" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the action when provided", () => {
+    render(
+      <SectionHeader title="New releases" action={<button>See all</button>} />
+    );
+    expect(screen.getByRole("button", { name: "See all" })).toBeInTheDocument();
+  });
+});
+
+describe("ShuffleButton", () => {
+  it("calls onClick when pressed", () => {
+    const onClick = vi.fn();
+    render(
+      <ShuffleButton
+        onClick={onClick}
+        disabled={false}
+        spinning={false}
+        ariaLabel="Shuffle things"
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Shuffle things"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("is disabled and spins while working", () => {
+    render(
+      <ShuffleButton
+        onClick={vi.fn()}
+        disabled
+        spinning
+        ariaLabel="Shuffle things"
+      />
+    );
+
+    const button = screen.getByLabelText("Shuffle things");
+    expect(button).toBeDisabled();
+    expect(button.querySelector("svg")).toHaveClass("animate-spin");
+  });
+});

--- a/src/pages/DiscoverPage/components/__tests__/TracksPreviewModal.test.tsx
+++ b/src/pages/DiscoverPage/components/__tests__/TracksPreviewModal.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import TracksPreviewModal from "../TracksPreviewModal";
+
+vi.mock("@/components/TrackList", () => ({
+  default: ({ loading }: { loading: boolean }) => (
+    <div data-testid="track-list">{loading ? "loading" : "loaded"}</div>
+  ),
+}));
+
+const baseProps = {
+  onClose: vi.fn(),
+  albumName: "OK Computer",
+  artistName: "Radiohead",
+  media: [],
+  loading: false,
+  error: null,
+  onTogglePreview: vi.fn(),
+  isTrackPlaying: () => false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TracksPreviewModal", () => {
+  it("renders nothing when closed", () => {
+    render(<TracksPreviewModal {...baseProps} isOpen={false} />);
+    expect(screen.queryByTestId("track-list")).not.toBeInTheDocument();
+  });
+
+  it("renders album, artist, and track list when open", () => {
+    render(<TracksPreviewModal {...baseProps} isOpen={true} />);
+    expect(screen.getByText("OK Computer")).toBeInTheDocument();
+    expect(screen.getByText("Radiohead")).toBeInTheDocument();
+    expect(screen.getByTestId("track-list")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    render(<TracksPreviewModal {...baseProps} isOpen={true} />);
+    fireEvent.click(screen.getByTestId("modal-backdrop"));
+    expect(baseProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/src/pages/DiscoverPage/components/sections/ArtistsSection.tsx
+++ b/src/pages/DiscoverPage/components/sections/ArtistsSection.tsx
@@ -1,0 +1,26 @@
+import usePromotedArtists from "@/hooks/usePromotedArtists";
+import useReportSectionStatus from "../../useReportSectionStatus";
+import PromotedArtists from "../PromotedArtists";
+import type { SectionComponentProps } from "../../types";
+
+export default function ArtistsSection({
+  onStatusChange,
+}: SectionComponentProps) {
+  const { promotedArtists, loading, error, refresh } = usePromotedArtists();
+
+  useReportSectionStatus(onStatusChange, {
+    loading,
+    error: Boolean(error),
+    empty: (promotedArtists?.artists ?? []).length === 0,
+  });
+
+  if (!promotedArtists && !loading) return null;
+
+  return (
+    <PromotedArtists
+      data={promotedArtists}
+      loading={loading}
+      onRefresh={refresh}
+    />
+  );
+}

--- a/src/pages/DiscoverPage/components/sections/SpotlightSection.tsx
+++ b/src/pages/DiscoverPage/components/sections/SpotlightSection.tsx
@@ -1,0 +1,22 @@
+import usePromotedAlbum from "@/hooks/usePromotedAlbum";
+import useReportSectionStatus from "../../useReportSectionStatus";
+import PromotedAlbum from "../PromotedAlbum";
+import type { SectionComponentProps } from "../../types";
+
+export default function SpotlightSection({
+  onStatusChange,
+}: SectionComponentProps) {
+  const { promotedAlbum, loading, error, refresh } = usePromotedAlbum();
+
+  useReportSectionStatus(onStatusChange, {
+    loading,
+    error: Boolean(error),
+    empty: !promotedAlbum,
+  });
+
+  if (!promotedAlbum && !loading) return null;
+
+  return (
+    <PromotedAlbum data={promotedAlbum} loading={loading} onRefresh={refresh} />
+  );
+}

--- a/src/pages/DiscoverPage/components/sections/__tests__/ArtistsSection.test.tsx
+++ b/src/pages/DiscoverPage/components/sections/__tests__/ArtistsSection.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import ArtistsSection from "../ArtistsSection";
+
+const mockRefresh = vi.fn();
+
+let mockPromotedArtists: unknown = null;
+let mockLoading = false;
+let mockError: string | null = null;
+
+vi.mock("@/hooks/usePromotedArtists", () => ({
+  default: () => ({
+    promotedArtists: mockPromotedArtists,
+    loading: mockLoading,
+    error: mockError,
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock("../../PromotedArtists", () => ({
+  default: ({ loading }: { loading: boolean }) => (
+    <div data-testid="promoted-artists">{loading ? "loading" : "loaded"}</div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPromotedArtists = null;
+  mockLoading = false;
+  mockError = null;
+});
+
+describe("ArtistsSection", () => {
+  it("renders PromotedArtists while loading", () => {
+    mockLoading = true;
+    render(<ArtistsSection onStatusChange={vi.fn()} />);
+    expect(screen.getByTestId("promoted-artists")).toBeInTheDocument();
+  });
+
+  it("renders nothing when loaded without data", () => {
+    render(<ArtistsSection onStatusChange={vi.fn()} />);
+    expect(screen.queryByTestId("promoted-artists")).not.toBeInTheDocument();
+  });
+
+  it("reports ready when artists are available", () => {
+    mockPromotedArtists = {
+      artists: [{ name: "Boards of Canada" }],
+      seedArtists: [],
+    };
+    const onStatusChange = vi.fn();
+    render(<ArtistsSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("ready");
+  });
+
+  it("reports empty when the artist list is empty", () => {
+    mockPromotedArtists = { artists: [], seedArtists: [] };
+    const onStatusChange = vi.fn();
+    render(<ArtistsSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("empty");
+  });
+
+  it("reports error when the hook errors", () => {
+    mockError = "boom";
+    const onStatusChange = vi.fn();
+    render(<ArtistsSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("error");
+  });
+});

--- a/src/pages/DiscoverPage/components/sections/__tests__/SpotlightSection.test.tsx
+++ b/src/pages/DiscoverPage/components/sections/__tests__/SpotlightSection.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import SpotlightSection from "../SpotlightSection";
+
+const mockRefresh = vi.fn();
+
+let mockPromotedAlbum: unknown = null;
+let mockLoading = false;
+let mockError: string | null = null;
+
+vi.mock("@/hooks/usePromotedAlbum", () => ({
+  default: () => ({
+    promotedAlbum: mockPromotedAlbum,
+    loading: mockLoading,
+    error: mockError,
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock("../../PromotedAlbum", () => ({
+  default: ({ loading }: { loading: boolean }) => (
+    <div data-testid="promoted-album">{loading ? "loading" : "loaded"}</div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPromotedAlbum = null;
+  mockLoading = false;
+  mockError = null;
+});
+
+describe("SpotlightSection", () => {
+  it("renders PromotedAlbum while loading", () => {
+    mockLoading = true;
+    render(<SpotlightSection onStatusChange={vi.fn()} />);
+    expect(screen.getByTestId("promoted-album")).toBeInTheDocument();
+  });
+
+  it("renders PromotedAlbum when data is available", () => {
+    mockPromotedAlbum = { album: { name: "OK Computer" } };
+    render(<SpotlightSection onStatusChange={vi.fn()} />);
+    expect(screen.getByTestId("promoted-album")).toBeInTheDocument();
+  });
+
+  it("renders nothing when loaded without data", () => {
+    render(<SpotlightSection onStatusChange={vi.fn()} />);
+    expect(screen.queryByTestId("promoted-album")).not.toBeInTheDocument();
+  });
+
+  it("reports loading while the hook is loading", () => {
+    mockLoading = true;
+    const onStatusChange = vi.fn();
+    render(<SpotlightSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("loading");
+  });
+
+  it("reports ready when data arrives", () => {
+    mockPromotedAlbum = { album: { name: "OK Computer" } };
+    const onStatusChange = vi.fn();
+    render(<SpotlightSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("ready");
+  });
+
+  it("reports empty when loaded without data", () => {
+    const onStatusChange = vi.fn();
+    render(<SpotlightSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("empty");
+  });
+
+  it("reports error when the hook errors", () => {
+    mockError = "boom";
+    const onStatusChange = vi.fn();
+    render(<SpotlightSection onStatusChange={onStatusChange} />);
+    expect(onStatusChange).toHaveBeenCalledWith("error");
+  });
+});

--- a/src/pages/DiscoverPage/layout.ts
+++ b/src/pages/DiscoverPage/layout.ts
@@ -1,0 +1,67 @@
+import type {
+  SectionDefinition,
+  SectionSpan,
+  SectionStatus,
+  SectionStatusMap,
+} from "./types";
+
+export type ResolvedSection = {
+  definition: SectionDefinition;
+  hidden: boolean;
+};
+
+const COL_SPAN_CLASSES: Record<SectionSpan["cols"], string> = {
+  2: "lg:col-span-2",
+  4: "lg:col-span-4",
+  6: "lg:col-span-6",
+};
+
+const ROW_SPAN_CLASSES: Record<SectionSpan["rows"], string> = {
+  1: "lg:row-span-1",
+  2: "lg:row-span-2",
+};
+
+const MOBILE_ORDER_CLASS = "max-lg:[order:var(--order-mobile)]";
+
+function isSectionHidden(
+  definition: SectionDefinition,
+  status: SectionStatus
+): boolean {
+  return (
+    definition.whenEmpty === "hide" &&
+    (status === "empty" || status === "error")
+  );
+}
+
+/**
+ * Resolve the section registry against reported statuses into an ordered,
+ * visibility-resolved list. DOM order follows desktopOrder; mobile order is
+ * applied separately via CSS (see sectionSlotClasses).
+ */
+export function resolveLayout(
+  definitions: readonly SectionDefinition[],
+  statuses: SectionStatusMap
+): ResolvedSection[] {
+  return [...definitions]
+    .sort((a, b) => a.desktopOrder - b.desktopOrder)
+    .map((definition) => ({
+      definition,
+      hidden: isSectionHidden(definition, statuses[definition.id] ?? "loading"),
+    }));
+}
+
+/**
+ * Grid classes for a section slot. Hidden tiles stay mounted (so their data
+ * hooks survive and can recover) but are removed from the visual grid.
+ */
+export function sectionSlotClasses(
+  definition: SectionDefinition,
+  hidden: boolean
+): string {
+  if (hidden) return "hidden";
+  return [
+    COL_SPAN_CLASSES[definition.span.cols],
+    ROW_SPAN_CLASSES[definition.span.rows],
+    MOBILE_ORDER_CLASS,
+  ].join(" ");
+}

--- a/src/pages/DiscoverPage/sections.ts
+++ b/src/pages/DiscoverPage/sections.ts
@@ -1,0 +1,27 @@
+import ArtistsSection from "./components/sections/ArtistsSection";
+import SpotlightSection from "./components/sections/SpotlightSection";
+import type { SectionDefinition } from "./types";
+
+/**
+ * The Discover page section registry — the single place to add, remove,
+ * resize, or reorder sections. Spans target the 6-column desktop grid;
+ * mobileOrder controls the single-column stack independently.
+ */
+export const SECTION_DEFINITIONS: readonly SectionDefinition[] = [
+  {
+    id: "spotlight",
+    span: { cols: 6, rows: 1 },
+    desktopOrder: 1,
+    mobileOrder: 1,
+    whenEmpty: "hide",
+    Component: SpotlightSection,
+  },
+  {
+    id: "artists",
+    span: { cols: 6, rows: 1 },
+    desktopOrder: 2,
+    mobileOrder: 2,
+    whenEmpty: "hide",
+    Component: ArtistsSection,
+  },
+];

--- a/src/pages/DiscoverPage/sections.ts
+++ b/src/pages/DiscoverPage/sections.ts
@@ -10,7 +10,7 @@ import type { SectionDefinition } from "./types";
 export const SECTION_DEFINITIONS: readonly SectionDefinition[] = [
   {
     id: "spotlight",
-    span: { cols: 6, rows: 1 },
+    span: { cols: 4, rows: 2 },
     desktopOrder: 1,
     mobileOrder: 1,
     whenEmpty: "hide",
@@ -18,7 +18,7 @@ export const SECTION_DEFINITIONS: readonly SectionDefinition[] = [
   },
   {
     id: "artists",
-    span: { cols: 6, rows: 1 },
+    span: { cols: 2, rows: 2 },
     desktopOrder: 2,
     mobileOrder: 2,
     whenEmpty: "hide",

--- a/src/pages/DiscoverPage/types.ts
+++ b/src/pages/DiscoverPage/types.ts
@@ -1,0 +1,43 @@
+import type { ComponentType } from "react";
+
+/** Unique key for a Discover section. Extend this union when adding a section. */
+export type SectionId = "spotlight" | "artists";
+
+/** Data lifecycle a section reports to the grid. */
+export type SectionStatus = "loading" | "ready" | "empty" | "error";
+
+/** Statuses by section id; sections that have not reported yet are treated as "loading". */
+export type SectionStatusMap = Partial<Record<SectionId, SectionStatus>>;
+
+/** Tile size on the 6-column desktop grid. Mobile is always a single column. */
+export type SectionSpan = {
+  cols: 2 | 4 | 6;
+  rows: 1 | 2;
+};
+
+/** Props every section component receives from its grid slot. */
+export type SectionComponentProps = {
+  /** Report the section's data lifecycle so the grid can resolve tile visibility. */
+  onStatusChange: (status: SectionStatus) => void;
+};
+
+/**
+ * One entry in the Discover section registry. Adding a section means adding
+ * its id to {@link SectionId}, writing a component that fulfils
+ * {@link SectionComponentProps}, and appending one of these to
+ * `SECTION_DEFINITIONS`.
+ */
+export type SectionDefinition = {
+  id: SectionId;
+  span: SectionSpan;
+  /** Position in the desktop grid flow (lower renders earlier). */
+  desktopOrder: number;
+  /** Position in the mobile stack, independent of desktop order. */
+  mobileOrder: number;
+  /**
+   * "hide" removes the tile when the section reports empty or error;
+   * "keep" leaves the tile visible so the section renders its own fallback.
+   */
+  whenEmpty: "hide" | "keep";
+  Component: ComponentType<SectionComponentProps>;
+};

--- a/src/pages/DiscoverPage/useReportSectionStatus.ts
+++ b/src/pages/DiscoverPage/useReportSectionStatus.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import type { SectionStatus } from "./types";
+
+/** Raw data lifecycle flags from a section's data hook. */
+export type SectionDataState = {
+  loading: boolean;
+  error: boolean;
+  empty: boolean;
+};
+
+export function deriveSectionStatus(state: SectionDataState): SectionStatus {
+  if (state.loading) return "loading";
+  if (state.error) return "error";
+  if (state.empty) return "empty";
+  return "ready";
+}
+
+/**
+ * Report a section's data lifecycle to its grid slot. Call once per section
+ * component with the flags from its data hook.
+ */
+export default function useReportSectionStatus(
+  onStatusChange: (status: SectionStatus) => void,
+  state: SectionDataState
+): void {
+  const status = deriveSectionStatus(state);
+
+  useEffect(() => {
+    onStatusChange(status);
+  }, [onStatusChange, status]);
+}


### PR DESCRIPTION
## Summary

Turns the Discover page into a dashboard-style bento grid driven by a single typed section registry, and redesigns the two existing sections to fit it.

### Section registry & grid system
- `SECTION_DEFINITIONS` (`src/pages/DiscoverPage/sections.ts`) is the one place to add, resize, or reorder sections. Each entry declares its id, desktop span (6-col grid), independent desktop/mobile order, and empty behavior.
- Adding a section = extend the `SectionId` union, write a component fulfilling `SectionComponentProps` (owns its data hook, reports status via `useReportSectionStatus`), append one registry entry. The compiler enumerates anything missing.
- `DiscoverGrid` resolves the registry against reported statuses (pure, unit-tested `resolveLayout`). Tiles that report empty/error hide via CSS while staying mounted, so their hooks can recover.
- Mobile order is applied with a `--order-mobile` CSS variable — one DOM tree for both breakpoints, no duplicate mounting or double fetching.

### Section redesigns
- **Artists (2×2):** card-chromed 2-column avatar grid (3 columns on mobile), sized to the server's 6 promoted artists; seed explanation moves to the card footer.
- **Spotlight (4×2):** on desktop the cover art fills the card as a backdrop behind a bottom scrim with content overlaid; compact side-by-side layout below `lg`. The inline expanding tracklist (grid-hostile height animation) is replaced by `TracksPreviewModal` — desktop modal, drag-dismissable bottom sheet on mobile via the existing `Modal`.
- Shared `SectionHeader`/`ShuffleButton` primitives extract the header pattern both sections duplicated.
- Fixes a latent `ImageWithShimmer` bug: the wrapper div had no size, so `h-full` images could never fill their container (new optional `wrapperClassName` prop).

Also syncs CLAUDE.md with current routes/pages/entities (removes stale `/explore` references).

## Test plan
- [x] `pnpm test` — 892 passing (new: layout resolver, status hook, DiscoverGrid/SectionSlot, section wrappers, TracksPreviewModal)
- [x] `pnpm typecheck`, `pnpm lint`
- [x] Manual check of desktop bento layout, backdrop hero, mobile stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)