### PR TITLE
fix(discover): filter placeholder artists out of recommendations

### DIFF
--- a/server/promotedAlbum/artistWeights.test.ts
+++ b/server/promotedAlbum/artistWeights.test.ts
@@ -189,6 +189,19 @@ describe("loadArtistWeights (with DB)", () => {
     expect(result).toEqual([{ name: "A", viewCount: 42 }]);
   });
 
+  it("drops Various Artists from the weight set", async () => {
+    await appendSignalEvent(1, "plex_plays", {
+      artists: [
+        { name: "Various Artists", playCount: 900 },
+        { name: "A", playCount: 10 },
+      ],
+    });
+
+    const result = await loadArtistWeights(1, "tok", 30 * DAY, 0.5, NOW);
+
+    expect(result).toEqual([{ name: "A", viewCount: 10 }]);
+  });
+
   it("reads existing plays + ratings without a live fetch", async () => {
     await appendSignalEvent(1, "plex_plays", {
       artists: [{ name: "A", playCount: 100 }],

--- a/server/promotedAlbum/artistWeights.ts
+++ b/server/promotedAlbum/artistWeights.ts
@@ -1,4 +1,5 @@
 import { getSignalEvents } from "../db/userProfile";
+import { isPlaceholderArtist } from "../utils/artistFilter";
 import {
   ingestUserPlays,
   latestRatings,
@@ -109,5 +110,7 @@ export async function loadArtistWeights(
   const ratings = aggregateArtistRatings(
     await getSignalEvents(userId, "plex_rating")
   );
-  return applyRatingMultiplier(plays, ratings, ratingWeight);
+  return applyRatingMultiplier(plays, ratings, ratingWeight).filter(
+    (weight) => !isPlaceholderArtist(weight.name)
+  );
 }

--- a/server/promotedAlbum/explore.test.ts
+++ b/server/promotedAlbum/explore.test.ts
@@ -25,6 +25,7 @@ vi.mock("../api/musicbrainz/releaseGroups", () => ({
 }));
 
 import { buildSimilarGraph, buildExploreResult } from "./explore";
+import { VARIOUS_ARTISTS_MBID } from "../utils/artistFilter";
 
 const config = {
   genericTags: ["seen live"],
@@ -119,6 +120,28 @@ describe("buildSimilarGraph", () => {
     expect(graph).toEqual([]);
   });
 
+  it("drops Various Artists from the candidate list", async () => {
+    mockGetArtistMbidByName.mockResolvedValue("mbid-seed");
+    mockGetSimilarArtists.mockResolvedValue([
+      similar("Various Artists", VARIOUS_ARTISTS_MBID, 9999),
+      similar("Jazz Cat", "mbid-jazz", 9000),
+    ]);
+    mockGetArtistTopTags.mockImplementation((name: string) =>
+      Promise.resolve(
+        name === "Radiohead"
+          ? [{ name: "alternative", count: 100 }]
+          : [{ name: "jazz", count: 100 }]
+      )
+    );
+
+    const graph = await buildSimilarGraph(
+      [{ name: "Radiohead", viewCount: 100 }],
+      config
+    );
+
+    expect(graph[0].candidates.map((c) => c.name)).toEqual(["Jazz Cat"]);
+  });
+
   it("caps candidates at exploreCandidateCount", async () => {
     mockGetArtistMbidByName.mockResolvedValue("mbid-seed");
     mockGetSimilarArtists.mockResolvedValue(
@@ -168,6 +191,33 @@ describe("buildExploreResult", () => {
       artistInLibrary: notInLibrary,
       albumInLibrary: notInLibrary,
     });
+    expect(result).toBeNull();
+    expect(mockFetchReleaseGroupsForArtist).not.toHaveBeenCalled();
+  });
+
+  it("skips Various Artists left in an already-persisted graph", async () => {
+    mockFetchReleaseGroupsForArtist.mockResolvedValue([]);
+
+    const staleSeed: SimilarGraphSeed = {
+      ...seed,
+      candidates: [
+        {
+          name: "Various Artists",
+          artistMbid: VARIOUS_ARTISTS_MBID,
+          score: 9999,
+          genres: ["jazz", "bebop"],
+        },
+      ],
+    };
+
+    const result = await buildExploreResult({
+      similarGraph: [staleSeed],
+      config,
+      recentlyShown: new Set(),
+      artistInLibrary: notInLibrary,
+      albumInLibrary: notInLibrary,
+    });
+
     expect(result).toBeNull();
     expect(mockFetchReleaseGroupsForArtist).not.toHaveBeenCalled();
   });

--- a/server/promotedAlbum/explore.ts
+++ b/server/promotedAlbum/explore.ts
@@ -9,6 +9,7 @@ import type {
   SimilarGraphCandidate,
 } from "../db/entity/UserProfile";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { isPlaceholderArtist } from "../utils/artistFilter";
 import type {
   BuiltAlbum,
   ExploreResult,
@@ -94,7 +95,9 @@ async function buildSeed(
   );
   if (seedGenres.size === 0) return null;
 
-  const candidates = similar.slice(0, config.exploreCandidateCount);
+  const candidates = similar
+    .filter((c) => !isPlaceholderArtist(c.name, c.artist_mbid))
+    .slice(0, config.exploreCandidateCount);
   const tagSets = await Promise.all(candidates.map((c) => safeTopTags(c.name)));
 
   return {
@@ -136,16 +139,18 @@ function evaluateSeed(
   seedGenres: Set<string>,
   threshold: number
 ): EvaluatedCandidate[] {
-  return seed.candidates.map((candidate) => {
-    const genres = new Set(candidate.genres);
-    const overlap = jaccard(seedGenres, genres);
-    return {
-      candidate,
-      genres,
-      overlap,
-      isDifferentGenre: genres.size > 0 && overlap <= threshold,
-    };
-  });
+  return seed.candidates
+    .filter((c) => !isPlaceholderArtist(c.name, c.artistMbid))
+    .map((candidate) => {
+      const genres = new Set(candidate.genres);
+      const overlap = jaccard(seedGenres, genres);
+      return {
+        candidate,
+        genres,
+        overlap,
+        isDifferentGenre: genres.size > 0 && overlap <= threshold,
+      };
+    });
 }
 
 async function pickAlbumFromArtist(

--- a/server/promotedAlbum/getPromotedAlbum.test.ts
+++ b/server/promotedAlbum/getPromotedAlbum.test.ts
@@ -263,6 +263,27 @@ describe("getPromotedAlbum", () => {
     expect(result).toBeNull();
   });
 
+  it("filters Various Artists compilations out of the album pool", async () => {
+    mockLoadArtistWeights.mockResolvedValue(plexArtists);
+    mockGetArtistTopTags.mockResolvedValue(tags);
+    mockGetTopAlbumsByTag.mockResolvedValue({
+      albums: [
+        {
+          name: "Now That's What I Call Music",
+          mbid: "alb-va",
+          artistName: "Various Artists",
+          artistMbid: "art-va",
+        },
+        ...albumsPage.albums,
+      ],
+      pagination: { page: 1, totalPages: 1 },
+    });
+    mockLidarrGet.mockResolvedValue({ ok: true, data: [] });
+
+    const result = await getPromotedAlbum(userId);
+    expect(result!.album.artistName).toBe("Radiohead");
+  });
+
   it("marks inLibrary true when the album is in the Lidarr album list", async () => {
     mockLoadArtistWeights.mockResolvedValue(plexArtists);
     mockGetArtistTopTags.mockResolvedValue(tags);

--- a/server/promotedAlbum/getPromotedAlbum.ts
+++ b/server/promotedAlbum/getPromotedAlbum.ts
@@ -6,6 +6,7 @@ import type { ReleaseGroupInfo } from "../api/musicbrainz/types";
 import { getConfigValue } from "../config";
 import type { LibraryPreference, PromotedAlbumConfig } from "../config";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { isPlaceholderArtist } from "../utils/artistFilter";
 import { findUserById } from "../auth/users";
 import { updateExplorationHistory } from "../db/userProfile";
 import type { DerivedProfile } from "../db/entity/UserProfile";
@@ -236,6 +237,7 @@ async function buildWithinTasteFromProfile(
   const seen = new Set<string>();
   const allAlbums = [...page1.albums, ...pageDeep.albums].filter((a) => {
     if (!a.mbid) return false;
+    if (isPlaceholderArtist(a.artistName, a.artistMbid)) return false;
     if (seen.has(a.mbid)) return false;
     seen.add(a.mbid);
     return true;

--- a/server/promotedArtists/getPromotedArtists.test.ts
+++ b/server/promotedArtists/getPromotedArtists.test.ts
@@ -33,6 +33,7 @@ import {
   clearPromotedArtistsCache,
 } from "./getPromotedArtists";
 import { initializeDatabase, closeDatabase, getDataSource } from "../db";
+import { VARIOUS_ARTISTS_MBID } from "../utils/artistFilter";
 
 type SimilarArtist = {
   name: string;
@@ -171,6 +172,32 @@ describe("getPromotedArtists", () => {
     const boc = result!.artists.find((a) => a.name === "Boards of Canada");
     expect(tycho?.inLibrary).toBe(true);
     expect(boc?.inLibrary).toBe(false);
+  });
+
+  it("excludes Various Artists from the similar results", async () => {
+    mockGetSimilarArtists.mockImplementation((name: string) =>
+      Promise.resolve(
+        name === "Aphex Twin"
+          ? [
+              {
+                name: "Various Artists",
+                mbid: VARIOUS_ARTISTS_MBID,
+                match: 1,
+                imageUrl: "",
+              },
+              {
+                name: "Boards of Canada",
+                mbid: "boc",
+                match: 0.9,
+                imageUrl: "",
+              },
+            ]
+          : []
+      )
+    );
+
+    const result = await getPromotedArtists(userId);
+    expect(result!.artists.map((a) => a.name)).toEqual(["Boards of Canada"]);
   });
 
   it("returns null when no similar artists remain after exclusion", async () => {

--- a/server/promotedArtists/getPromotedArtists.ts
+++ b/server/promotedArtists/getPromotedArtists.ts
@@ -5,6 +5,7 @@ import { lidarrGet } from "../api/lidarr/get";
 import type { LidarrArtist } from "../api/lidarr/types";
 import { getConfigValue } from "../config";
 import { weightedRandomPick, shuffle } from "../utils/random";
+import { isPlaceholderArtist } from "../utils/artistFilter";
 import { findUserById } from "../auth/users";
 import {
   getUserProfile,
@@ -76,6 +77,7 @@ function mergeSimilar(
     for (const artist of list) {
       const key = artist.name.toLowerCase();
       if (excludeNames.has(key)) continue;
+      if (isPlaceholderArtist(artist.name, artist.mbid)) continue;
 
       const existing = byName.get(key);
       if (!existing || artist.match > existing.match) {

--- a/server/services/discover/newReleases.test.ts
+++ b/server/services/discover/newReleases.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../logger", () => ({
 }));
 
 import { getNewReleases } from "./newReleases";
+import { VARIOUS_ARTISTS_MBID } from "../../utils/artistFilter";
 
 const NOW = Date.parse("2026-07-09T12:00:00.000Z");
 
@@ -200,6 +201,31 @@ describe("getNewReleases", () => {
     const result = await getNewReleases(1, NOW);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].releaseGroupMbid).toBe("rg-ost");
+  });
+
+  it("drops Various Artists compilations from feed and followed tiers", async () => {
+    mockGetFollowedReleases.mockResolvedValue([
+      followedRow({
+        artist_name: "Various Artists",
+        artist_mbid: VARIOUS_ARTISTS_MBID,
+      }),
+    ]);
+    mockGetArtistList.mockResolvedValue({
+      ok: true,
+      data: [{ id: 1, name: "A", foreignArtistId: "mbid-library" }],
+    });
+    mockGetCachedFeed.mockResolvedValue([
+      feedRelease({ artistName: "Various Artists", releaseGroupMbid: "rg-va" }),
+      feedRelease({
+        artistMbids: ["mbid-library", VARIOUS_ARTISTS_MBID],
+        releaseGroupMbid: "rg-va-credit",
+      }),
+      feedRelease({ releaseGroupMbid: "rg-real" }),
+    ]);
+
+    const result = await getNewReleases(1, NOW);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].releaseGroupMbid).toBe("rg-real");
   });
 
   it("prefers the followed entry when the same release appears in the feed", async () => {

--- a/server/services/discover/newReleases.ts
+++ b/server/services/discover/newReleases.ts
@@ -13,6 +13,10 @@ import { getArtistList } from "../lidarr/artists";
 import { enrichRequestsWithLidarr } from "../requests/lidarrEnrichment";
 import { getUserProfile } from "../../db/userProfile";
 import { parseDerivedProfile } from "../../db/userProfile";
+import {
+  hasPlaceholderArtist,
+  isPlaceholderArtist,
+} from "../../utils/artistFilter";
 import type { ListenBrainzFreshRelease } from "../../api/listenbrainz/types";
 import { createLogger } from "../../logger";
 
@@ -84,6 +88,7 @@ function feedToCandidate(
 }
 
 function isFollowedRowAllowed(row: FollowedReleaseWithArtist): boolean {
+  if (isPlaceholderArtist(row.artist_name, row.artist_mbid)) return false;
   return isAllowedReleaseType(
     row.release_type,
     parseSecondaryTypes(row.secondary_types)
@@ -91,6 +96,12 @@ function isFollowedRowAllowed(row: FollowedReleaseWithArtist): boolean {
 }
 
 function isFeedReleaseAllowed(release: ListenBrainzFreshRelease): boolean {
+  if (
+    isPlaceholderArtist(release.artistName) ||
+    hasPlaceholderArtist(release.artistMbids)
+  ) {
+    return false;
+  }
   return isAllowedReleaseType(
     release.primaryType,
     release.secondaryType === null ? [] : [release.secondaryType]

--- a/server/utils/artistFilter.test.ts
+++ b/server/utils/artistFilter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  isPlaceholderArtist,
+  hasPlaceholderArtist,
+  VARIOUS_ARTISTS_MBID,
+  UNKNOWN_ARTIST_MBID,
+  NO_ARTIST_MBID,
+} from "./artistFilter";
+
+describe("isPlaceholderArtist", () => {
+  it("matches the special-purpose MBIDs regardless of name", () => {
+    expect(isPlaceholderArtist("Anything", VARIOUS_ARTISTS_MBID)).toBe(true);
+    expect(isPlaceholderArtist("Anything", UNKNOWN_ARTIST_MBID)).toBe(true);
+    expect(isPlaceholderArtist("Anything", NO_ARTIST_MBID)).toBe(true);
+    expect(isPlaceholderArtist(null, VARIOUS_ARTISTS_MBID.toUpperCase())).toBe(
+      true
+    );
+  });
+
+  it("matches placeholder names case- and whitespace-insensitively", () => {
+    expect(isPlaceholderArtist("Various Artists")).toBe(true);
+    expect(isPlaceholderArtist("  various artists  ")).toBe(true);
+    expect(isPlaceholderArtist("VARIOUS")).toBe(true);
+    expect(isPlaceholderArtist("V.A.")).toBe(true);
+    expect(isPlaceholderArtist("[unknown]")).toBe(true);
+    expect(isPlaceholderArtist("Unknown Artist")).toBe(true);
+    expect(isPlaceholderArtist("[no artist]")).toBe(true);
+  });
+
+  it("leaves real artists alone", () => {
+    expect(isPlaceholderArtist("Various Production")).toBe(false);
+    expect(isPlaceholderArtist("VA", "mbid-va")).toBe(false);
+    expect(isPlaceholderArtist("Radiohead", "mbid-radiohead")).toBe(false);
+    expect(isPlaceholderArtist(null)).toBe(false);
+    expect(isPlaceholderArtist(undefined, null)).toBe(false);
+    expect(isPlaceholderArtist("")).toBe(false);
+  });
+});
+
+describe("hasPlaceholderArtist", () => {
+  it("is true when any credited MBID is a placeholder", () => {
+    expect(hasPlaceholderArtist(["mbid-a", VARIOUS_ARTISTS_MBID])).toBe(true);
+  });
+
+  it("is false for an all-real credit list", () => {
+    expect(hasPlaceholderArtist(["mbid-a", "mbid-b"])).toBe(false);
+    expect(hasPlaceholderArtist([])).toBe(false);
+  });
+});

--- a/server/utils/artistFilter.ts
+++ b/server/utils/artistFilter.ts
@@ -1,0 +1,44 @@
+/**
+ * MusicBrainz special-purpose artists — placeholders for "no single artist"
+ * rather than something a user can have a taste for. Compilations credited to
+ * them flood any recommendation surface that ranks by release count, so they
+ * are filtered out of every candidate pool.
+ * https://musicbrainz.org/doc/Style/Unknown_and_untitled/Special_purpose_artist
+ */
+export const VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
+export const UNKNOWN_ARTIST_MBID = "125ec42a-7229-4250-afc5-e057484327fe";
+export const NO_ARTIST_MBID = "eec63d3c-3b81-4ad4-b1e4-7c147d4d2b61";
+
+const PLACEHOLDER_MBIDS: ReadonlySet<string> = new Set([
+  VARIOUS_ARTISTS_MBID,
+  UNKNOWN_ARTIST_MBID,
+  NO_ARTIST_MBID,
+]);
+
+/**
+ * Bare "VA" is deliberately absent — it is a real artist name as often as it is
+ * an abbreviation, and the dotted form covers the abbreviation case.
+ */
+const PLACEHOLDER_NAMES: ReadonlySet<string> = new Set([
+  "various artists",
+  "various",
+  "v.a.",
+  "[unknown]",
+  "unknown artist",
+  "[no artist]",
+]);
+
+/** True when this artist is a placeholder credit rather than a real artist. */
+export function isPlaceholderArtist(
+  name?: string | null,
+  mbid?: string | null
+): boolean {
+  if (mbid && PLACEHOLDER_MBIDS.has(mbid.toLowerCase())) return true;
+  if (!name) return false;
+  return PLACEHOLDER_NAMES.has(name.trim().toLowerCase());
+}
+
+/** True when any credited artist MBID is a placeholder (multi-artist credits). */
+export function hasPlaceholderArtist(mbids: readonly string[]): boolean {
+  return mbids.some((mbid) => PLACEHOLDER_MBIDS.has(mbid.toLowerCase()));
+}


### PR DESCRIPTION
## Problem

The **New releases** shelf was almost entirely "Various Artists" compilations.

The ListenBrainz fresh-releases feed credits compilations to `Various Artists`, but `artist_mbids` still lists every individual contributor. Our library-artist intersection matched on those MBIDs, so every compilation any library artist happened to appear on landed on the shelf — and compilations are numerous, so they crowded out everything else.

## Fix

New `server/utils/artistFilter.ts` — recognises MusicBrainz special-purpose artists by MBID (Various Artists, `[unknown]`, `[no artist]`) and by name (`various artists`, `various`, `v.a.`, `[unknown]`, `unknown artist`, `[no artist]`).

Bare `"VA"` is deliberately **not** treated as a placeholder — too many real artist names collide with it.

Applied across the recommendation paths, not just the shelf that surfaced the bug:

| Path | What is filtered |
| --- | --- |
| `discover/newReleases.ts` | Feed rows on VA credit name **or** any placeholder MBID in `artistMbids`; followed rows on name + MBID |
| `promotedAlbum/artistWeights.ts` | `loadArtistWeights` — the canonical weight source, so VA can't seed the profile, similar graph, promoted album, or promoted artists |
| `promotedAlbum/explore.ts` | Candidates at graph-build **and** at read (`evaluateSeed`), so already-persisted graphs stop surfacing VA before the profile TTL expires |
| `promotedArtists/getPromotedArtists.ts` | Last.fm similar-artist merge |
| `promotedAlbum/getPromotedAlbum.ts` | Last.fm tag album pool |

## Tests

New `server/utils/artistFilter.test.ts`, plus cases added to `newReleases`, `artistWeights`, `explore` (×2), `getPromotedArtists`, and `getPromotedAlbum`.

Server 1130 passed, frontend 930 passed. Typecheck, lint, format clean.

## Note

Promoted album/artists results are cached in memory for `cacheDurationMinutes` (default 30) and the LB feed has its own cache TTL, so VA entries already cached survive until they expire or the server restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)